### PR TITLE
feat(ux): :shield: add guardrails to chatbot API

### DIFF
--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -1,4 +1,5 @@
 import { createSystemPrompt } from "@/lib/chat/llm-prompt";
+import { runGuardrails } from "@/lib/chat/guardrails";
 import { findRelevantContent } from "@/lib/upstash/upstash-vector";
 import { groq } from "@ai-sdk/groq";
 import { convertToModelMessages, stepCountIs, streamText, tool, UIMessage } from "ai";
@@ -6,6 +7,23 @@ import z from "zod";
 
 export async function POST(req: Request) {
   const { messages }: { messages: UIMessage[] } = await req.json();
+
+  const lastUserMessage = messages.findLast((m) => m.role === "user");
+  const lastUserText =
+    lastUserMessage?.parts
+      .filter((p) => p.type === "text")
+      .map((p) => p.text)
+      .join(" ")
+      .trim() ?? "";
+
+  if (lastUserText) {
+    const guardrailResult = await runGuardrails(lastUserText);
+
+    if (!guardrailResult.safe) {
+      return new Response(guardrailResult.blockedReason, { status: 400 });
+    }
+  }
+
   const result = streamText({
     model: groq("llama-3.3-70b-versatile"),
     // model: groq("llama-3.1-8b-instant"),

--- a/src/components/sections/chat/components/chat.tsx
+++ b/src/components/sections/chat/components/chat.tsx
@@ -75,8 +75,8 @@ export const Chat: FC = () => {
           ))}
           {error && (
             <ChatMessage isUser={false}>
-              Sorry, I have encountered an error while trying to processing your
-              question. Please try again later.
+              {error.message ||
+                "Sorry, I have encountered an error while trying to process your question. Please try again later."}
             </ChatMessage>
           )}
           <div ref={messagesEndRef} />

--- a/src/lib/chat/guardrails.ts
+++ b/src/lib/chat/guardrails.ts
@@ -1,0 +1,121 @@
+import { groq } from "@ai-sdk/groq";
+import { generateText } from "ai";
+
+export interface GuardrailResult {
+    safe: boolean;
+    blockedReason?: string;
+}
+
+const INJECTION_PATTERNS = [
+    /ignore\s+(all\s+)?(previous|prior|above)\s+instructions/i,
+    /disregard\s+(all\s+)?(previous|prior|above)\s+instructions/i,
+    /forget\s+(all\s+)?(previous|prior|above)\s+instructions/i,
+    /you\s+are\s+now\s+/i,
+    /act\s+as\s+(if\s+you\s+are\s+|a\s+)?(?!Fabrizio)/i,
+    /pretend\s+(you\s+are|to\s+be)\s+/i,
+    /do\s+anything\s+now/i,
+    /jailbreak/i,
+    /override\s+(your\s+)?(system\s+)?prompt/i,
+    /\[system\]/i,
+    /<\|system\|>/i,
+];
+
+const TOPIC_RELEVANCE_SYSTEM_PROMPT = `You are a strict topic classifier for Fabrizio Duroni's portfolio chatbot.
+Reply with ONLY the single word "yes" or "no".
+
+Reply "yes" if the message is about any of:
+- Fabrizio Duroni (his career, skills, projects, experience, education, personality, jokes)
+- Software development, programming, technology, computer science
+- His blog posts, articles, or technical writing
+- General greetings, introductions, or small talk
+- Questions about what the chatbot can help with
+
+Reply "no" if the message asks about completely unrelated topics (sports, cooking, weather, politics, entertainment)
+or requests the assistant to perform tasks unrelated to answering questions about Fabrizio (e.g., writing code for the user, translating text, solving math problems).`;
+
+export const checkPromptInjection = (message: string): GuardrailResult => {
+    const matched = INJECTION_PATTERNS.some((pattern) => pattern.test(message));
+
+    if (matched) {
+        return {
+            safe: false,
+            blockedReason:
+                "I detected an attempt to override my instructions. I'm here to answer questions about Fabrizio Duroni — feel free to ask me anything about his work, projects, or experience.",
+        };
+    }
+
+    return { safe: true };
+};
+
+export const checkInputSafety = async (message: string): Promise<GuardrailResult> => {
+    try {
+        const { text } = await generateText({
+            model: groq("meta-llama/llama-guard-3-8b"),
+            messages: [{ role: "user", content: message }],
+        });
+
+        const isSafe = text.trim().toLowerCase().startsWith("safe");
+
+        if (!isSafe) {
+            return {
+                safe: false,
+                blockedReason:
+                    "I'm not able to respond to that message. I'm here to answer questions about Fabrizio Duroni and his work as a software engineer.",
+            };
+        }
+
+        return { safe: true };
+    } catch (error) {
+        // Fail open — if the safety model is unavailable, allow the request through
+        console.warn("Llama Guard safety check failed, allowing request:", error);
+        return { safe: true };
+    }
+};
+
+export const checkTopicRelevance = async (message: string): Promise<GuardrailResult> => {
+    try {
+        const { text } = await generateText({
+            model: groq("llama-3.1-8b-instant"),
+            system: TOPIC_RELEVANCE_SYSTEM_PROMPT,
+            prompt: message,
+            maxOutputTokens: 5,
+            temperature: 0,
+        });
+
+        const isOnTopic = text.trim().toLowerCase().startsWith("yes");
+
+        if (!isOnTopic) {
+            return {
+                safe: false,
+                blockedReason:
+                    "That topic is outside my scope. I'm Fabrizio's portfolio assistant — ask me about his skills, experience, projects, or anything software development related!",
+            };
+        }
+
+        return { safe: true };
+    } catch (error) {
+        // Fail open — if the relevance model is unavailable, allow the request through
+        console.warn("Topic relevance check failed, allowing request:", error);
+        return { safe: true };
+    }
+};
+
+export const runGuardrails = async (message: string): Promise<GuardrailResult> => {
+    const injectionResult = checkPromptInjection(message);
+
+    if (!injectionResult.safe) {
+        return injectionResult;
+    }
+
+    const [safetyResult, relevanceResult] = await Promise.all([checkInputSafety(message), checkTopicRelevance(message)]);
+
+    if (!safetyResult.safe) {
+        return safetyResult;
+    }
+
+    if (!relevanceResult.safe) {
+        return relevanceResult;
+    }
+
+    return { safe: true };
+};

--- a/src/lib/chat/guardrails.ts
+++ b/src/lib/chat/guardrails.ts
@@ -25,6 +25,7 @@ Reply with ONLY the single word "yes" or "no".
 
 Reply "yes" if the message is about any of:
 - Fabrizio Duroni (his career, skills, projects, experience, education, personality, jokes)
+- Fabrizio's personal life (his hobbies, interests, relationship, girlfriend, partner, family, where he lives, lifestyle)
 - Software development, programming, technology, computer science
 - His blog posts, articles, or technical writing
 - General greetings, introductions, or small talk


### PR DESCRIPTION
Add three-layer input guardrail pipeline to the chatbot API to prevent misuse, prompt injection, unsafe content, and off-topic requests.

## Description
- **New file `src/lib/chat/guardrails.ts`**: three guard functions + `runGuardrails()` orchestrator
  - `checkPromptInjection()` — sync regex check for jailbreak/override patterns (~0ms, no API call)
  - `checkInputSafety()` — Llama Guard 3 8B via Groq detects hate/harm/violence/sexual content
  - `checkTopicRelevance()` — `llama-3.1-8b-instant` as a yes/no topic classifier, keeps chat scoped to Fabrizio and software dev
  - Safety + relevance run in parallel via `Promise.all`; all guards **fail open** so a Groq outage never blocks legitimate traffic
- **`src/app/api/chat/route.ts`**: extracts last user message, runs `runGuardrails()` before `streamText`, returns `400` plain-text when blocked
- **`src/components/sections/chat/components/chat.tsx`**: surfaces `error.message` in the error bubble so blocked users see the specific reason instead of a generic string

## Motivation and Context
The public chatbot had no input validation — anyone could use it as a general-purpose LLM proxy, inject instructions to override Fabrizio's persona, or send harmful content. The guardrails keep the bot on-scope and safe at minimal cost (Llama Guard and the instant model are already available on the existing Groq account, zero extra infra).

## How Has This Been Tested?
Browser

## Types of changes
- [ ] Bug fix :bug: (non-breaking change which fixes an issue)
- [x] New feature :sparkles: (non-breaking change which adds functionality)
- [ ] Breaking change :boom: (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project :beers:.
- [X] My change requires a change to the documentation :bulb: and I have updated the documentation accordingly.
- [X] I have read the [CONTRIBUTING](https://github.com/chicio/chicio-blog/blob/master/CONTRIBUTING.md) document :busts_in_silhouette:.
- [X] I have added tests to cover my changes :tada:.
- [X] All new and existing tests passed :white_check_mark:.