### PR TITLE
feat(content): :sparkles: graph traversal DFS and BFS

### DIFF
--- a/.claude/agent-memory/dsa-senior-engineer/completed_topics.md
+++ b/.claude/agent-memory/dsa-senior-engineer/completed_topics.md
@@ -48,6 +48,12 @@ All topics below have been published. Some may be reviewed later for consistency
 | k-way-merge | From Two-Way to K-Way, Heap-Based Merge, Implementation, Variations and Problem Mapping | Prose (no dedicated section) | None |
 | tree-traversal-bfs-dfs | BFS, DFS (Pre-Order, In-Order, Post-Order), Time and Space Complexity | Table | None |
 
+### Graph Traversal
+
+| Topic | Sections (H2) | Complexity Format | Interactive Components |
+|-------|---------------|-------------------|----------------------|
+| graph-traversal-dfs-bfs | What is a Graph?, Types of Graphs, Graph Representations, DFS on Graphs (Connected Components/Flood Fill, Graph Cloning, Cycle Detection/Bipartiteness, DFS on Implicit Graphs/Grids, DFS with Value Propagation), BFS on Graphs (Single-source/Multi-source BFS, BFS on Implicit/State-Space Graphs, BFS with Constraints/Extended State), Choosing Between DFS and BFS, Time and Space Complexity | Table | None |
+
 ### Meta / Design
 
 | Topic | Sections (H2) | Complexity Format | Interactive Components |

--- a/.claude/agent-memory/dsa-senior-engineer/structure_patterns.md
+++ b/.claude/agent-memory/dsa-senior-engineer/structure_patterns.md
@@ -60,6 +60,12 @@ Topics within the same group share a similar article layout and can be used as t
 **Template**: greedy
 **Why**: Greedy is a broad paradigm. The article is organized around structural patterns (single-pass, multi-pass, heap-based) with generic illustrative examples, not tightly coupled to specific exercises. The intervals article overlaps because it covers greedy scheduling, but intervals is more narrowly focused on interval-specific operations.
 
+### Group: Graph Algorithms
+**Topics**: graph-traversal-dfs-bfs, topological-sort (future), shortest-path (future), minimum-spanning-tree (future)
+**Pattern**: Intro connecting to tree traversal, formal definitions section, graph representations section, then separate DFS and BFS sections organized by sub-patterns (flood fill, state-space search, etc.), choosing between approaches section, complexity table, exercises.
+**Template**: graph-traversal-dfs-bfs
+**Why**: Graph topics build on each other and share the same foundational definitions. Future graph topics (topological sort, shortest path, MST) can reference this article for graph basics and extend DFS/BFS patterns.
+
 ## Complexity Format Convention
 
 - **Data structures** → use a **table** (operations vs time/space)

--- a/src/components/sections/data-structures-and-algorithms/components/graph-properties-visualizer.tsx
+++ b/src/components/sections/data-structures-and-algorithms/components/graph-properties-visualizer.tsx
@@ -1,0 +1,316 @@
+"use client";
+
+import { useState, FC } from "react";
+import {
+    RedPillButton,
+    BluePillButton,
+} from "@/components/design-system/molecules/buttons/pills-buttons";
+
+interface GraphNode {
+    id: string;
+    x: number;
+    y: number;
+}
+
+interface GraphEdge {
+    from: string;
+    to: string;
+    weight?: number;
+}
+
+interface GraphExample {
+    label: string;
+    description: string;
+    nodes: GraphNode[];
+    edges: GraphEdge[];
+    directed: boolean;
+    weighted: boolean;
+}
+
+const graphExamples: GraphExample[] = [
+    {
+        label: "Undirected",
+        description:
+            "Edges have no direction. If A connects to B, then B connects to A.",
+        nodes: [
+            { id: "A", x: 60, y: 40 },
+            { id: "B", x: 200, y: 40 },
+            { id: "C", x: 130, y: 140 },
+            { id: "D", x: 270, y: 140 },
+        ],
+        edges: [
+            { from: "A", to: "B" },
+            { from: "A", to: "C" },
+            { from: "B", to: "C" },
+            { from: "B", to: "D" },
+        ],
+        directed: false,
+        weighted: false,
+    },
+    {
+        label: "Directed",
+        description:
+            "Each edge has a direction. An edge from A to B does not imply an edge from B to A.",
+        nodes: [
+            { id: "A", x: 60, y: 40 },
+            { id: "B", x: 200, y: 40 },
+            { id: "C", x: 130, y: 140 },
+            { id: "D", x: 270, y: 140 },
+        ],
+        edges: [
+            { from: "A", to: "B" },
+            { from: "A", to: "C" },
+            { from: "C", to: "B" },
+            { from: "B", to: "D" },
+        ],
+        directed: true,
+        weighted: false,
+    },
+    {
+        label: "Weighted",
+        description:
+            "Each edge carries a numerical weight representing cost, distance, or capacity.",
+        nodes: [
+            { id: "A", x: 60, y: 40 },
+            { id: "B", x: 200, y: 40 },
+            { id: "C", x: 130, y: 140 },
+            { id: "D", x: 270, y: 140 },
+        ],
+        edges: [
+            { from: "A", to: "B", weight: 4 },
+            { from: "A", to: "C", weight: 2 },
+            { from: "B", to: "D", weight: 7 },
+            { from: "C", to: "D", weight: 3 },
+        ],
+        directed: false,
+        weighted: true,
+    },
+    {
+        label: "Cyclic",
+        description:
+            "Contains at least one cycle: a path that starts and ends at the same vertex.",
+        nodes: [
+            { id: "A", x: 60, y: 40 },
+            { id: "B", x: 200, y: 40 },
+            { id: "C", x: 200, y: 140 },
+            { id: "D", x: 60, y: 140 },
+        ],
+        edges: [
+            { from: "A", to: "B" },
+            { from: "B", to: "C" },
+            { from: "C", to: "D" },
+            { from: "D", to: "A" },
+        ],
+        directed: true,
+        weighted: false,
+    },
+    {
+        label: "DAG",
+        description:
+            "A Directed Acyclic Graph has directed edges but no cycles. Admits topological ordering.",
+        nodes: [
+            { id: "A", x: 60, y: 40 },
+            { id: "B", x: 180, y: 40 },
+            { id: "C", x: 60, y: 140 },
+            { id: "D", x: 180, y: 140 },
+            { id: "E", x: 300, y: 90 },
+        ],
+        edges: [
+            { from: "A", to: "B" },
+            { from: "A", to: "C" },
+            { from: "B", to: "D" },
+            { from: "C", to: "D" },
+            { from: "D", to: "E" },
+        ],
+        directed: true,
+        weighted: false,
+    },
+    {
+        label: "Disconnected",
+        description:
+            "Multiple connected components with no edges between them. A single traversal from one node cannot reach all vertices.",
+        nodes: [
+            { id: "A", x: 50, y: 60 },
+            { id: "B", x: 140, y: 60 },
+            { id: "C", x: 95, y: 140 },
+            { id: "X", x: 230, y: 60 },
+            { id: "Y", x: 320, y: 60 },
+        ],
+        edges: [
+            { from: "A", to: "B" },
+            { from: "B", to: "C" },
+            { from: "A", to: "C" },
+            { from: "X", to: "Y" },
+        ],
+        directed: false,
+        weighted: false,
+    },
+];
+
+const nodeRadius = 18;
+
+const getNode = (nodes: GraphNode[], id: string): GraphNode =>
+    nodes.find((n) => n.id === id)!;
+
+const ArrowHead: FC<{ id: string }> = ({ id }) => (
+    <defs>
+        <marker
+            id={id}
+            viewBox="0 0 10 10"
+            refX="10"
+            refY="5"
+            markerWidth="6"
+            markerHeight="6"
+            orient="auto-start-reverse"
+        >
+            <path d="M 0 0 L 10 5 L 0 10 z" fill="#22d3ee" />
+        </marker>
+    </defs>
+);
+
+const EdgeLine: FC<{
+    edge: GraphEdge;
+    nodes: GraphNode[];
+    directed: boolean;
+    weighted: boolean;
+    index: number;
+}> = ({ edge, nodes, directed, weighted, index }) => {
+    const fromNode = getNode(nodes, edge.from);
+    const toNode = getNode(nodes, edge.to);
+
+    const dx = toNode.x - fromNode.x;
+    const dy = toNode.y - fromNode.y;
+    const dist = Math.sqrt(dx * dx + dy * dy);
+    const ux = dx / dist;
+    const uy = dy / dist;
+
+    const startX = fromNode.x + ux * nodeRadius;
+    const startY = fromNode.y + uy * nodeRadius;
+    const endX = toNode.x - ux * (nodeRadius + (directed ? 6 : 0));
+    const endY = toNode.y - uy * (nodeRadius + (directed ? 6 : 0));
+
+    const markerId = `arrow-${index}`;
+
+    return (
+        <g>
+            {directed && <ArrowHead id={markerId} />}
+            <line
+                x1={startX}
+                y1={startY}
+                x2={endX}
+                y2={endY}
+                stroke="#22d3ee"
+                strokeWidth={2}
+                markerEnd={directed ? `url(#${markerId})` : undefined}
+            />
+            {weighted && edge.weight !== undefined && (
+                <text
+                    x={(startX + endX) / 2 + uy * 14}
+                    y={(startY + endY) / 2 - ux * 14}
+                    fill="#fbbf24"
+                    fontSize={13}
+                    fontWeight="bold"
+                    textAnchor="middle"
+                    dominantBaseline="central"
+                >
+                    {edge.weight}
+                </text>
+            )}
+        </g>
+    );
+};
+
+const NodeCircle: FC<{ node: GraphNode }> = ({ node }) => (
+    <g>
+        <circle
+            cx={node.x}
+            cy={node.y}
+            r={nodeRadius}
+            fill="#1e293b"
+            stroke="#22d3ee"
+            strokeWidth={2}
+        />
+        <text
+            x={node.x}
+            y={node.y}
+            fill="#ffffff"
+            fontSize={14}
+            fontWeight="bold"
+            textAnchor="middle"
+            dominantBaseline="central"
+        >
+            {node.id}
+        </text>
+    </g>
+);
+
+export const GraphPropertiesVisualizer: FC = () => {
+    const [selectedIndex, setSelectedIndex] = useState(0);
+    const example = graphExamples[selectedIndex];
+
+    const goToPrevious = () => {
+        setSelectedIndex(
+            (prev) =>
+                (prev - 1 + graphExamples.length) % graphExamples.length,
+        );
+    };
+
+    const goToNext = () => {
+        setSelectedIndex((prev) => (prev + 1) % graphExamples.length);
+    };
+
+    return (
+        <div className="w-full">
+            <div className="mb-4 flex flex-wrap items-center justify-center gap-2">
+                {graphExamples.map((ex, i) => (
+                    <button
+                        key={ex.label}
+                        onClick={() => setSelectedIndex(i)}
+                        className={`rounded-lg border px-3 py-1 text-sm font-mono transition-colors ${
+                            i === selectedIndex
+                                ? "border-accent bg-primary-dark text-accent"
+                                : "border-gray-600 bg-transparent text-gray-400 hover:border-accent hover:text-accent"
+                        }`}
+                    >
+                        {ex.label}
+                    </button>
+                ))}
+            </div>
+
+            <div className="flex justify-center">
+                <svg
+                    viewBox="0 0 360 180"
+                    className="w-full max-w-md"
+                    aria-label={`Graph example: ${example.label}`}
+                >
+                    {example.edges.map((edge, i) => (
+                        <EdgeLine
+                            key={`${edge.from}-${edge.to}`}
+                            edge={edge}
+                            nodes={example.nodes}
+                            directed={example.directed}
+                            weighted={example.weighted}
+                            index={i}
+                        />
+                    ))}
+                    {example.nodes.map((node) => (
+                        <NodeCircle key={node.id} node={node} />
+                    ))}
+                </svg>
+            </div>
+
+            <p className="mt-3 text-center text-sm text-gray-300">
+                <span className="font-bold text-accent">{example.label}</span>
+                {" — "}
+                {example.description}
+            </p>
+
+            <div className="mt-4 flex justify-center gap-3">
+                <BluePillButton onClick={goToPrevious}>
+                    Previous
+                </BluePillButton>
+                <RedPillButton onClick={goToNext}>Next</RedPillButton>
+            </div>
+        </div>
+    );
+};

--- a/src/content/data-structures-and-algorithms/roadmap/content.mdx
+++ b/src/content/data-structures-and-algorithms/roadmap/content.mdx
@@ -20,8 +20,6 @@ Below you can find the list of topics still not available:
 
 | Topic | Description |
 | ------ | ------------ |
-| **Depth First Search (DFS) (Soon available)** | Traversing graphs and trees using recursion or stack. |
-| **Breadth First Search (BFS) (Soon available)** | Level-wise traversal for shortest paths and connectivity. |
 | **Topological Sort (Soon available)** | Ordering nodes in DAGs respecting dependencies. |
 | **Union Find (Soon available)** | Disjoint set operations for connectivity and cycle detection. |
 | **Minimum Spanning Tree (Soon available)** | MST algorithms like Kruskal and Prim. |

--- a/src/content/data-structures-and-algorithms/topic/graph-traversal-dfs-bfs/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/graph-traversal-dfs-bfs/content.mdx
@@ -1,0 +1,706 @@
+---
+title: "Graph Traversal: DFS and BFS"
+description: "A comprehensive guide to graph traversal using Depth-First Search and Breadth-First Search, extending tree traversal techniques to general graphs with cycles, disconnected components, and implicit structures."
+date: 2026-04-11
+image: /images/posts/data-structures-and-algorithms-featured.png
+tags: [graph, dfs, bfs, traversal, data structures, algorithms]
+authors: [fabrizio_duroni]
+---
+
+import { TopicExercises } from "@/components/sections/data-structures-and-algorithms/components/topic-exercises";
+
+# Graph Traversal: DFS and BFS
+
+In the [tree traversal](/data-structures-and-algorithms/topic/tree-traversal-bfs-dfs) article, we explored how BFS and DFS operate on trees,
+structures where every node has exactly one parent and no cycles exist.
+Trees, however, are a special case.
+The moment we allow multiple paths between nodes, cycles, or disconnected regions, we enter the world of **graphs**,
+and our traversal techniques must adapt to handle these new challenges.
+
+The good news is that the core ideas remain the same.
+DFS still explores as deep as possible before backtracking, and BFS still explores level by level.
+The fundamental difference is that graphs can contain **cycles**, which means a naive traversal can revisit nodes forever.
+The solution is a **visited set** (or equivalent marking mechanism) that prevents re-exploration of nodes already processed.
+This single addition transforms tree traversal into graph traversal.
+
+This article develops graph DFS and BFS as natural generalizations of what you already know from trees.
+We start with the formal definitions and representations that make graph problems precise,
+then extend DFS and BFS with the machinery needed for general graphs,
+and finally explore the patterns and problem families where each traversal strategy excels.
+
+## What is a Graph?
+
+A **graph** $G = (V, E)$ consists of a set of **vertices** (also called **nodes**) $V$ and a set of **edges** $E$,
+where each edge connects a pair of vertices.
+This is the most general structure for modeling pairwise relationships: social networks, road maps, dependency chains,
+state machines, and grid-based puzzles are all naturally expressed as graphs.
+
+The key terminology is concise but essential.
+The **degree** of a vertex is the number of edges incident to it.
+In a directed graph, we distinguish between **in-degree** (edges arriving at the vertex) and **out-degree** (edges leaving it).
+Two vertices connected by an edge are called **neighbors** or **adjacent** vertices.
+A **path** is a sequence of vertices where each consecutive pair is connected by an edge.
+A graph is **connected** if there is a path between every pair of vertices (for directed graphs, the analogous property is called **strongly connected**).
+A **cycle** is a path that starts and ends at the same vertex without repeating any edge.
+
+## Types of Graphs
+
+Graphs come in several flavors, and recognizing which type you are dealing with determines how you represent it,
+how you traverse it, and which algorithms apply.
+
+A **directed graph** (digraph) has edges with a direction: an edge from $u$ to $v$ does not imply an edge from $v$ to $u$.
+Dependency graphs, web links, and state transitions are naturally directed.
+An **undirected graph** has symmetric edges: if $u$ and $v$ are connected, the connection goes both ways.
+Social networks and road maps without one-way streets are undirected.
+
+A **weighted graph** assigns a numerical value (weight) to each edge, representing cost, distance, capacity, or any other metric.
+An **unweighted graph** treats all edges as equal.
+BFS on unweighted graphs guarantees shortest paths, a property that does not carry over to weighted graphs without modification.
+
+A **cyclic graph** contains at least one cycle.
+An **acyclic graph** has none.
+A **directed acyclic graph (DAG)** is particularly important because it admits topological ordering,
+which is the basis for dependency resolution, build systems, and course scheduling.
+
+A **connected graph** has a path between every pair of vertices.
+A **disconnected graph** has multiple **connected components**, isolated subgraphs with no edges between them.
+When traversing a disconnected graph, a single BFS or DFS from one node will not reach all vertices.
+You must iterate over all nodes and start a new traversal from each unvisited one.
+
+A **dense graph** has $|E|$ close to $|V|^2$, meaning most pairs of vertices are connected.
+A **sparse graph** has $|E|$ close to $|V|$, meaning most pairs are not connected.
+The distinction matters for representation choice and algorithm complexity.
+
+One important observation ties this article to the previous one:
+**a tree is a connected acyclic undirected graph**.
+Every tree is a graph, but not every graph is a tree.
+The tree traversal techniques from the [previous article](/data-structures-and-algorithms/topic/tree-traversal-bfs-dfs)
+are therefore special cases of the graph traversal techniques we develop here.
+The key simplification that trees enjoy is the absence of cycles, which means tree traversals do not need a visited set.
+
+## Graph Representations
+
+Before traversing a graph, we need to represent it in memory.
+The choice of representation affects both the time complexity of operations and the ease of implementing algorithms.
+
+### Adjacency list
+
+An adjacency list stores, for each vertex, the list of its neighbors.
+It is the most common representation for sparse graphs and the default choice for most graph traversal problems.
+
+```ts
+// Adjacency list for an undirected graph with 5 nodes
+const graph: number[][] = [
+    [1, 2],    // node 0 connects to 1, 2
+    [0, 3],    // node 1 connects to 0, 3
+    [0, 4],    // node 2 connects to 0, 4
+    [1],       // node 3 connects to 1
+    [2],       // node 4 connects to 2
+];
+```
+
+Accessing all neighbors of a vertex takes $O(\text{degree}(v))$ time, and the total space is $O(|V| + |E|)$.
+This makes adjacency lists efficient for traversal, where the dominant operation is iterating over neighbors.
+
+### Adjacency matrix
+
+An adjacency matrix is a $|V| \times |V|$ boolean (or weighted) matrix where entry $(i, j)$ indicates whether an edge exists
+from vertex $i$ to vertex $j$.
+
+```ts
+// Adjacency matrix for the same graph
+const matrix: number[][] = [
+    [0, 1, 1, 0, 0],
+    [1, 0, 0, 1, 0],
+    [1, 0, 0, 0, 1],
+    [0, 1, 0, 0, 0],
+    [0, 0, 1, 0, 0],
+];
+```
+
+Checking whether two specific vertices are connected takes $O(1)$, but iterating over all neighbors of a vertex
+takes $O(|V|)$ regardless of the actual degree.
+The space is $O(|V|^2)$, which is wasteful for sparse graphs but natural for dense ones.
+Adjacency matrices are most useful when you need fast edge existence queries or when the graph is dense.
+
+### Edge list
+
+An edge list is simply an array of pairs (or triples, for weighted graphs), each representing an edge.
+
+```ts
+const edges: [number, number][] = [
+    [0, 1], [0, 2], [1, 3], [2, 4],
+];
+```
+
+This representation is compact and useful for algorithms that process edges directly (like Kruskal's MST algorithm),
+but it is inefficient for traversal because finding all neighbors of a vertex requires scanning the entire list.
+
+### Implicit graphs (grids)
+
+Many graph problems do not provide an explicit list of vertices and edges.
+Instead, the graph is defined implicitly by a grid or a set of rules.
+A 2D grid of cells is one of the most common implicit graph structures:
+each cell is a vertex, and edges connect each cell to its four (or eight) neighbors.
+
+```ts
+// Implicit graph traversal on a grid
+const directions = [[0, 1], [0, -1], [1, 0], [-1, 0]];
+
+function getNeighbors(row: number, col: number, rows: number, cols: number): [number, number][] {
+    const neighbors: [number, number][] = [];
+
+    for (const [dr, dc] of directions) {
+        const nr = row + dr;
+        const nc = col + dc;
+
+        if (nr >= 0 && nr < rows && nc >= 0 && nc < cols) {
+            neighbors.push([nr, nc]);
+        }
+    }
+
+    return neighbors;
+}
+```
+
+With implicit graphs, there is no need to build an adjacency list upfront.
+The neighbor function generates edges on the fly, keeping memory usage proportional to the grid size rather than the number of edges.
+The visited set typically uses a 2D boolean array matching the grid dimensions.
+
+### Choosing a representation
+
+For most traversal problems, the adjacency list is the right default.
+It provides $O(|V| + |E|)$ time for a full traversal, matches the structure of DFS and BFS naturally,
+and uses space proportional to the graph's actual size rather than its theoretical maximum.
+Adjacency matrices become preferable when the graph is dense or when constant-time edge queries are needed.
+Implicit graphs (grids) should stay implicit, using a neighbor-generation function rather than materializing the full adjacency structure.
+
+## DFS on Graphs
+
+Depth-First Search on trees follows each branch as deep as possible before backtracking.
+On graphs, the algorithm is identical in spirit, but it must handle the possibility of revisiting a node through a cycle.
+The solution is a **visited set** that records which nodes have already been explored.
+Before processing a neighbor, the algorithm checks whether it has been visited.
+If so, it skips the neighbor entirely.
+
+### Template
+
+The recursive template for graph DFS mirrors the tree version with the addition of the visited set.
+
+```ts
+function dfs(
+    node: number,
+    graph: number[][],
+    visited: Set<number>
+): void {
+    visited.add(node);
+
+    for (const neighbor of graph[node]) {
+        if (!visited.has(neighbor)) {
+            dfs(neighbor, graph, visited);
+        }
+    }
+}
+```
+
+The iterative version uses an explicit [stack](/data-structures-and-algorithms/topic/stack), replacing the call stack.
+
+```ts
+function dfsIterative(
+    start: number,
+    graph: number[][]
+): void {
+    const visited = new Set<number>();
+    const stack: number[] = [start];
+
+    while (stack.length > 0) {
+        const node = stack.pop()!;
+
+        if (visited.has(node)) {
+            continue;
+        }
+
+        visited.add(node);
+
+        for (const neighbor of graph[node]) {
+            if (!visited.has(neighbor)) {
+                stack.push(neighbor);
+            }
+        }
+    }
+}
+```
+
+For **disconnected graphs**, a single DFS call from one node will not visit all vertices.
+The standard approach is to wrap the DFS in a loop over all nodes.
+
+```ts
+function dfsAll(graph: number[][]): void {
+    const visited = new Set<number>();
+
+    for (let node = 0; node < graph.length; node++) {
+        if (!visited.has(node)) {
+            dfs(node, graph, visited);
+        }
+    }
+}
+```
+
+Each call to `dfs` in this loop discovers one **connected component**.
+This pattern is the foundation for problems that ask you to count, label, or analyze connected components.
+
+### Connected components and flood fill
+
+The most direct application of graph DFS is identifying connected components.
+On an explicit graph, this means counting how many separate groups of reachable vertices exist.
+On an implicit grid graph, the same idea manifests as **flood fill**: starting from a cell,
+DFS marks all reachable cells that satisfy some condition (same color, same value, land vs. water).
+
+The classic example is counting islands in a grid.
+Each land cell (`'1'`) that has not been visited becomes the seed for a DFS that marks all connected land cells as visited.
+Each seed corresponds to one island.
+
+```ts
+function countComponents(grid: string[][]): number {
+    const rows = grid.length;
+    const cols = grid[0].length;
+    const visited: boolean[][] = Array.from(
+        { length: rows }, () => Array(cols).fill(false)
+    );
+    let count = 0;
+
+    for (let r = 0; r < rows; r++) {
+        for (let c = 0; c < cols; c++) {
+            if (grid[r][c] === '1' && !visited[r][c]) {
+                count++;
+                floodFill(r, c, grid, visited);
+            }
+        }
+    }
+
+    return count;
+}
+
+function floodFill(
+    row: number, col: number,
+    grid: string[][], visited: boolean[][]
+): void {
+    if (
+        row < 0 || col < 0 ||
+        row >= grid.length || col >= grid[0].length ||
+        visited[row][col] || grid[row][col] !== '1'
+    ) {
+        return;
+    }
+
+    visited[row][col] = true;
+
+    floodFill(row + 1, col, grid, visited);
+    floodFill(row - 1, col, grid, visited);
+    floodFill(row, col + 1, grid, visited);
+    floodFill(row, col - 1, grid, visited);
+}
+```
+
+A subtler variant of flood fill works in reverse: instead of flooding inward from each unvisited cell,
+you flood outward from the **boundary**.
+This is useful when you need to identify cells that are *not* reachable from the boundary.
+For example, to capture surrounded regions in a grid, you first mark all boundary-connected cells as safe using DFS from the edges,
+then flip everything that was not marked.
+
+Another important variant is running DFS from multiple boundaries simultaneously.
+The Pacific-Atlantic water flow problem requires determining which cells can drain to both oceans.
+Rather than checking each cell individually (which would be $O(n^2 m^2)$), you run one DFS from all Pacific boundary cells
+and another from all Atlantic boundary cells, then intersect the results.
+This reduces the problem to two linear-time traversals.
+
+### Graph cloning and structure traversal
+
+DFS naturally handles problems that require building a copy of a graph while traversing it.
+The visited map serves a dual purpose: it prevents revisiting nodes *and* it maps each original node to its clone.
+
+When the DFS visits a node for the first time, it creates a clone and stores the mapping.
+When it encounters a node that has already been cloned (through a cycle or a converging path),
+it retrieves the existing clone from the map instead of creating a duplicate.
+This guarantees that the cloned graph has exactly the same structure as the original, including all cycles and shared references.
+
+The same DFS backbone supports path enumeration.
+In a DAG, where cycles are impossible, DFS can enumerate all paths from source to target
+by building a path incrementally, recording it at the target, and backtracking.
+The absence of cycles means no visited set is needed for correctness, though one can be used for optimization.
+
+### Cycle detection and bipartiteness
+
+DFS is the natural tool for cycle detection in both directed and undirected graphs.
+In an undirected graph, a cycle exists if DFS encounters a neighbor that is already visited and is not the immediate parent
+of the current node.
+In a directed graph, cycle detection requires distinguishing between nodes that are currently on the recursion stack
+(indicating a back edge, hence a cycle) and nodes that have been fully processed (indicating a cross or forward edge, not a cycle).
+
+A closely related problem is determining whether a graph is **bipartite**: whether its vertices can be colored with two colors
+such that no two adjacent vertices share the same color.
+DFS performs this check by attempting to **two-color** the graph during traversal.
+When visiting a node, it assigns the opposite color of its parent.
+If it encounters a neighbor that is already colored with the *same* color as the current node, the graph is not bipartite.
+
+```ts
+function isBipartite(graph: number[][]): boolean {
+    const colors = new Array(graph.length).fill(-1);
+
+    for (let i = 0; i < graph.length; i++) {
+        if (colors[i] === -1) {
+            colors[i] = 0;
+
+            if (!dfsBipartite(graph, i, colors)) {
+                return false;
+            }
+        }
+    }
+
+    return true;
+}
+
+function dfsBipartite(
+    graph: number[][], node: number, colors: number[]
+): boolean {
+    for (const neighbor of graph[node]) {
+        if (colors[neighbor] === colors[node]) {
+            return false;
+        }
+
+        if (colors[neighbor] === -1) {
+            colors[neighbor] = 1 - colors[node];
+
+            if (!dfsBipartite(graph, neighbor, colors)) {
+                return false;
+            }
+        }
+    }
+
+    return true;
+}
+```
+
+The outer loop handles disconnected graphs, ensuring every component is checked.
+The coloring array doubles as the visited set: a value of `-1` means unvisited.
+
+### DFS on implicit graphs and grids
+
+Many DFS problems operate on 2D grids where the graph structure is implicit.
+The grid itself serves as both the vertex set and the adjacency structure.
+Each cell has up to four neighbors (or eight, if diagonals are allowed), and the neighbor-generation logic replaces the adjacency list.
+
+A powerful technique on grids is **component labeling with area tracking**.
+Instead of simply marking cells as visited, DFS assigns each connected component a unique label and records its size.
+This preprocessing step transforms $O(n^2)$ per-query component lookups into $O(1)$ lookups.
+
+The "making a large island" problem illustrates this.
+The first phase labels every island with a unique ID and records its area using DFS.
+The second phase iterates over every water cell and checks which distinct island labels are adjacent to it.
+Flipping that water cell would merge those islands, and the total area is the sum of their pre-computed areas plus one.
+The label-and-lookup approach avoids redundant DFS calls and runs in $O(n^2)$ total.
+
+### DFS with value propagation
+
+A common DFS pattern involves propagating computed values through the graph: times, distances, costs, or importance scores.
+The DFS visits each node, computes a value based on its children's values, and returns (or aggregates) the result upward.
+
+In a company hierarchy modeled as a tree, computing the total importance of a subtree requires DFS that
+sums the importance of the root with the recursively computed importance of each subordinate.
+Similarly, computing the time to inform all employees requires DFS that tracks the maximum accumulated time along any path from the root to a leaf.
+
+When the graph is a tree (as hierarchies typically are), no visited set is needed because there are no cycles.
+When the graph may contain cycles (or when a tree is augmented with back-pointers), the visited set becomes essential.
+
+The "all nodes distance K in binary tree" problem combines DFS and BFS on a tree.
+First, DFS builds a parent map, effectively converting the tree into an undirected graph where each node has edges to its children and its parent.
+Then, BFS from the target node explores this undirected graph to find all nodes at distance exactly $k$.
+This technique of augmenting a tree with parent pointers and then running BFS is a general pattern for distance queries on trees.
+
+## BFS on Graphs
+
+Breadth-First Search on trees processes nodes level by level using a [queue](/data-structures-and-algorithms/topic/queue).
+On graphs, BFS retains this structure but adds a visited set to handle cycles, just as DFS does.
+The critical property that distinguishes BFS from DFS on graphs is the **shortest path guarantee**:
+in an unweighted graph, BFS finds the shortest path (minimum number of edges) from the source to every reachable vertex.
+
+This guarantee follows directly from the level-by-level expansion.
+All vertices at distance $d$ from the source are processed before any vertex at distance $d + 1$.
+When a vertex is first discovered by BFS, the path through which it was discovered is necessarily a shortest path.
+
+### Template
+
+```ts
+function bfs(start: number, graph: number[][]): void {
+    const visited = new Set<number>();
+    const queue: number[] = [start];
+    visited.add(start);
+
+    while (queue.length > 0) {
+        const node = queue.shift()!;
+
+        for (const neighbor of graph[node]) {
+            if (!visited.has(neighbor)) {
+                visited.add(neighbor);
+                queue.push(neighbor);
+            }
+        }
+    }
+}
+```
+
+A crucial difference from DFS is *when* the visited mark is applied.
+In BFS, a node is marked as visited **when it is enqueued**, not when it is dequeued.
+This prevents the same node from being added to the queue multiple times,
+which would waste time and could lead to incorrect distance calculations.
+
+For level-by-level processing (where you need to know the current distance or "wave number"),
+the standard technique is to record the queue length at the start of each iteration and process exactly that many nodes.
+
+```ts
+function bfsLevelByLevel(start: number, graph: number[][]): number {
+    const visited = new Set<number>();
+    const queue: number[] = [start];
+    visited.add(start);
+    let distance = 0;
+
+    while (queue.length > 0) {
+        const levelSize = queue.length;
+
+        for (let i = 0; i < levelSize; i++) {
+            const node = queue.shift()!;
+
+            for (const neighbor of graph[node]) {
+                if (!visited.has(neighbor)) {
+                    visited.add(neighbor);
+                    queue.push(neighbor);
+                }
+            }
+        }
+
+        distance++;
+    }
+
+    return distance;
+}
+```
+
+### Single-source and multi-source BFS
+
+Standard BFS starts from a single source vertex and computes distances to all reachable vertices.
+**Multi-source BFS** generalizes this by starting from *multiple* source vertices simultaneously.
+All sources are enqueued at the start with distance zero, and BFS expands outward from all of them in parallel.
+
+Multi-source BFS is equivalent to adding a virtual "super-source" connected to all actual sources with zero-weight edges
+and then running standard BFS from the super-source.
+The result is that each cell's computed distance is the minimum distance to *any* source.
+
+The "01 Matrix" problem is a canonical example: given a binary matrix, compute the distance of each cell to the nearest zero.
+Enqueue all zero cells as sources and run BFS outward. When BFS reaches a non-zero cell for the first time,
+the distance at that moment is the shortest distance to any zero cell.
+
+"Rotting Oranges" is another multi-source BFS problem with a time simulation layer.
+All initially rotten oranges are sources.
+Each BFS level represents one minute, and the oranges that become rotten in that minute are the newly discovered nodes.
+The total number of levels is the answer (the time until all oranges are rotten or the conclusion that some cannot be reached).
+
+```ts
+function multiSourceBFS(
+    grid: number[][], sources: [number, number][]
+): number[][] {
+    const rows = grid.length;
+    const cols = grid[0].length;
+    const distances: number[][] = Array.from(
+        { length: rows }, () => Array(cols).fill(-1)
+    );
+    const queue: [number, number][] = [];
+
+    for (const [r, c] of sources) {
+        distances[r][c] = 0;
+        queue.push([r, c]);
+    }
+
+    const dirs = [[0, 1], [0, -1], [1, 0], [-1, 0]];
+
+    while (queue.length > 0) {
+        const [row, col] = queue.shift()!;
+
+        for (const [dr, dc] of dirs) {
+            const nr = row + dr;
+            const nc = col + dc;
+
+            if (
+                nr >= 0 && nr < rows &&
+                nc >= 0 && nc < cols &&
+                distances[nr][nc] === -1
+            ) {
+                distances[nr][nc] = distances[row][col] + 1;
+                queue.push([nr, nc]);
+            }
+        }
+    }
+
+    return distances;
+}
+```
+
+### BFS on implicit and state-space graphs
+
+Some of the most interesting BFS problems involve graphs that are never constructed explicitly.
+Instead, the "vertices" are **states** and the "edges" are **transitions** between states.
+The graph exists only conceptually, and BFS explores it by generating neighbors on the fly.
+
+The "Open the Lock" problem is a textbook example.
+The state is a 4-digit combination.
+Each move (turning one wheel one slot up or down) produces a neighbor state.
+The deadend combinations are blocked states that cannot be entered.
+BFS from the initial state `"0000"` finds the shortest sequence of moves to reach the target, or determines that no path exists.
+
+The "Word Ladder" problem has a similar structure.
+Each word is a state, and two words are neighbors if they differ by exactly one letter.
+BFS from the start word finds the shortest transformation sequence to the target word.
+To avoid checking all $O(n^2)$ word pairs for adjacency, a common optimization is to use wildcard patterns:
+for each word, replace each character with `'*'` and group words by pattern.
+Two words are neighbors if they share at least one pattern, and the pattern map provides $O(1)$ neighbor lookup.
+
+The key insight with state-space BFS is that the visited set must track *states*, not just positions.
+The state might include the position on the grid plus some additional dimension (remaining resources, collected keys, turn parity),
+and two visits to the same position with different auxiliary state are genuinely different and must both be explored.
+
+### BFS with constraints and extended state
+
+When the problem introduces resource constraints, the BFS state must be extended to encode the constraint.
+The visited structure becomes multi-dimensional to match.
+
+The "Shortest Path in a Grid with Obstacles Elimination" problem allows eliminating up to $k$ obstacles.
+The state is a triple $(row, col, k_{remaining})$.
+Two visits to the same cell are different if they arrive with different values of $k_{remaining}$,
+because having more eliminations available opens up paths that fewer eliminations would block.
+The visited array stores the *best* (highest) $k_{remaining}$ seen at each cell.
+A new visit to a cell is only useful if it arrives with more remaining eliminations than any previous visit.
+
+```ts
+function bfsWithConstraint(
+    grid: number[][], k: number
+): number {
+    const rows = grid.length;
+    const cols = grid[0].length;
+    const visited = Array.from(
+        { length: rows },
+        () => Array(cols).fill(-1)
+    );
+
+    const queue: [number, number, number][] = [[0, 0, k]];
+    visited[0][0] = k;
+    let steps = 0;
+
+    const dirs = [[1, 0], [-1, 0], [0, 1], [0, -1]];
+
+    while (queue.length > 0) {
+        let levelSize = queue.length;
+
+        while (levelSize-- > 0) {
+            const [row, col, kLeft] = queue.shift()!;
+
+            if (row === rows - 1 && col === cols - 1) {
+                return steps;
+            }
+
+            for (const [dr, dc] of dirs) {
+                const nr = row + dr;
+                const nc = col + dc;
+
+                if (nr < 0 || nc < 0 || nr >= rows || nc >= cols) {
+                    continue;
+                }
+
+                const newK = kLeft - grid[nr][nc];
+
+                if (newK >= 0 && newK > visited[nr][nc]) {
+                    visited[nr][nc] = newK;
+                    queue.push([nr, nc, newK]);
+                }
+            }
+        }
+
+        steps++;
+    }
+
+    return -1;
+}
+```
+
+The "Bus Routes" problem pushes this further by changing the granularity of BFS.
+Instead of traversing stop-to-stop, BFS operates at the **route level**: each "node" in the BFS is a bus route, not a stop.
+The neighbors of a route are all other routes that share at least one stop.
+This abstraction reduces the problem size dramatically when routes are large.
+A stop-to-bus mapping is built in preprocessing, and the visited set tracks both visited stops and visited routes
+to avoid redundant exploration.
+
+## Choosing Between DFS and BFS
+
+DFS and BFS are both complete traversal strategies, meaning they will visit every reachable vertex.
+The choice between them depends on the problem's requirements.
+
+**BFS is the right choice when shortest path matters.**
+In unweighted graphs (or graphs where all edges have equal cost), BFS guarantees that the first time it reaches a vertex,
+it has found the shortest path.
+DFS provides no such guarantee.
+Any problem that asks for "minimum number of steps", "shortest transformation sequence", or "fewest moves"
+is a strong signal for BFS.
+
+**DFS is the right choice for exhaustive exploration and structural analysis.**
+Problems that require enumerating all paths, detecting cycles, checking connectivity, computing connected components,
+or performing [backtracking](/data-structures-and-algorithms/topic/backtracking)-style search are natural fits for DFS.
+The recursive structure of DFS aligns with the recursive nature of these problems,
+and the implicit stack provides the backtracking mechanism.
+
+**DFS uses less memory in deep, narrow graphs.**
+The recursive call stack (or explicit stack) holds at most $O(h)$ nodes, where $h$ is the depth of the deepest path explored.
+BFS holds all nodes at the current frontier, which can be $O(w)$ where $w$ is the maximum width.
+For trees and tree-like graphs, DFS typically uses $O(h)$ space while BFS uses $O(w)$, and $h$ is often much smaller than $w$.
+For graphs that are wide and shallow (like grids), the difference is less pronounced.
+
+**BFS naturally supports multi-source queries.**
+When the problem requires computing distances from multiple sources simultaneously,
+multi-source BFS handles this elegantly by enqueuing all sources at the start.
+Achieving the same with DFS would require separate traversals from each source.
+
+In practice, many graph problems can be solved with either strategy, and the choice comes down to which one
+more naturally expresses the solution.
+When the problem requires level-by-level processing, distance computation, or shortest paths, reach for BFS.
+When it requires deep exploration, path building, cycle detection, or recursive decomposition, reach for DFS.
+
+## Time and Space Complexity
+
+The complexity of graph traversal depends on the graph representation and the traversal strategy.
+For both DFS and BFS, every vertex is visited at most once and every edge is examined at most once (twice for undirected graphs),
+giving a consistent time bound across both strategies.
+
+| Algorithm | Time Complexity | Space Complexity | Notes |
+|-----------|----------------|-----------------|-------|
+| DFS (adjacency list) | $O(\|V\| + \|E\|)$ | $O(\|V\|)$ | Visited set plus recursion stack (or explicit stack). Stack depth is at most $\|V\|$ in the worst case. |
+| BFS (adjacency list) | $O(\|V\| + \|E\|)$ | $O(\|V\|)$ | Visited set plus queue. Queue size is at most $\|V\|$ in the worst case (when all vertices are at the same distance from the source). |
+| DFS (adjacency matrix) | $O(\|V\|^2)$ | $O(\|V\|)$ | Checking all potential neighbors of each vertex takes $O(\|V\|)$ per vertex, regardless of actual degree. |
+| BFS (adjacency matrix) | $O(\|V\|^2)$ | $O(\|V\|)$ | Same reasoning as DFS with adjacency matrix. |
+| DFS/BFS on grid ($m \times n$) | $O(m \cdot n)$ | $O(m \cdot n)$ | Each cell is a vertex, and each cell has at most 4 neighbors. The visited array is $m \times n$. |
+| Multi-source BFS | $O(\|V\| + \|E\|)$ | $O(\|V\|)$ | Same as standard BFS. Multiple sources do not increase asymptotic cost. |
+| BFS with extended state | $O(\|V\| \cdot S + \|E\| \cdot S)$ | $O(\|V\| \cdot S)$ | Where $S$ is the size of the auxiliary state dimension (e.g., $k+1$ possible elimination counts). |
+
+The $O(|V| + |E|)$ bound for adjacency list traversal is optimal: you cannot do better than visiting every vertex and every edge once.
+The adjacency matrix bound of $O(|V|^2)$ reflects the cost of scanning each row to find neighbors, even when most entries are zero.
+For sparse graphs ($|E| \ll |V|^2$), the adjacency list representation is strictly superior.
+
+For grid-based problems, $|V| = m \cdot n$ and $|E| = O(m \cdot n)$ (since each cell has at most 4 edges),
+so both time and space are $O(m \cdot n)$.
+The visited array (or in-place grid modification) accounts for the space.
+
+Extended-state BFS multiplies both time and space by the size of the state dimension.
+When the constraint parameter $k$ is bounded by a constant or a small polynomial of $|V|$,
+this remains tractable.
+When $k$ is large, the state space may become prohibitively large and alternative approaches
+(such as Dijkstra's algorithm or A* search) may be needed.
+
+## Exercises
+
+<TopicExercises topic="graph-traversal-dfs-bfs" />

--- a/src/content/data-structures-and-algorithms/topic/graph-traversal-dfs-bfs/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/graph-traversal-dfs-bfs/content.mdx
@@ -8,6 +8,8 @@ authors: [fabrizio_duroni]
 ---
 
 import { TopicExercises } from "@/components/sections/data-structures-and-algorithms/components/topic-exercises";
+import { InteractiveBlock } from "@/components/sections/data-structures-and-algorithms/components/interactive-block";
+import { GraphPropertiesVisualizer } from "@/components/sections/data-structures-and-algorithms/components/graph-properties-visualizer";
 
 # Graph Traversal: DFS and BFS
 
@@ -30,46 +32,56 @@ and finally explore the patterns and problem families where each traversal strat
 
 ## What is a Graph?
 
-A **graph** $G = (V, E)$ consists of a set of **vertices** (also called **nodes**) $V$ and a set of **edges** $E$,
+A [**graph**](https://en.wikipedia.org/wiki/Graph_(discrete_mathematics)) $G = (V, E)$ consists of a set of **vertices** (also called **nodes**) $V$ and a set of **edges** $E$,
 where each edge connects a pair of vertices.
 This is the most general structure for modeling pairwise relationships: social networks, road maps, dependency chains,
 state machines, and grid-based puzzles are all naturally expressed as graphs.
 
 The key terminology is concise but essential.
-The **degree** of a vertex is the number of edges incident to it.
+The [**degree**](https://en.wikipedia.org/wiki/Degree_(graph_theory)) of a vertex is the number of edges incident to it.
 In a directed graph, we distinguish between **in-degree** (edges arriving at the vertex) and **out-degree** (edges leaving it).
 Two vertices connected by an edge are called **neighbors** or **adjacent** vertices.
-A **path** is a sequence of vertices where each consecutive pair is connected by an edge.
-A graph is **connected** if there is a path between every pair of vertices (for directed graphs, the analogous property is called **strongly connected**).
-A **cycle** is a path that starts and ends at the same vertex without repeating any edge.
+A [**path**](https://en.wikipedia.org/wiki/Path_(graph_theory)) is a sequence of vertices where each consecutive pair is connected by an edge.
+A graph is [**connected**](https://en.wikipedia.org/wiki/Connectivity_(graph_theory)) if there is a path between every pair of vertices
+(for directed graphs, the analogous property is called [**strongly connected**](https://en.wikipedia.org/wiki/Strongly_connected_component)).
+A [**cycle**](https://en.wikipedia.org/wiki/Cycle_(graph_theory)) is a path that starts and ends at the same vertex without repeating any edge.
 
 ## Types of Graphs
 
 Graphs come in several flavors, and recognizing which type you are dealing with determines how you represent it,
 how you traverse it, and which algorithms apply.
 
-A **directed graph** (digraph) has edges with a direction: an edge from $u$ to $v$ does not imply an edge from $v$ to $u$.
+A [**directed graph**](https://en.wikipedia.org/wiki/Directed_graph) (digraph) has edges with a direction: an edge from $u$ to $v$ does not imply an edge from $v$ to $u$.
 Dependency graphs, web links, and state transitions are naturally directed.
-An **undirected graph** has symmetric edges: if $u$ and $v$ are connected, the connection goes both ways.
+An [**undirected graph**](https://en.wikipedia.org/wiki/Graph_(discrete_mathematics)#Undirected_graph) has symmetric edges: if $u$ and $v$ are connected, the connection goes both ways.
 Social networks and road maps without one-way streets are undirected.
 
-A **weighted graph** assigns a numerical value (weight) to each edge, representing cost, distance, capacity, or any other metric.
+A [**weighted graph**](https://en.wikipedia.org/wiki/Graph_(discrete_mathematics)#Weighted_graph) assigns a numerical value (weight) to each edge,
+representing cost, distance, capacity, or any other metric.
 An **unweighted graph** treats all edges as equal.
 BFS on unweighted graphs guarantees shortest paths, a property that does not carry over to weighted graphs without modification.
 
-A **cyclic graph** contains at least one cycle.
+A **cyclic graph** contains at least one [cycle](https://en.wikipedia.org/wiki/Cycle_(graph_theory)).
 An **acyclic graph** has none.
-A **directed acyclic graph (DAG)** is particularly important because it admits topological ordering,
+A [**directed acyclic graph (DAG)**](https://en.wikipedia.org/wiki/Directed_acyclic_graph) is particularly important because it admits
+[topological ordering](https://en.wikipedia.org/wiki/Topological_sorting),
 which is the basis for dependency resolution, build systems, and course scheduling.
 
 A **connected graph** has a path between every pair of vertices.
-A **disconnected graph** has multiple **connected components**, isolated subgraphs with no edges between them.
+A **disconnected graph** has multiple [**connected components**](https://en.wikipedia.org/wiki/Component_(graph_theory)),
+isolated subgraphs with no edges between them.
 When traversing a disconnected graph, a single BFS or DFS from one node will not reach all vertices.
 You must iterate over all nodes and start a new traversal from each unvisited one.
 
 A **dense graph** has $|E|$ close to $|V|^2$, meaning most pairs of vertices are connected.
 A **sparse graph** has $|E|$ close to $|V|$, meaning most pairs are not connected.
 The distinction matters for representation choice and algorithm complexity.
+
+The interactive visualization below illustrates the main graph types described above.
+
+<InteractiveBlock title="Graph Types">
+    <GraphPropertiesVisualizer />
+</InteractiveBlock>
 
 One important observation ties this article to the previous one:
 **a tree is a connected acyclic undirected graph**.
@@ -85,7 +97,7 @@ The choice of representation affects both the time complexity of operations and 
 
 ### Adjacency list
 
-An adjacency list stores, for each vertex, the list of its neighbors.
+An [adjacency list](https://en.wikipedia.org/wiki/Adjacency_list) stores, for each vertex, the list of its neighbors.
 It is the most common representation for sparse graphs and the default choice for most graph traversal problems.
 
 ```ts
@@ -104,8 +116,8 @@ This makes adjacency lists efficient for traversal, where the dominant operation
 
 ### Adjacency matrix
 
-An adjacency matrix is a $|V| \times |V|$ boolean (or weighted) matrix where entry $(i, j)$ indicates whether an edge exists
-from vertex $i$ to vertex $j$.
+An [adjacency matrix](https://en.wikipedia.org/wiki/Adjacency_matrix) is a $|V| \times |V|$ boolean (or weighted) matrix where entry $(i, j)$ indicates
+whether an edge exists from vertex $i$ to vertex $j$.
 
 ```ts
 // Adjacency matrix for the same graph
@@ -125,7 +137,7 @@ Adjacency matrices are most useful when you need fast edge existence queries or 
 
 ### Edge list
 
-An edge list is simply an array of pairs (or triples, for weighted graphs), each representing an edge.
+An [edge list](https://en.wikipedia.org/wiki/Edge_list) is simply an array of pairs (or triples, for weighted graphs), each representing an edge.
 
 ```ts
 const edges: [number, number][] = [
@@ -133,13 +145,14 @@ const edges: [number, number][] = [
 ];
 ```
 
-This representation is compact and useful for algorithms that process edges directly (like Kruskal's MST algorithm),
+This representation is compact and useful for algorithms that process edges directly
+(like [Kruskal's algorithm](https://en.wikipedia.org/wiki/Kruskal%27s_algorithm) for minimum spanning trees),
 but it is inefficient for traversal because finding all neighbors of a vertex requires scanning the entire list.
 
 ### Implicit graphs (grids)
 
 Many graph problems do not provide an explicit list of vertices and edges.
-Instead, the graph is defined implicitly by a grid or a set of rules.
+Instead, the graph is defined [implicitly](https://en.wikipedia.org/wiki/Implicit_graph) by a grid or a set of rules.
 A 2D grid of cells is one of the most common implicit graph structures:
 each cell is a vertex, and edges connect each cell to its four (or eight) neighbors.
 
@@ -177,7 +190,7 @@ Implicit graphs (grids) should stay implicit, using a neighbor-generation functi
 
 ## DFS on Graphs
 
-Depth-First Search on trees follows each branch as deep as possible before backtracking.
+[Depth-First Search](https://en.wikipedia.org/wiki/Depth-first_search) on trees follows each branch as deep as possible before backtracking.
 On graphs, the algorithm is identical in spirit, but it must handle the possibility of revisiting a node through a cycle.
 The solution is a **visited set** that records which nodes have already been explored.
 Before processing a neighbor, the algorithm checks whether it has been visited.
@@ -253,7 +266,7 @@ This pattern is the foundation for problems that ask you to count, label, or ana
 
 The most direct application of graph DFS is identifying connected components.
 On an explicit graph, this means counting how many separate groups of reachable vertices exist.
-On an implicit grid graph, the same idea manifests as **flood fill**: starting from a cell,
+On an implicit grid graph, the same idea manifests as [**flood fill**](https://en.wikipedia.org/wiki/Flood_fill): starting from a cell,
 DFS marks all reachable cells that satisfy some condition (same color, same value, land vs. water).
 
 The classic example is counting islands in a grid.
@@ -337,9 +350,70 @@ of the current node.
 In a directed graph, cycle detection requires distinguishing between nodes that are currently on the recursion stack
 (indicating a back edge, hence a cycle) and nodes that have been fully processed (indicating a cross or forward edge, not a cycle).
 
-A closely related problem is determining whether a graph is **bipartite**: whether its vertices can be colored with two colors
-such that no two adjacent vertices share the same color.
-DFS performs this check by attempting to **two-color** the graph during traversal.
+The standard approach for directed graphs uses **three-state coloring**, often called the WHITE/GRAY/BLACK technique.
+Each node starts as WHITE (unvisited).
+When DFS begins processing a node, it is colored GRAY (in progress, currently on the recursion stack).
+When DFS finishes processing a node and all its descendants, it is colored BLACK (fully processed).
+A cycle exists if and only if DFS encounters a GRAY neighbor, because a GRAY node is an ancestor in the current DFS path,
+and an edge to it closes a cycle.
+Encountering a BLACK neighbor is safe: it means the neighbor was fully explored in a previous branch and no cycle passes through it.
+
+```ts
+enum Color {
+    WHITE = 0,  // unvisited
+    GRAY = 1,   // in progress (on the current recursion stack)
+    BLACK = 2,  // fully processed
+}
+
+function hasCycleDirected(graph: number[][]): boolean {
+    const color: Color[] = new Array(graph.length).fill(Color.WHITE);
+
+    for (let node = 0; node < graph.length; node++) {
+        if (color[node] === Color.WHITE) {
+            if (dfsDetectCycle(node, graph, color)) {
+                return true;
+            }
+        }
+    }
+
+    return false;
+}
+
+function dfsDetectCycle(
+    node: number,
+    graph: number[][],
+    color: Color[]
+): boolean {
+    color[node] = Color.GRAY;
+
+    for (const neighbor of graph[node]) {
+        if (color[neighbor] === Color.GRAY) {
+            // Back edge: neighbor is on the current recursion stack
+            return true;
+        }
+
+        if (color[neighbor] === Color.WHITE) {
+            if (dfsDetectCycle(neighbor, graph, color)) {
+                return true;
+            }
+        }
+        // If color[neighbor] === Color.BLACK, the neighbor is fully
+        // processed. This is a cross or forward edge, not a cycle.
+    }
+
+    color[node] = Color.BLACK;
+
+    return false;
+}
+```
+
+The outer loop ensures that every node is visited even in disconnected graphs.
+The three-state approach is essential for directed graphs because, unlike undirected graphs, a previously visited node
+does not necessarily indicate a cycle. Only a node that is still being processed (GRAY) confirms one.
+
+A closely related problem is determining whether a graph is [**bipartite**](https://en.wikipedia.org/wiki/Bipartite_graph):
+whether its vertices can be colored with two colors such that no two adjacent vertices share the same color.
+DFS performs this check by attempting to [**two-color**](https://en.wikipedia.org/wiki/Graph_coloring) the graph during traversal.
 When visiting a node, it assigns the opposite color of its parent.
 If it encounters a neighbor that is already colored with the *same* color as the current node, the graph is not bipartite.
 
@@ -419,7 +493,7 @@ This technique of augmenting a tree with parent pointers and then running BFS is
 
 ## BFS on Graphs
 
-Breadth-First Search on trees processes nodes level by level using a [queue](/data-structures-and-algorithms/topic/queue).
+[Breadth-First Search](https://en.wikipedia.org/wiki/Breadth-first_search) on trees processes nodes level by level using a [queue](/data-structures-and-algorithms/topic/queue).
 On graphs, BFS retains this structure but adds a visited set to handle cycles, just as DFS does.
 The critical property that distinguishes BFS from DFS on graphs is the **shortest path guarantee**:
 in an unweighted graph, BFS finds the shortest path (minimum number of edges) from the source to every reachable vertex.
@@ -699,7 +773,7 @@ Extended-state BFS multiplies both time and space by the size of the state dimen
 When the constraint parameter $k$ is bounded by a constant or a small polynomial of $|V|$,
 this remains tractable.
 When $k$ is large, the state space may become prohibitively large and alternative approaches
-(such as Dijkstra's algorithm or A* search) may be needed.
+(such as [Dijkstra's algorithm](https://en.wikipedia.org/wiki/Dijkstra%27s_algorithm) or [A* search](https://en.wikipedia.org/wiki/A*_search_algorithm)) may be needed.
 
 ## Exercises
 

--- a/src/content/data-structures-and-algorithms/topic/graph-traversal-dfs-bfs/exercise/01-matrix/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/graph-traversal-dfs-bfs/exercise/01-matrix/content.mdx
@@ -1,0 +1,89 @@
+---
+title: "01 Matrix"
+description: "Given a binary matrix, find the distance of each cell to the nearest zero using BFS."
+date: 2026-04-11
+image: /images/posts/data-structures-and-algorithms-featured.png
+tags: [graph, dfs, bfs, traversal, data structures, algorithms]
+authors: [fabrizio_duroni]
+metadata:
+  technique: "Multi-source BFS for distance computation"
+  leetcodeUrl: "https://leetcode.com/problems/01-matrix/"
+---
+# 01 Matrix
+
+Leetcode Problem 542: [01 Matrix](https://leetcode.com/problems/01-matrix/description/)
+
+## Problem Summary
+Given an **m x n** binary matrix where each cell contains either **0** or **1**, return a matrix of the same dimensions where each cell contains the distance to the nearest **0**. The distance between two adjacent cells (sharing an edge) is **1**. There is at least one **0** in the matrix. The matrix dimensions are at most **10,000** cells each, and the total number of cells does not exceed **10,000**.
+
+## Techniques
+- Array
+- Dynamic Programming
+- Breadth-First Search
+- Matrix
+
+## Solution
+```ts
+function updateMatrix(mat: number[][]): number[][] {
+    const rows = mat.length
+    const columns = mat[0].length
+    const queue: [number, number][] = []
+    const distances: number[][] = Array.from({ length: rows }, () =>
+        Array(columns).fill(0)
+    )
+
+    for (let row = 0; row < rows; row++) {
+        for (let column = 0; column < columns; column++) {
+            if (mat[row][column] === 0) {
+                queue.push([row, column])
+            }
+        }
+    }
+
+    while (queue.length > 0) {
+        const [row, column] = queue.shift()!
+        const currentDistance = distances[row][column] + 1
+
+        if (
+            row - 1 >= 0 && 
+            mat[row - 1][column] === 1 && 
+            distances[row - 1][column] === 0
+        ) {
+            distances[row - 1][column] = currentDistance
+            queue.push([row - 1, column])
+        }
+
+        if (
+            column + 1 < columns && 
+            mat[row][column + 1] === 1 && 
+            distances[row][column + 1] === 0
+        ) {
+            distances[row][column + 1] = currentDistance
+            queue.push([row, column + 1])
+        }
+
+        if (
+            row + 1 < rows && 
+            mat[row + 1][column] === 1 && 
+            distances[row + 1][column] === 0            
+        ) {
+            distances[row + 1][column] = currentDistance
+            queue.push([row + 1, column])
+        }
+
+        if (
+            column - 1 >= 0 && 
+            mat[row][column - 1] === 1 &&
+            distances[row][column - 1] === 0
+        ) {
+            distances[row][column - 1] = currentDistance
+            queue.push([row, column - 1])
+        }
+    }
+
+    return distances
+};
+
+console.log(updateMatrix([[0,0,0],[0,1,0],[0,0,0]])) // [[0,0,0],[0,1,0],[0,0,0]]
+console.log(updateMatrix([[0,0,0],[0,1,0],[1,1,1]])) // [[0,0,0],[0,1,0],[1,2,1]]
+```

--- a/src/content/data-structures-and-algorithms/topic/graph-traversal-dfs-bfs/exercise/all-nodes-distance-k-in-binary-tree/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/graph-traversal-dfs-bfs/exercise/all-nodes-distance-k-in-binary-tree/content.mdx
@@ -1,0 +1,81 @@
+---
+title: "All Nodes Distance K in Binary Tree"
+description: "Given a binary tree, a target node, and an integer K, return the values of all nodes that are exactly distance K from the target."
+date: 2026-04-11
+image: /images/posts/data-structures-and-algorithms-featured.png
+tags: [graph, dfs, bfs, traversal, data structures, algorithms]
+authors: [fabrizio_duroni]
+metadata:
+  technique: "DFS parent map construction then BFS from target"
+  leetcodeUrl: "https://leetcode.com/problems/all-nodes-distance-k-in-binary-tree/"
+---
+# All Nodes Distance K in Binary Tree
+
+Leetcode Problem 863: [All Nodes Distance K in Binary Tree](https://leetcode.com/problems/all-nodes-distance-k-in-binary-tree/description/)
+
+## Problem Summary
+Given the root of a binary tree, a target node within the tree, and an integer **k**, return an array of the values of all nodes that have distance exactly **k** from the target node. Distance is measured as the number of edges on the path between two nodes, and the path can go through the parent of either node. The answer can be returned in any order. The tree has at most **500** nodes with unique values, and **k** is at most **1,000**.
+
+## Techniques
+- Hash Table
+- Tree
+- Depth-First Search
+- Breadth-First Search
+- Binary Tree
+
+## Solution
+```ts
+class TreeNode {
+    val: number
+    left: TreeNode | null
+    right: TreeNode | null
+    constructor(val?: number, left?: TreeNode | null, right?: TreeNode | null) {
+        this.val = (val===undefined ? 0 : val)
+        this.left = (left===undefined ? null : left)
+        this.right = (right===undefined ? null : right)
+    }
+}
+
+function dfsToConvertToGraph(node: TreeNode | null, par: TreeNode | null, parent: Map<TreeNode, TreeNode | null>) {
+    if (!node) { 
+        return
+    }
+    
+    parent.set(node, par)
+
+    dfsToConvertToGraph(node.left, node, parent)
+    dfsToConvertToGraph(node.right, node, parent)
+}
+
+function distanceK(root: TreeNode | null, target: TreeNode | null, k: number): number[] {
+    // Step 1: parent map
+    const parent = new Map<TreeNode, TreeNode | null>()
+    dfsToConvertToGraph(root, null, parent)
+
+    // Step 2: BFS from target
+    const queue: [TreeNode, number][] = [[target!, 0]]
+    const visited = new Set<TreeNode>()
+    visited.add(target!)
+
+    const result: number[] = []
+
+    while (queue.length > 0) {
+        const [node, dist] = queue.shift()!
+
+        if (dist === k) {
+            result.push(node.val)
+            continue
+        }
+
+        // neighbor(node) = [node.left, node.right, parent[node]]
+        for (const neighbor of [node.left, node.right, parent.get(node)]) {
+            if (neighbor && !visited.has(neighbor)) {
+                visited.add(neighbor)
+                queue.push([neighbor, dist + 1])
+            }
+        }
+    }
+
+    return result;    
+};
+```

--- a/src/content/data-structures-and-algorithms/topic/graph-traversal-dfs-bfs/exercise/all-paths-from-source-to-target/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/graph-traversal-dfs-bfs/exercise/all-paths-from-source-to-target/content.mdx
@@ -1,0 +1,46 @@
+---
+title: "All Paths From Source to Target"
+description: "Given a directed acyclic graph with n nodes, find all possible paths from node 0 to node n-1."
+date: 2026-04-11
+image: /images/posts/data-structures-and-algorithms-featured.png
+tags: [graph, dfs, bfs, traversal, data structures, algorithms]
+authors: [fabrizio_duroni]
+metadata:
+  technique: "DFS path enumeration on DAG"
+  leetcodeUrl: "https://leetcode.com/problems/all-paths-from-source-to-target/"
+---
+# All Paths From Source to Target
+
+Leetcode Problem 797: [All Paths From Source to Target](https://leetcode.com/problems/all-paths-from-source-to-target/description/)
+
+## Problem Summary
+Given a directed acyclic graph (DAG) of **n** nodes labeled from **0** to **n - 1**, represented as an adjacency list where `graph[i]` contains all nodes reachable from node **i** by a single edge, find all possible paths from node **0** to node **n - 1** and return them in any order. The graph has at most **15** nodes and is guaranteed to be a DAG.
+
+## Techniques
+- Backtracking
+- Depth-First Search
+- Breadth-First Search
+- Graph
+
+## Solution
+```ts
+function dfs(node: number, graph: number[][], path: number[], result: number[][]) {
+    path.push(node)
+
+    if (node === graph.length - 1) {
+        result.push([...path])
+    } else {
+        for (const child of graph[node]) {
+            dfs(child, graph, path, result)
+        }
+    }
+
+    path.pop()
+}
+
+function allPathsSourceTarget(graph: number[][]): number[][] {
+    const result: number[][] = []
+    dfs(0, graph, [], result)
+    return result
+};
+```

--- a/src/content/data-structures-and-algorithms/topic/graph-traversal-dfs-bfs/exercise/bus-routes/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/graph-traversal-dfs-bfs/exercise/bus-routes/content.mdx
@@ -1,0 +1,94 @@
+---
+title: "Bus Routes"
+description: "Given bus routes and a source and target stop, find the minimum number of buses needed to travel from source to target."
+date: 2026-04-11
+image: /images/posts/data-structures-and-algorithms-featured.png
+tags: [graph, dfs, bfs, traversal, data structures, algorithms]
+authors: [fabrizio_duroni]
+metadata:
+  technique: "BFS on route-level graph with stop-to-bus mapping"
+  leetcodeUrl: "https://leetcode.com/problems/bus-routes/"
+---
+# Bus Routes
+
+Leetcode Problem 815: [Bus Routes](https://leetcode.com/problems/bus-routes/description/)
+
+## Problem Summary
+Given an array of bus routes where `routes[i]` lists all the stops that the **i-th** bus visits repeatedly in a cycle, along with a source stop and a target stop, return the minimum number of buses you must take to travel from source to target. If it is not possible, return **-1**. You can start at the source stop without taking a bus, and you may switch between buses at shared stops. The number of routes is at most **500**, and the total number of stops across all routes is at most **100,000**. Stop numbers can be up to **1,000,000**.
+
+## Techniques
+- Array
+- Hash Table
+- Breadth-First Search
+
+## Solution
+```ts
+function numBusesToDestination(routes: number[][], source: number, target: number): number {
+    if (source === target) {
+        return 0
+    }
+
+    let busesForEachStop = new Map<number, number[]>()
+
+    for (let bus = 0; bus < routes.length; bus++) {
+        let busRoute = routes[bus]
+
+        for (let k = 0; k < busRoute.length; k++) {
+            let stop = busRoute[k]
+
+            if (busesForEachStop.has(stop)) {
+               busesForEachStop.set(stop, [...busesForEachStop.get(stop)!, bus])     
+            } else {
+                busesForEachStop.set(stop, [bus])
+            }
+        }
+    }
+
+    let queue = busesForEachStop.get(source)
+    let visitedStops = new Set<number>()
+    let visitedBuses = new Set<number>(queue)
+    let numberOfBusesNeeded = 1
+
+    while (queue && queue.length > 0) {
+        let currentNumberOfBuses = queue.length
+
+        while (currentNumberOfBuses > 0) {
+            let bus = queue.shift()!
+            let busRoute = routes[bus]
+
+            for (let stopPosition = 0; stopPosition < busRoute.length; stopPosition++) {
+                let stop = busRoute[stopPosition]
+
+                if (visitedStops.has(stop)) {
+                    continue;
+                }
+
+                visitedStops.add(stop)
+
+                if (stop === target) {
+                    return numberOfBusesNeeded
+                }
+
+                const busesForStop = busesForEachStop.get(stop)!
+
+                for (let busForStopPosition = 0; busForStopPosition < busesForStop.length; busForStopPosition++) {
+                    let bus = busesForStop[busForStopPosition]
+                    if (!visitedBuses.has(bus)) {
+                        visitedBuses.add(bus)
+                        queue.push(bus)
+                    }
+                }
+            }
+
+            currentNumberOfBuses--
+        }
+
+        numberOfBusesNeeded++
+    }
+
+    return -1
+};
+
+console.log(numBusesToDestination([[1,2,7],[3,6,7]], 1, 6)) // 2
+console.log(numBusesToDestination([[7,12],[4,5,15],[6],[15,19],[9,12,13]], 15, 12)) // -1
+```

--- a/src/content/data-structures-and-algorithms/topic/graph-traversal-dfs-bfs/exercise/clone-graph/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/graph-traversal-dfs-bfs/exercise/clone-graph/content.mdx
@@ -1,0 +1,59 @@
+---
+title: "Clone Graph"
+description: "Given a reference to a node in a connected undirected graph, return a deep copy of the entire graph."
+date: 2026-04-11
+image: /images/posts/data-structures-and-algorithms-featured.png
+tags: [graph, dfs, bfs, traversal, data structures, algorithms]
+authors: [fabrizio_duroni]
+metadata:
+  technique: "DFS with visited map for graph cloning"
+  leetcodeUrl: "https://leetcode.com/problems/clone-graph/"
+---
+# Clone Graph
+
+Leetcode Problem 133: [Clone Graph](https://leetcode.com/problems/clone-graph/description/)
+
+## Problem Summary
+Given a reference to a node in a connected undirected graph, return a deep copy (clone) of the entire graph. Each node contains an integer value and a list of its neighbors. The graph has at most **100** nodes with values from **1** to the number of nodes. There are no repeated edges or self-loops, and the graph is connected so that all nodes can be reached from the given node.
+
+## Techniques
+- Hash Table
+- Depth-First Search
+- Breadth-First Search
+- Graph
+
+## Solution
+```ts
+class _Node2 {
+    val: number
+    neighbors: _Node2[]
+
+    constructor(val?: number, neighbors?: _Node2[]) {
+        this.val = (val===undefined ? 0 : val)
+        this.neighbors = (neighbors===undefined ? [] : neighbors)
+    }
+}
+
+function cloneDfs(currentNode: _Node2 | null, visited: Map<_Node2, _Node2>): _Node2 | null {
+    if (!currentNode) {
+        return null
+    }
+
+    if (visited.has(currentNode)) {
+        return visited.get(currentNode)!
+    }
+
+    const clonedNode = new _Node2(currentNode.val, [])
+    visited.set(currentNode, clonedNode)
+
+    for (const neighbor of currentNode.neighbors) {
+        clonedNode.neighbors.push(cloneDfs(neighbor, visited)!)
+    }
+
+    return clonedNode
+}
+
+function cloneGraph(node: _Node2 | null): _Node2 | null {
+    return cloneDfs(node, new Map<_Node2, _Node2>())
+};
+```

--- a/src/content/data-structures-and-algorithms/topic/graph-traversal-dfs-bfs/exercise/employee-importance/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/graph-traversal-dfs-bfs/exercise/employee-importance/content.mdx
@@ -1,0 +1,64 @@
+---
+title: "Employee Importance"
+description: "Given a list of employees with importance values and subordinate lists, return the total importance of a given employee and all their subordinates."
+date: 2026-04-11
+image: /images/posts/data-structures-and-algorithms-featured.png
+tags: [graph, dfs, bfs, traversal, data structures, algorithms]
+authors: [fabrizio_duroni]
+metadata:
+  technique: "DFS value propagation on tree-structured graph"
+  leetcodeUrl: "https://leetcode.com/problems/employee-importance/"
+---
+# Employee Importance
+
+Leetcode Problem 690: [Employee Importance](https://leetcode.com/problems/employee-importance/description/)
+
+## Problem Summary
+Given a list of employees where each employee has a unique integer ID, an importance value, and a list of direct subordinate IDs, return the total importance value of a given employee and all their direct and indirect subordinates. There are at most **2,000** employees, and each employee has at most one direct manager.
+
+## Techniques
+- Hash Table
+- Depth-First Search
+- Breadth-First Search
+- Tree
+
+## Solution
+```ts
+class Employee {
+    id: number
+    importance: number
+    subordinates: number[]
+    constructor(id: number, importance: number, subordinates: number[]) {
+        this.id = (id === undefined) ? 0 : id;
+        this.importance = (importance === undefined) ? 0 : importance;
+        this.subordinates = (subordinates === undefined) ? [] : subordinates;
+    }
+}
+
+function employeeImportance(currentEmployee: Employee | undefined, employeesMap: Map<number, Employee>): number {
+    if (!currentEmployee) {
+        return 0
+    }
+
+    let subordinatesImportance = 0
+
+    for (let i = 0; i < currentEmployee.subordinates.length; i++) {
+        subordinatesImportance = subordinatesImportance + employeeImportance(
+            employeesMap.get(currentEmployee.subordinates[i]), 
+            employeesMap
+        )
+    }
+
+    return currentEmployee.importance + subordinatesImportance
+}
+
+function getImportance(employees: Employee[], id: number): number {
+    const employeesMap = new Map<number, Employee>()
+
+    for (const employee of employees) {
+        employeesMap.set(employee.id, employee)
+    }
+
+    return employeeImportance(employeesMap.get(id), employeesMap)
+};
+```

--- a/src/content/data-structures-and-algorithms/topic/graph-traversal-dfs-bfs/exercise/is-graph-bipartite/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/graph-traversal-dfs-bfs/exercise/is-graph-bipartite/content.mdx
@@ -1,0 +1,68 @@
+---
+title: "Is Graph Bipartite?"
+description: "Given an undirected graph, determine whether it can be partitioned into two sets such that every edge connects nodes in different sets."
+date: 2026-04-11
+image: /images/posts/data-structures-and-algorithms-featured.png
+tags: [graph, dfs, bfs, traversal, data structures, algorithms]
+authors: [fabrizio_duroni]
+metadata:
+  technique: "DFS two-coloring for bipartiteness"
+  leetcodeUrl: "https://leetcode.com/problems/is-graph-bipartite/"
+---
+# Is Graph Bipartite?
+
+Leetcode Problem 785: [Is Graph Bipartite?](https://leetcode.com/problems/is-graph-bipartite/description/)
+
+## Problem Summary
+Given an undirected graph with **n** nodes numbered from **0** to **n - 1**, represented as an adjacency list, determine whether the graph is bipartite. A graph is bipartite if its nodes can be partitioned into two independent sets **A** and **B** such that every edge connects a node in **A** to a node in **B**. The graph has no self-edges, no parallel edges, and may be disconnected. The number of nodes is at most **100**.
+
+## Techniques
+- Depth-First Search
+- Breadth-First Search
+- Union-Find
+- Graph
+
+## Solution
+```ts
+function graphBipartiteDfs(graph: number[][], node: number, colors: number[]): boolean {
+    const neighbors = graph[node]
+
+    for (const neighbor of neighbors) {
+        if (colors[neighbor] !== -1 && colors[neighbor] === colors[node]) {
+            return false
+        } else {
+            if (colors[neighbor] === -1) {
+                colors[neighbor] = 1 - colors[node] 
+                
+                if (!graphBipartiteDfs(graph, neighbor, colors)) {
+                    return false
+                }
+            }
+        }
+    }
+
+    return true
+}
+
+function isBipartite(graph: number[][]): boolean {
+    const colors = Array(graph.length).fill(-1)
+
+    for (let i = 0; i < graph.length; i++) {
+        for (let k = 0; k < graph[i].length; k++) {
+            if (colors[i] === -1) {
+                colors[i] = 0
+                const isBipartite = graphBipartiteDfs(graph, i, colors)
+
+                if (!isBipartite) {
+                    return false
+                }
+            }
+        }
+    }
+
+    return true
+};
+
+console.log(isBipartite([[1,3],[0,2],[1,3],[0,2]])) // true
+console.log(isBipartite([[1,2,3],[0,2],[0,1,3],[0,2]])) // false
+```

--- a/src/content/data-structures-and-algorithms/topic/graph-traversal-dfs-bfs/exercise/making-a-large-island/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/graph-traversal-dfs-bfs/exercise/making-a-large-island/content.mdx
@@ -1,0 +1,98 @@
+---
+title: "Making A Large Island"
+description: "Given an n x n binary grid, change at most one 0 to 1 and return the size of the largest island."
+date: 2026-04-11
+image: /images/posts/data-structures-and-algorithms-featured.png
+tags: [graph, dfs, bfs, traversal, data structures, algorithms]
+authors: [fabrizio_duroni]
+metadata:
+  technique: "DFS island labeling with component merging"
+  leetcodeUrl: "https://leetcode.com/problems/making-a-large-island/"
+---
+# Making A Large Island
+
+Leetcode Problem 827: [Making A Large Island](https://leetcode.com/problems/making-a-large-island/description/)
+
+## Problem Summary
+Given an **n x n** binary grid where **1** represents land and **0** represents water, you are allowed to change at most one **0** to **1**. Return the size of the largest island after applying this operation. An island is a group of **1**s connected in four directions (up, down, left, right). The grid dimension **n** is at most **500**.
+
+## Techniques
+- Array
+- Depth-First Search
+- Breadth-First Search
+- Union-Find
+- Matrix
+
+## Solution
+```ts
+function dfsArea(row: number, column: number, grid: number[][], label: number): number {
+    if (!grid[row] || !grid[row][column] || grid[row][column] != 1) {
+        return 0
+    }
+
+    grid[row][column] = label
+    let area = 1
+
+    area += dfsArea(row, column - 1, grid, label)
+    area += dfsArea(row - 1, column, grid, label)
+    area += dfsArea(row, column + 1, grid, label)
+    area += dfsArea(row + 1, column, grid, label)
+
+    return area
+}
+
+function largestIsland(grid: number[][]): number {
+    let label = 2
+    let areas = new Map<number, number>
+    let rows = grid.length
+    let columns = grid[0].length
+
+    for (let i = 0; i < rows; i++) {
+        for (let j = 0; j < columns; j++) {
+            if (grid[i][j] === 1) {
+                let area = dfsArea(i, j, grid, label)
+                areas.set(label, area)
+                label++
+            }
+        }
+    }
+
+    let sumOfAreas = 0
+
+    for (const area of areas.values()) {
+        sumOfAreas = sumOfAreas + area
+    }
+
+    if (rows * columns === sumOfAreas) {
+        return sumOfAreas
+    }
+
+    let maxArea = 0
+
+    for (let row = 0; row < grid.length; row++) {
+        for (let column = 0; column < grid[0].length; column++) {
+            if (grid[row][column] === 0) {
+                let seen = new Set<number>()
+                let leftArea = grid[row] && grid[row][column - 1] ? seen.add(grid[row][column - 1]) ?? 0 : 0
+                let topArea = grid[row - 1] && grid[row - 1][column] ? seen.add(grid[row - 1][column]) ?? 0 : 0
+                let rightArea = grid[row] && grid[row][column + 1] ? seen.add(grid[row][column + 1]) ?? 0 : 0
+                let bottomArea = grid[row + 1] && grid[row + 1][column] ? seen.add(grid[row + 1][column]) ?? 0 : 0
+                
+                let area = 1
+                for (let lbl of seen) {
+                    area += areas.get(lbl) ?? 0
+                } 
+
+                maxArea = Math.max(maxArea, area)
+            }
+        }
+    }
+
+    return maxArea
+};
+
+console.log(largestIsland([[1, 0], [0, 1]])) // 3
+console.log(largestIsland([[1, 1], [1, 0]])) // 4
+console.log(largestIsland([[1, 1], [1, 1]])) // 4
+console.log(largestIsland([[0, 0], [0, 0]])) // 1
+```

--- a/src/content/data-structures-and-algorithms/topic/graph-traversal-dfs-bfs/exercise/number-of-islands/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/graph-traversal-dfs-bfs/exercise/number-of-islands/content.mdx
@@ -1,0 +1,69 @@
+---
+title: "Number of Islands"
+description: "Given a 2D binary grid representing a map of land and water, return the number of islands formed by horizontally or vertically adjacent land cells."
+date: 2026-04-11
+image: /images/posts/data-structures-and-algorithms-featured.png
+tags: [graph, dfs, bfs, traversal, data structures, algorithms]
+authors: [fabrizio_duroni]
+metadata:
+  technique: "DFS flood fill on implicit grid graph"
+  leetcodeUrl: "https://leetcode.com/problems/number-of-islands/"
+---
+# Number of Islands
+
+Leetcode Problem 200: [Number of Islands](https://leetcode.com/problems/number-of-islands/description/)
+
+## Problem Summary
+Given an **m x n** 2D binary grid where `'1'` represents land and `'0'` represents water, return the number of islands. An island is a group of adjacent land cells connected horizontally or vertically, and all four edges of the grid are surrounded by water. The grid dimensions are at most **300 x 300**.
+
+## Techniques
+- Array
+- Depth-First Search
+- Breadth-First Search
+- Union-Find
+- Matrix
+
+## Solution
+```ts
+function dfs(grid: string[][], r: number, c: number, visited: boolean[][]): void {
+    if (
+        (r < 0 || c < 0 || r >= grid.length || c >= grid[0].length) || 
+        visited[r][c] ||
+        grid[r][c] !== "1"
+    ) {
+        return
+    }
+
+    visited[r][c] = true;
+
+    dfs(grid, r + 1, c, visited);
+    dfs(grid, r - 1, c, visited);
+    dfs(grid, r, c + 1, visited);
+    dfs(grid, r, c - 1, visited);
+}
+
+function numIslands(grid: string[][]): number {
+    const visited: boolean[][] = Array.from(
+        Array(grid.length), _ => Array(grid[0].length).fill(false)
+    )
+    let islands = 0
+    
+    for (let i = 0; i < grid.length; i++) {
+        for (let j = 0; j < grid[0].length; j++) {
+            if (grid[i][j] === '1' && !visited[i][j]) {
+                islands++
+                dfs(grid, i, j, visited)
+            }
+        }
+    }
+
+    return islands
+};
+
+console.log(numIslands([
+    ["1","1","0","0","0"],
+    ["1","1","0","0","0"],
+    ["0","0","1","0","0"],
+    ["0","0","0","1","1"]
+]))
+```

--- a/src/content/data-structures-and-algorithms/topic/graph-traversal-dfs-bfs/exercise/open-the-lock/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/graph-traversal-dfs-bfs/exercise/open-the-lock/content.mdx
@@ -1,0 +1,86 @@
+---
+title: "Open the Lock"
+description: "Given a lock with 4 circular wheels and a list of deadends, find the minimum number of turns to reach the target combination from 0000."
+date: 2026-04-11
+image: /images/posts/data-structures-and-algorithms-featured.png
+tags: [graph, dfs, bfs, traversal, data structures, algorithms]
+authors: [fabrizio_duroni]
+metadata:
+  technique: "BFS on implicit state-space graph"
+  leetcodeUrl: "https://leetcode.com/problems/open-the-lock/"
+---
+# Open the Lock
+
+Leetcode Problem 752: [Open the Lock](https://leetcode.com/problems/open-the-lock/description/)
+
+## Problem Summary
+A lock has 4 circular wheels, each with digits **0** through **9** that wrap around (so **9** can turn to **0** and vice versa). The lock starts at `"0000"`. Each move turns one wheel one slot. Given a list of deadend combinations (states that lock the wheels permanently) and a target combination, return the minimum number of moves to reach the target, or **-1** if it is impossible. The deadends list has at most **500** entries, and both deadends and target are 4-character digit strings.
+
+## Techniques
+- Array
+- Hash Table
+- String
+- Breadth-First Search
+
+## Solution
+```ts
+function setCharAt(str: string, index: number, chr: string | number): string {
+    if(index > str.length-1) {
+        return str;
+    } 
+
+    return str.substring(0,index) + chr + str.substring(index+1);
+}
+
+function openLock(deadends: string[], target: string): number {
+    if (deadends.includes('0000')) {
+        return -1
+    }
+
+    let visited = new Set<string>(
+        ["0000"]
+    )
+    let queue = [
+        "0000"
+    ]
+
+    let moves = 0
+
+    while (queue.length > 0) {
+        let currentLevelSize = queue.length
+
+        while (currentLevelSize > 0) {
+            const currentMove = queue.shift()!
+
+            if (currentMove === target)  {
+                return moves
+            }
+
+            for (let i = 0; i < 4; i++) {
+                const value = Number(currentMove.charAt(i))
+                const upMove = setCharAt(currentMove, i, (value + 1) % 10)
+                const downMove = setCharAt(currentMove, i, (value + 9) % 10)
+
+                if (!deadends.includes(upMove) && !visited.has(upMove)) {
+                    queue.push(upMove)
+                    visited.add(upMove)
+                }
+
+                if (!deadends.includes(downMove) && !visited.has(downMove)) {
+                    queue.push(downMove)
+                    visited.add(downMove)
+                }
+            }
+            currentLevelSize--
+        }
+
+        moves++
+    }
+
+    return -1
+};
+
+console.log(openLock(["0201","0101","0102","1212","2002"], "0202")) // 6
+console.log(openLock(["8888"], "0009")) // 1
+console.log(openLock(["8887","8889","8878","8898","8788","8988","7888","9888"], "8888")) // -1
+```

--- a/src/content/data-structures-and-algorithms/topic/graph-traversal-dfs-bfs/exercise/pacific-atlantic-water-flow/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/graph-traversal-dfs-bfs/exercise/pacific-atlantic-water-flow/content.mdx
@@ -1,0 +1,100 @@
+---
+title: "Pacific Atlantic Water Flow"
+description: "Given a rectangular island height map, find all cells from which water can flow to both the Pacific and Atlantic oceans."
+date: 2026-04-11
+image: /images/posts/data-structures-and-algorithms-featured.png
+tags: [graph, dfs, bfs, traversal, data structures, algorithms]
+authors: [fabrizio_duroni]
+metadata:
+  technique: "DFS reverse flow from ocean boundaries"
+  leetcodeUrl: "https://leetcode.com/problems/pacific-atlantic-water-flow/"
+---
+# Pacific Atlantic Water Flow
+
+Leetcode Problem 417: [Pacific Atlantic Water Flow](https://leetcode.com/problems/pacific-atlantic-water-flow/description/)
+
+## Problem Summary
+Given an **m x n** rectangular island where the Pacific Ocean borders the top and left edges and the Atlantic Ocean borders the bottom and right edges, each cell contains a height value. Water can flow from a cell to any adjacent cell (up, down, left, right) with height less than or equal to the current cell. Return a list of all grid coordinates from which water can flow to both oceans. Heights are non-negative integers up to **100,000**, and the grid dimensions are at most **200 x 200**.
+
+## Techniques
+- Array
+- Depth-First Search
+- Breadth-First Search
+- Matrix
+
+## Solution
+```ts
+function dfsOcean(
+    row: number,
+    column: number,
+    heights: number[][],
+    reachable: boolean[][]
+) {
+    if (reachable[row][column]) {
+        return
+    } 
+
+    reachable[row][column] = true
+
+    const rows = heights.length
+    const cols = heights[0].length
+    const currentHeight = heights[row][column]
+
+    if (row - 1 >= 0) {
+        if (heights[row - 1][column] >= currentHeight) {
+            dfsOcean(row - 1, column, heights, reachable)
+        }
+    }
+
+    if (row + 1 < rows) {
+        if (heights[row + 1][column] >= currentHeight) {
+            dfsOcean(row + 1, column, heights, reachable)
+        }
+    }
+
+    if (column - 1 >= 0) {
+        if (heights[row][column - 1] >= currentHeight) {
+            dfsOcean(row, column - 1, heights, reachable)
+        }
+    }
+
+    if (column + 1 < cols) {
+        if (heights[row][column + 1] >= currentHeight) {
+            dfsOcean(row, column + 1, heights, reachable)
+        }
+    }
+}
+
+function pacificAtlantic(heights: number[][]): number[][] {
+    const rows = heights.length
+    const columns = heights[0].length
+    const reachablePacific: boolean[][] = Array.from(
+        Array(heights.length), _ => Array(heights[0].length).fill(false)
+    )
+    const reachableAtlantic: boolean[][] = Array.from(
+        Array(heights.length), _ => Array(heights[0].length).fill(false)
+    )
+
+    for (let c = 0; c < columns; c++) {
+        dfsOcean(0, c, heights, reachablePacific)
+        dfsOcean(rows - 1, c, heights, reachableAtlantic)
+    }
+
+    for (let r = 0; r < rows; r++) {
+        dfsOcean(r, 0, heights, reachablePacific)
+        dfsOcean(r, columns - 1, heights, reachableAtlantic)
+    }
+
+    const results = []
+
+    for (let i = 0; i < rows; i++) {
+        for (let j = 0; j < columns; j++) {
+            if (reachablePacific[i][j] && reachableAtlantic[i][j]) {
+                results.push([i, j])
+            }
+        }
+    }
+
+    return results
+};
+```

--- a/src/content/data-structures-and-algorithms/topic/graph-traversal-dfs-bfs/exercise/rotting-oranges/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/graph-traversal-dfs-bfs/exercise/rotting-oranges/content.mdx
@@ -1,0 +1,88 @@
+---
+title: "Rotting Oranges"
+description: "Given a grid of fresh and rotten oranges, determine the minimum time for all fresh oranges to become rotten, or return -1 if impossible."
+date: 2026-04-11
+image: /images/posts/data-structures-and-algorithms-featured.png
+tags: [graph, dfs, bfs, traversal, data structures, algorithms]
+authors: [fabrizio_duroni]
+metadata:
+  technique: "Multi-source BFS simulation"
+  leetcodeUrl: "https://leetcode.com/problems/rotting-oranges/"
+---
+# Rotting Oranges
+
+Leetcode Problem 994: [Rotting Oranges](https://leetcode.com/problems/rotting-oranges/description/)
+
+## Problem Summary
+Given an **m x n** grid where each cell can be empty (**0**), contain a fresh orange (**1**), or contain a rotten orange (**2**), every minute each rotten orange causes all adjacent fresh oranges (up, down, left, right) to become rotten. Return the minimum number of minutes that must elapse until no fresh orange remains. If it is impossible for all oranges to rot, return **-1**. The grid dimensions are at most **10 x 10**.
+
+## Techniques
+- Array
+- Breadth-First Search
+- Matrix
+
+## Solution
+```ts
+function orangesRotting(grid: number[][]): number {
+    const rows = grid.length
+    const columns = grid[0].length
+    const queue: [number, number][] = []
+    let fresh = 0
+
+    for (let row = 0; row < rows; row++) {
+        for (let column = 0; column < columns; column++) {
+            if (grid[row][column] === 2) {
+                queue.push([row, column])
+            }
+
+            if (grid[row][column] === 1) {
+                fresh++
+            }
+        }
+    }
+
+    let time = 0
+
+    while (queue.length > 0) {
+        let currentLevelCount = queue.length
+
+        for (let i = 0; i < currentLevelCount; i++) {
+            const [row, column] = queue.shift()!
+
+            if (row - 1 >= 0 && grid[row - 1][column] === 1) {
+                grid[row - 1][column] = 2
+                queue.push([row - 1, column])
+                fresh--
+            }
+
+            if (column + 1 < columns && grid[row][column + 1] === 1) {
+                grid[row][column + 1] = 2
+                queue.push([row, column + 1])
+                fresh--
+            }
+
+            if (row + 1 < rows && grid[row + 1][column] === 1) {
+                grid[row + 1][column] = 2
+                queue.push([row + 1, column])
+                fresh--
+            }
+
+            if (column - 1 >= 0 && grid[row][column - 1] === 1) {
+                grid[row][column - 1] = 2
+                queue.push([row, column - 1]) 
+                fresh--
+            }
+        }
+
+        if (queue.length > 0) {
+            time++
+        }
+    }
+
+    return fresh === 0 ? time : -1
+};
+
+console.log(orangesRotting([[2,1,1],[1,1,0],[0,1,1]])) // 4
+console.log(orangesRotting([[2,1,1],[0,1,1],[1,0,1]])) // -1
+console.log(orangesRotting([[0,2]])) // 0
+```

--- a/src/content/data-structures-and-algorithms/topic/graph-traversal-dfs-bfs/exercise/shortest-path-in-a-grid-with-obstacles-elimination/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/graph-traversal-dfs-bfs/exercise/shortest-path-in-a-grid-with-obstacles-elimination/content.mdx
@@ -1,0 +1,80 @@
+---
+title: "Shortest Path in a Grid with Obstacles Elimination"
+description: "Find the shortest path in a grid from top-left to bottom-right, with the ability to eliminate up to k obstacles."
+date: 2026-04-11
+image: /images/posts/data-structures-and-algorithms-featured.png
+tags: [graph, dfs, bfs, traversal, data structures, algorithms]
+authors: [fabrizio_duroni]
+metadata:
+  technique: "BFS with extended state (position + remaining eliminations)"
+  leetcodeUrl: "https://leetcode.com/problems/shortest-path-in-a-grid-with-obstacles-elimination/"
+---
+# Shortest Path in a Grid with Obstacles Elimination
+
+Leetcode Problem 1293: [Shortest Path in a Grid with Obstacles Elimination](https://leetcode.com/problems/shortest-path-in-a-grid-with-obstacles-elimination/description/)
+
+## Problem Summary
+Given an **m x n** grid of **0**s (empty) and **1**s (obstacles), find the length of the shortest path from the top-left corner to the bottom-right corner. You may eliminate (walk through) at most **k** obstacles along the way. Each step moves to an adjacent cell (up, down, left, right). If no such path exists, return **-1**. The grid dimensions are at most **40 x 40**, and **k** is at most **m * n**.
+
+## Techniques
+- Array
+- Breadth-First Search
+- Matrix
+
+## Solution
+```ts
+function shortestPath(grid: number[][], k: number): number {
+    const rows = grid.length;
+    const cols = grid[0].length;
+    const visited = Array.from(
+        { length: rows },
+        () => Array(cols).fill(-1)
+    );
+
+    const queue: [number, number, number][] = [[0, 0, k]];
+    visited[0][0] = k;
+
+    let steps = 0;
+
+    const dirs = [
+        [1, 0],
+        [-1, 0],
+        [0, 1],
+        [0, -1]
+    ];
+
+    while (queue.length > 0) {
+        let levelSize = queue.length;
+
+        while (levelSize-- > 0) {
+            const [row, col, kLeft] = queue.shift()!;
+
+            if (row === rows - 1 && col === cols - 1) {
+                return steps;
+            }
+
+            for (const [dr, dc] of dirs) {
+                const newRow = row + dr;
+                const newColumn = col + dc;
+
+                if (newRow < 0 || newColumn < 0 || newRow >= rows || newColumn >= cols) { 
+                    continue;
+                }
+
+                const newK = kLeft - grid[newRow][newColumn];
+
+                if (newK >= 0 && newK > visited[newRow][newColumn]) {
+                    visited[newRow][newColumn] = newK;
+                    queue.push([newRow, newColumn, newK]);
+                }
+            }
+        }
+
+        steps++;
+    }
+
+    return -1;
+}
+
+console.log(shortestPath([[0,0,0],[1,1,0],[0,0,0],[0,1,1],[0,0,0]], 1)); // Output: 6
+```

--- a/src/content/data-structures-and-algorithms/topic/graph-traversal-dfs-bfs/exercise/surrounded-regions/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/graph-traversal-dfs-bfs/exercise/surrounded-regions/content.mdx
@@ -1,0 +1,75 @@
+---
+title: "Surrounded Regions"
+description: "Given a matrix of 'X' and 'O', capture all regions of 'O' that are completely surrounded by 'X' by flipping them to 'X'."
+date: 2026-04-11
+image: /images/posts/data-structures-and-algorithms-featured.png
+tags: [graph, dfs, bfs, traversal, data structures, algorithms]
+authors: [fabrizio_duroni]
+metadata:
+  technique: "DFS boundary flood fill"
+  leetcodeUrl: "https://leetcode.com/problems/surrounded-regions/"
+---
+# Surrounded Regions
+
+Leetcode Problem 130: [Surrounded Regions](https://leetcode.com/problems/surrounded-regions/description/)
+
+## Problem Summary
+Given an **m x n** board containing `'X'` and `'O'`, capture all regions that are completely surrounded by `'X'`. A region is captured by flipping all `'O'`s into `'X'`s in that surrounded region. An `'O'` on the border of the board, or any `'O'` connected to a border `'O'`, is not considered surrounded and must not be flipped. The board dimensions are at most **200 x 200**.
+
+## Techniques
+- Array
+- Depth-First Search
+- Breadth-First Search
+- Union-Find
+- Matrix
+
+## Solution
+```ts
+function dfsRegions(row: number, column: number, board: string[][]) {
+    if (!board[row] || !board[row][column] || board[row][column] === 'X' || board[row][column] === 'T') {
+        return
+    }
+
+    if (board[row][column] === 'O') {
+        board[row][column] = 'T'
+    }
+
+    dfsRegions(row, column - 1, board)
+    dfsRegions(row - 1, column, board)
+    dfsRegions(row, column + 1, board)
+    dfsRegions(row + 1, column, board)
+}
+
+function deleteSafeO(board: string[][], rows: number, columns: number) {
+    for (let i = 0; i < rows; i++) {
+        for (let k = 0; k < columns; k++) {
+            if (board[i][k] === 'O') {
+                board[i][k] = 'X'
+            }
+
+            if (board[i][k] === 'T') {
+                board[i][k] = 'O'
+            }        
+        }
+    }
+}
+
+function solve(board: string[][]): void {
+    const rows = board.length
+    const columns = board[0].length
+
+    for (let c = 0; c < columns; c++) {
+        dfsRegions(0, c, board)
+        dfsRegions(rows - 1, c, board)
+    }
+
+    for (let r = 0; r < rows; r++) {
+        dfsRegions(r, 0, board)
+        dfsRegions(r, columns - 1, board)
+    }
+
+    deleteSafeO(board, rows, columns)
+}
+
+console.log(solve([["X","X","X","X"],["X","O","O","X"],["X","X","O","X"],["X","O","X","X"]]))
+```

--- a/src/content/data-structures-and-algorithms/topic/graph-traversal-dfs-bfs/exercise/time-needed-to-inform-all-employees/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/graph-traversal-dfs-bfs/exercise/time-needed-to-inform-all-employees/content.mdx
@@ -1,0 +1,59 @@
+---
+title: "Time Needed to Inform All Employees"
+description: "Given a company hierarchy and inform times, find the total time needed for the head to inform all employees."
+date: 2026-04-11
+image: /images/posts/data-structures-and-algorithms-featured.png
+tags: [graph, dfs, bfs, traversal, data structures, algorithms]
+authors: [fabrizio_duroni]
+metadata:
+  technique: "DFS with time propagation on tree graph"
+  leetcodeUrl: "https://leetcode.com/problems/time-needed-to-inform-all-employees/"
+---
+# Time Needed to Inform All Employees
+
+Leetcode Problem 1376: [Time Needed to Inform All Employees](https://leetcode.com/problems/time-needed-to-inform-all-employees/description/)
+
+## Problem Summary
+A company has **n** employees numbered from **0** to **n - 1**, each with a direct manager given in the `manager` array (the head of the company has manager value **-1**). Each employee has an `informTime` representing the minutes needed to inform all their direct subordinates. When an employee is informed, they can begin informing their own subordinates. Return the total time needed for the head to inform all employees. The number of employees is at most **100,000**.
+
+## Techniques
+- Tree
+- Depth-First Search
+- Breadth-First Search
+
+## Solution
+```ts
+function buildAdjList(n: number, manager: number[]): number[][] {
+    const adj: number[][] = Array.from({ length: n }, () => [])
+
+    for (let employee = 0; employee < n; employee++) {
+        const boss = manager[employee]
+
+        if (boss !== -1) {
+            adj[boss].push(employee)
+        }
+    }
+
+    return adj
+}
+
+function dfs(current: number, hierarchy: number[][], informTime: number[], currentTime: number): number {
+   const employees = hierarchy[current]
+   let maxTime = currentTime
+
+    for (const employee of employees) {
+        maxTime = Math.max(maxTime, dfs(employee, hierarchy, informTime, currentTime + informTime[current]))
+    }
+
+    return maxTime
+}
+
+function numOfMinutes(n: number, headID: number, manager: number[], informTime: number[]): number {
+    const hierarchy = buildAdjList(n, manager)
+    return dfs(headID, hierarchy, informTime, 0)
+};
+
+console.log(numOfMinutes(1, 0, [-1], [0])) // 0
+console.log(numOfMinutes(6, 2, [2,2,-1,2,2,2], [0,0,1,0,0,0])) // 1
+console.log(numOfMinutes(7, 6, [1,2,3,4,5,6,-1], [0,6,5,4,3,2,1])) // 21
+```

--- a/src/content/data-structures-and-algorithms/topic/graph-traversal-dfs-bfs/exercise/word-ladder/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/graph-traversal-dfs-bfs/exercise/word-ladder/content.mdx
@@ -1,0 +1,93 @@
+---
+title: "Word Ladder"
+description: "Given two words and a dictionary, find the length of the shortest transformation sequence where each step changes one letter."
+date: 2026-04-11
+image: /images/posts/data-structures-and-algorithms-featured.png
+tags: [graph, dfs, bfs, traversal, data structures, algorithms]
+authors: [fabrizio_duroni]
+metadata:
+  technique: "BFS on implicit word-transformation graph"
+  leetcodeUrl: "https://leetcode.com/problems/word-ladder/"
+---
+# Word Ladder
+
+Leetcode Problem 127: [Word Ladder](https://leetcode.com/problems/word-ladder/description/)
+
+## Problem Summary
+Given a `beginWord`, an `endWord`, and a list of dictionary words, find the number of words in the shortest transformation sequence from `beginWord` to `endWord`. Each transformation changes exactly one letter, and every intermediate word must exist in the dictionary. The `beginWord` does not need to be in the dictionary. If no such sequence exists, return **0**. All words have the same length (at most **10** characters), the dictionary contains at most **5,000** words, and all words consist of lowercase English letters.
+
+## Techniques
+- Hash Table
+- String
+- Breadth-First Search
+
+## Solution
+```ts
+function getPattern(word: string, starPosition: number) {
+    return word.slice(0, starPosition) + '*' + word.slice(starPosition + 1)
+}
+
+function ladderLength(beginWord: string, endWord: string, wordList: string[]): number {
+    const patterns = new Map<string, string[]>()
+
+    for (let wordPosition = 0; wordPosition < wordList.length; wordPosition++) {
+        const word = wordList[wordPosition]
+
+        for (let charPosition = 0; charPosition < word.length; charPosition++) {
+            const pattern = getPattern(word, charPosition)
+
+            if (patterns.has(pattern)) {
+                patterns.set(pattern, [...patterns.get(pattern)!, word])
+            } else {
+                patterns.set(pattern, [word])                
+            }
+        }
+    }
+
+    let numberOfTransformations = 1
+    let queue = [beginWord]
+    const visitedPatterns = new Set<string>()
+    const visitedWords = new Set<string>()
+
+    while (queue && queue.length > 0) {
+        let currentLevelLenght = queue.length
+
+        while (currentLevelLenght > 0) {
+            const word = queue.shift()!
+
+            if (word === endWord) {
+                return numberOfTransformations
+            }
+
+            for (let charPosition = 0; charPosition < word.length; charPosition++) {
+                const newPattern = getPattern(word, charPosition)
+
+                if (!visitedPatterns.has(newPattern)) {
+                    const words = patterns.get(newPattern)
+                    
+                    if (words) {
+                        for (const newWord of words) {
+                            if (!visitedWords.has(newWord)) {
+                                queue.push(newWord)
+                                visitedWords.add(newWord)
+                            }
+                        }
+                    }
+
+                    visitedPatterns.add(newPattern)
+                }
+            }
+
+            currentLevelLenght--
+        }
+
+        numberOfTransformations++
+    }
+
+    return 0
+};
+
+
+console.log(ladderLength("hit", "cog", ["hot","dot","dog","lot","log","cog"])) // 5
+console.log(ladderLength("hit", "cog", ["hot","dot","dog","lot","log"])) // 0
+```


### PR DESCRIPTION
Graph traversal DFS and BFS dsa page

## Description
New DSA course article covering graph traversal with DFS and BFS. The article frames graph traversal as a natural generalization of the existing tree traversal article, introducing graph fundamentals (types, representations) before developing DFS and BFS patterns with code templates and worked examples. Includes 16 exercise pages (10 DFS, 6 BFS) with LeetCode problem summaries and TypeScript solutions. Updates the roadmap to remove the DFS and BFS "soon available" entries.

## Motivation and Context
Dsa course

## How Has This Been Tested?
Browser

## Types of changes
- [ ] Bug fix :bug: (non-breaking change which fixes an issue)
- [x] New feature :sparkles: (non-breaking change which adds functionality)
- [ ] Breaking change :boom: (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project :beers:.
- [X] My change requires a change to the documentation :bulb: and I have updated the documentation accordingly.
- [X] I have read the [CONTRIBUTING](https://github.com/chicio/chicio.github.io/blob/master/CONTRIBUTING.md) document :busts_in_silhouette:.
- [X] I have added tests to cover my changes :tada:.
- [X] All new and existing tests passed :white_check_mark:.