### PR TITLE
feat(content): :sparkles: simplify exercise list

### DIFF
--- a/src/components/sections/data-structures-and-algorithms/components/topic-exercises.tsx
+++ b/src/components/sections/data-structures-and-algorithms/components/topic-exercises.tsx
@@ -11,31 +11,12 @@ export const TopicExercises: FC<TopicExercisesProps> = ({ topic }) => {
     if (exercises.length === 0) return null;
 
     return (
-        <div className="table-wrapper">
-            <table>
-                <thead>
-                    <tr>
-                        <th>Exercise</th>
-                        <th>Technique</th>
-                        <th>Solution</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    {exercises.map((exercise) => (
-                        <tr key={exercise.slug.formatted}>
-                            <td>
-                                <a href={exercise.frontmatter.metadata?.leetcodeUrl} target="_blank" rel="noopener noreferrer">
-                                    {exercise.frontmatter.title}
-                                </a>
-                            </td>
-                            <td>{exercise.frontmatter.metadata?.technique}</td>
-                            <td>
-                                <a href={exercise.slug.formatted}>Solution</a>
-                            </td>
-                        </tr>
-                    ))}
-                </tbody>
-            </table>
-        </div>
+        <ul>
+            {exercises.map((exercise) => (
+                <li key={exercise.slug.formatted}>
+                    <a href={exercise.slug.formatted}>{exercise.frontmatter.title}</a>
+                </li>
+            ))}
+        </ul>
     );
 };


### PR DESCRIPTION
## Summary
- Replace the 3-column exercise table (Exercise, Technique, Solution) with a simple link list at the end of each DSA topic article
- Each exercise has its own dedicated page with all details (technique, LeetCode link, solution), so the table columns are redundant

## Motivation and Context
DSA course UX improvement

## How Has This Been Tested?
Browser

## Types of changes
- [ ] Bug fix :bug: (non-breaking change which fixes an issue)
- [x] New feature :sparkles: (non-breaking change which adds functionality)
- [ ] Breaking change :boom: (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project :beers:.
- [X] My change requires a change to the documentation :bulb: and I have updated the documentation accordingly.
- [X] I have read the [CONTRIBUTING](https://github.com/chicio/chicio.github.io/blob/master/CONTRIBUTING.md) document :busts_in_silhouette:.
- [X] I have added tests to cover my changes :tada:.
- [X] All new and existing tests passed :white_check_mark:.