### PR TITLE
feat(content): :sparkles: add difficulty badges to exercise tables

### DIFF
--- a/.claude/agent-memory/dsa-senior-engineer/MEMORY.md
+++ b/.claude/agent-memory/dsa-senior-engineer/MEMORY.md
@@ -4,3 +4,4 @@
 - [Structure Patterns](structure_patterns.md) — Similarity groups between topics for reusing article layouts
 - [Component Patterns](component_patterns.md) — When and how to create interactive visualizers
 - [Writing Approach](writing_approach.md) — Established writing conventions: punctuation, prose over lists, depth, no interview framing
+- [Exercise Difficulty](feedback_exercise_difficulty.md) — Exercise MDX must include difficulty metadata (Easy/Medium/Hard)

--- a/.claude/agent-memory/dsa-senior-engineer/feedback_exercise_difficulty.md
+++ b/.claude/agent-memory/dsa-senior-engineer/feedback_exercise_difficulty.md
@@ -1,12 +1,12 @@
 ---
 name: exercise-difficulty-metadata
-description: Exercise MDX must include difficulty metadata; exercise tables use 2-column format (Exercise + Difficulty)
+description: Exercise MDX must include difficulty metadata; all exercise tables use unified 3-column ExerciseTable component
 type: feedback
 ---
 
 When generating exercise MDX files, always include `difficulty` in the metadata alongside `technique` and `leetcodeUrl`.
 
-**Why:** Both the `TopicExercises` component (end of each topic article) and the `ExercisesList` component (global exercises page) display difficulty as a color-coded badge. The difficulty field is required for this to work.
+**Why:** The shared `ExerciseTable` component displays difficulty as a color-coded badge. The difficulty field is required for this to work.
 
 **How to apply:** When creating exercise MDX files (Step 8 of the new topic flow), fetch the difficulty from LeetCode's GraphQL API and add it to the frontmatter:
 ```yaml
@@ -17,11 +17,17 @@ metadata:
 ```
 The `ExerciseMetadata` type enforces this: `difficulty: "Easy" | "Medium" | "Hard"`.
 
-## Exercise Table Format
+## Unified Exercise Table Format
 
-Both tables follow a consistent format with color-coded difficulty badges:
-- **TopicExercises** (topic article footer): 2 columns — Exercise (links to exercise page), Difficulty (color badge)
-- **ExercisesList** (global exercises page): 3 columns — Exercise (links to exercise page), Difficulty (color badge), Description
+There is a single shared `ExerciseTable` component (`exercise-table.tsx`) used everywhere exercises are listed. It renders a 3-column table:
+
+| Exercise (w-2/5) | Difficulty | Description |
+|---|---|---|
+| Link to exercise page (bold title) | Color-coded badge | Markdown-rendered description from frontmatter |
+
+This component is used by:
+- **`TopicExercises`** — renders exercises at the end of each topic article (`<TopicExercises topic="..." />`)
+- **`ExercisesList`** — renders all exercises grouped by topic on the global exercises page
 
 Difficulty colors are defined in `difficulty-color.ts`:
 - Easy → green (`text-green-500`)

--- a/.claude/agent-memory/dsa-senior-engineer/feedback_exercise_difficulty.md
+++ b/.claude/agent-memory/dsa-senior-engineer/feedback_exercise_difficulty.md
@@ -1,12 +1,12 @@
 ---
 name: exercise-difficulty-metadata
-description: Exercise MDX files must include difficulty (Easy/Medium/Hard) in frontmatter metadata
+description: Exercise MDX must include difficulty metadata; exercise tables use 2-column format (Exercise + Difficulty)
 type: feedback
 ---
 
 When generating exercise MDX files, always include `difficulty` in the metadata alongside `technique` and `leetcodeUrl`.
 
-**Why:** The `TopicExercises` component renders a 2-column table (Exercise name linking to the exercise page, Difficulty with color-coded badge). The difficulty field is required for this to work.
+**Why:** Both the `TopicExercises` component (end of each topic article) and the `ExercisesList` component (global exercises page) display difficulty as a color-coded badge. The difficulty field is required for this to work.
 
 **How to apply:** When creating exercise MDX files (Step 8 of the new topic flow), fetch the difficulty from LeetCode's GraphQL API and add it to the frontmatter:
 ```yaml
@@ -16,3 +16,14 @@ metadata:
   difficulty: "Easy" | "Medium" | "Hard"
 ```
 The `ExerciseMetadata` type enforces this: `difficulty: "Easy" | "Medium" | "Hard"`.
+
+## Exercise Table Format
+
+Both tables follow a consistent format with color-coded difficulty badges:
+- **TopicExercises** (topic article footer): 2 columns — Exercise (links to exercise page), Difficulty (color badge)
+- **ExercisesList** (global exercises page): 3 columns — Exercise (links to exercise page), Difficulty (color badge), Description
+
+Difficulty colors are defined in `difficulty-color.ts`:
+- Easy → green (`text-green-500`)
+- Medium → amber (`text-amber-500`)
+- Hard → red (`text-red-500`)

--- a/.claude/agent-memory/dsa-senior-engineer/feedback_exercise_difficulty.md
+++ b/.claude/agent-memory/dsa-senior-engineer/feedback_exercise_difficulty.md
@@ -1,0 +1,18 @@
+---
+name: exercise-difficulty-metadata
+description: Exercise MDX files must include difficulty (Easy/Medium/Hard) in frontmatter metadata
+type: feedback
+---
+
+When generating exercise MDX files, always include `difficulty` in the metadata alongside `technique` and `leetcodeUrl`.
+
+**Why:** The `TopicExercises` component renders a 2-column table (Exercise name linking to the exercise page, Difficulty with color-coded badge). The difficulty field is required for this to work.
+
+**How to apply:** When creating exercise MDX files (Step 8 of the new topic flow), fetch the difficulty from LeetCode's GraphQL API and add it to the frontmatter:
+```yaml
+metadata:
+  technique: "..."
+  leetcodeUrl: "https://leetcode.com/problems/.../"
+  difficulty: "Easy" | "Medium" | "Hard"
+```
+The `ExerciseMetadata` type enforces this: `difficulty: "Easy" | "Medium" | "Hard"`.

--- a/src/components/sections/data-structures-and-algorithms/components/difficulty-color.ts
+++ b/src/components/sections/data-structures-and-algorithms/components/difficulty-color.ts
@@ -1,0 +1,7 @@
+import { ExerciseMetadata } from "@/types/content/data-structures-and-algorithms";
+
+export const difficultyColor: Record<ExerciseMetadata["difficulty"], string> = {
+    Easy: "text-green-500",
+    Medium: "text-amber-500",
+    Hard: "text-red-500",
+};

--- a/src/components/sections/data-structures-and-algorithms/components/exercise-table.tsx
+++ b/src/components/sections/data-structures-and-algorithms/components/exercise-table.tsx
@@ -1,0 +1,43 @@
+import { Content } from "@/types/content/content";
+import { ExerciseMetadata } from "@/types/content/data-structures-and-algorithms";
+import { FC } from "react";
+import { Markdown } from "../../../design-system/atoms/typography/markdown";
+import { difficultyColor } from "./difficulty-color";
+
+interface ExerciseTableProps {
+    exercises: Content<ExerciseMetadata>[];
+    markdownId: string;
+}
+
+export const ExerciseTable: FC<ExerciseTableProps> = ({ exercises, markdownId }) => (
+    <div className="table-wrapper">
+        <table>
+            <thead>
+                <tr>
+                    <th className="w-2/5">Exercise</th>
+                    <th>Difficulty</th>
+                    <th>Description</th>
+                </tr>
+            </thead>
+            <tbody>
+                {exercises.map((exercise) => (
+                    <tr key={exercise.slug.formatted}>
+                        <td className="w-2/5">
+                            <a href={exercise.slug.formatted}>
+                                <strong>{exercise.frontmatter.title}</strong>
+                            </a>
+                        </td>
+                        <td>
+                            <span className={`font-semibold ${difficultyColor[exercise.frontmatter.metadata?.difficulty ?? "Easy"]}`}>
+                                {exercise.frontmatter.metadata?.difficulty}
+                            </span>
+                        </td>
+                        <td>
+                            <Markdown content={exercise.frontmatter.description} id={`${markdownId}-description`} />
+                        </td>
+                    </tr>
+                ))}
+            </tbody>
+        </table>
+    </div>
+);

--- a/src/components/sections/data-structures-and-algorithms/components/exercises-list.tsx
+++ b/src/components/sections/data-structures-and-algorithms/components/exercises-list.tsx
@@ -5,8 +5,7 @@ import {
 import { Content } from "@/types/content/content";
 import { ExerciseMetadata } from "@/types/content/data-structures-and-algorithms";
 import { FC } from "react";
-import { Markdown } from "../../../design-system/atoms/typography/markdown";
-import { difficultyColor } from "./difficulty-color";
+import { ExerciseTable } from "./exercise-table";
 
 export const ExercisesList: FC = () => {
   const exercises = getAllExercises();
@@ -32,36 +31,7 @@ export const ExercisesList: FC = () => {
         return (
           <div key={topicKey}>
             <h2>{topic.frontmatter.title}</h2>
-            <div className="table-wrapper">
-              <table>
-                <thead>
-                  <tr>
-                    <th className="w-2/5">Exercise</th>
-                    <th>Difficulty</th>
-                    <th>Description</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {topicExercises.map((exercise) => (
-                    <tr key={exercise.slug.formatted}>
-                      <td className="w-2/5">
-                        <a href={exercise.slug.formatted}>
-                          <strong>{exercise.frontmatter.title}</strong>
-                        </a>
-                      </td>
-                      <td>
-                        <span className={`font-semibold ${difficultyColor[exercise.frontmatter.metadata?.difficulty ?? "Easy"]}`}>
-                          {exercise.frontmatter.metadata?.difficulty}
-                        </span>
-                      </td>
-                      <td>
-                        <Markdown content={exercise.frontmatter.description} id={`${topicKey}-description`} />
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
+            <ExerciseTable exercises={topicExercises} markdownId={topicKey} />
           </div>
         );
       })}

--- a/src/components/sections/data-structures-and-algorithms/components/exercises-list.tsx
+++ b/src/components/sections/data-structures-and-algorithms/components/exercises-list.tsx
@@ -3,8 +3,10 @@ import {
   getAllExercises,
 } from "@/lib/content/data-structures-and-algorithms";
 import { Content } from "@/types/content/content";
+import { ExerciseMetadata } from "@/types/content/data-structures-and-algorithms";
 import { FC } from "react";
 import { Markdown } from "../../../design-system/atoms/typography/markdown";
+import { difficultyColor } from "./difficulty-color";
 
 export const ExercisesList: FC = () => {
   const exercises = getAllExercises();
@@ -17,7 +19,7 @@ export const ExercisesList: FC = () => {
       acc[topicKey].push(exercise);
       return acc;
     },
-    {} as Record<string, Content[]>,
+    {} as Record<string, Content<ExerciseMetadata>[]>,
   );
 
   return (
@@ -35,6 +37,7 @@ export const ExercisesList: FC = () => {
                 <thead>
                   <tr>
                     <th className="w-2/5">Exercise</th>
+                    <th>Difficulty</th>
                     <th>Description</th>
                   </tr>
                 </thead>
@@ -45,6 +48,11 @@ export const ExercisesList: FC = () => {
                         <a href={exercise.slug.formatted}>
                           <strong>{exercise.frontmatter.title}</strong>
                         </a>
+                      </td>
+                      <td>
+                        <span className={`font-semibold ${difficultyColor[exercise.frontmatter.metadata?.difficulty ?? "Easy"]}`}>
+                          {exercise.frontmatter.metadata?.difficulty}
+                        </span>
                       </td>
                       <td>
                         <Markdown content={exercise.frontmatter.description} id={`${topicKey}-description`} />

--- a/src/components/sections/data-structures-and-algorithms/components/topic-exercises.tsx
+++ b/src/components/sections/data-structures-and-algorithms/components/topic-exercises.tsx
@@ -1,9 +1,16 @@
 import { getAllExercisesForTopic } from "@/lib/content/data-structures-and-algorithms";
+import { ExerciseMetadata } from "@/types/content/data-structures-and-algorithms";
 import { FC } from "react";
 
 interface TopicExercisesProps {
     topic: string;
 }
+
+const difficultyColor: Record<ExerciseMetadata["difficulty"], string> = {
+    Easy: "text-green-500",
+    Medium: "text-amber-500",
+    Hard: "text-red-500",
+};
 
 export const TopicExercises: FC<TopicExercisesProps> = ({ topic }) => {
     const exercises = getAllExercisesForTopic(topic);
@@ -16,21 +23,21 @@ export const TopicExercises: FC<TopicExercisesProps> = ({ topic }) => {
                 <thead>
                     <tr>
                         <th>Exercise</th>
-                        <th>Technique</th>
-                        <th>Solution</th>
+                        <th>Difficulty</th>
                     </tr>
                 </thead>
                 <tbody>
                     {exercises.map((exercise) => (
                         <tr key={exercise.slug.formatted}>
                             <td>
-                                <a href={exercise.frontmatter.metadata?.leetcodeUrl} target="_blank" rel="noopener noreferrer">
+                                <a href={exercise.slug.formatted}>
                                     {exercise.frontmatter.title}
                                 </a>
                             </td>
-                            <td>{exercise.frontmatter.metadata?.technique}</td>
                             <td>
-                                <a href={exercise.slug.formatted}>Solution</a>
+                                <span className={`font-semibold ${difficultyColor[exercise.frontmatter.metadata?.difficulty ?? "Easy"]}`}>
+                                    {exercise.frontmatter.metadata?.difficulty}
+                                </span>
                             </td>
                         </tr>
                     ))}

--- a/src/components/sections/data-structures-and-algorithms/components/topic-exercises.tsx
+++ b/src/components/sections/data-structures-and-algorithms/components/topic-exercises.tsx
@@ -1,6 +1,6 @@
 import { getAllExercisesForTopic } from "@/lib/content/data-structures-and-algorithms";
 import { FC } from "react";
-import { difficultyColor } from "./difficulty-color";
+import { ExerciseTable } from "./exercise-table";
 
 interface TopicExercisesProps {
     topic: string;
@@ -11,32 +11,5 @@ export const TopicExercises: FC<TopicExercisesProps> = ({ topic }) => {
 
     if (exercises.length === 0) return null;
 
-    return (
-        <div className="table-wrapper">
-            <table>
-                <thead>
-                    <tr>
-                        <th>Exercise</th>
-                        <th>Difficulty</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    {exercises.map((exercise) => (
-                        <tr key={exercise.slug.formatted}>
-                            <td>
-                                <a href={exercise.slug.formatted}>
-                                    {exercise.frontmatter.title}
-                                </a>
-                            </td>
-                            <td>
-                                <span className={`font-semibold ${difficultyColor[exercise.frontmatter.metadata?.difficulty ?? "Easy"]}`}>
-                                    {exercise.frontmatter.metadata?.difficulty}
-                                </span>
-                            </td>
-                        </tr>
-                    ))}
-                </tbody>
-            </table>
-        </div>
-    );
+    return <ExerciseTable exercises={exercises} markdownId={topic} />;
 };

--- a/src/components/sections/data-structures-and-algorithms/components/topic-exercises.tsx
+++ b/src/components/sections/data-structures-and-algorithms/components/topic-exercises.tsx
@@ -1,16 +1,10 @@
 import { getAllExercisesForTopic } from "@/lib/content/data-structures-and-algorithms";
-import { ExerciseMetadata } from "@/types/content/data-structures-and-algorithms";
 import { FC } from "react";
+import { difficultyColor } from "./difficulty-color";
 
 interface TopicExercisesProps {
     topic: string;
 }
-
-const difficultyColor: Record<ExerciseMetadata["difficulty"], string> = {
-    Easy: "text-green-500",
-    Medium: "text-amber-500",
-    Hard: "text-red-500",
-};
 
 export const TopicExercises: FC<TopicExercisesProps> = ({ topic }) => {
     const exercises = getAllExercisesForTopic(topic);

--- a/src/content/data-structures-and-algorithms/topic/array/exercise/best-time-to-buy-and-sell-stock-ii/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/array/exercise/best-time-to-buy-and-sell-stock-ii/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Greedy / Sliding Window"
   leetcodeUrl: "https://leetcode.com/problems/best-time-to-buy-and-sell-stock-ii/"
+  difficulty: "Medium"
 ---
 # Best Time to Buy and Sell Stock II
 

--- a/src/content/data-structures-and-algorithms/topic/array/exercise/best-time-to-buy-and-sell-stock/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/array/exercise/best-time-to-buy-and-sell-stock/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Sliding Window"
   leetcodeUrl: "https://leetcode.com/problems/best-time-to-buy-and-sell-stock/"
+  difficulty: "Easy"
 ---
 # Best Time to Buy and Sell Stock
 

--- a/src/content/data-structures-and-algorithms/topic/array/exercise/first-missing-positive/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/array/exercise/first-missing-positive/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Index Mapping / In-Place Hashing"
   leetcodeUrl: "https://leetcode.com/problems/first-missing-positive/"
+  difficulty: "Hard"
 ---
 # First Missing Positive
 

--- a/src/content/data-structures-and-algorithms/topic/array/exercise/increasing-triplet-subsequence/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/array/exercise/increasing-triplet-subsequence/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Greedy"
   leetcodeUrl: "https://leetcode.com/problems/increasing-triplet-subsequence/"
+  difficulty: "Medium"
 ---
 # Increasing Triplet Subsequence
 

--- a/src/content/data-structures-and-algorithms/topic/array/exercise/majority-element/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/array/exercise/majority-element/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Hashing / Boyer-Moore Voting"
   leetcodeUrl: "https://leetcode.com/problems/majority-element/"
+  difficulty: "Easy"
 ---
 # Majority Element
 

--- a/src/content/data-structures-and-algorithms/topic/array/exercise/move-zeros/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/array/exercise/move-zeros/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Two Pointers"
   leetcodeUrl: "https://leetcode.com/problems/move-zeroes/"
+  difficulty: "Easy"
 ---
 # Move Zeroes
 

--- a/src/content/data-structures-and-algorithms/topic/array/exercise/number-of-zero-filled-subarrays/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/array/exercise/number-of-zero-filled-subarrays/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Counting"
   leetcodeUrl: "https://leetcode.com/problems/number-of-zero-filled-subarrays/"
+  difficulty: "Medium"
 ---
 # Number of Zero-Filled Subarrays
 

--- a/src/content/data-structures-and-algorithms/topic/array/exercise/product-of-array-except-self/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/array/exercise/product-of-array-except-self/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Prefix Product"
   leetcodeUrl: "https://leetcode.com/problems/product-of-array-except-self/"
+  difficulty: "Medium"
 ---
 # Product of Array Except Self
 

--- a/src/content/data-structures-and-algorithms/topic/array/exercise/remove-duplicates-from-sorted-array/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/array/exercise/remove-duplicates-from-sorted-array/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Two Pointers"
   leetcodeUrl: "https://leetcode.com/problems/remove-duplicates-from-sorted-array/"
+  difficulty: "Easy"
 ---
 # Remove Duplicates from Sorted Array
 

--- a/src/content/data-structures-and-algorithms/topic/array/exercise/rotate-array/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/array/exercise/rotate-array/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Array Rotation"
   leetcodeUrl: "https://leetcode.com/problems/rotate-array/"
+  difficulty: "Medium"
 ---
 # Rotate Array
 

--- a/src/content/data-structures-and-algorithms/topic/backtracking/exercise/combination-sum-II/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/backtracking/exercise/combination-sum-II/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Backtracking"
   leetcodeUrl: "https://leetcode.com/problems/combination-sum-ii/"
+  difficulty: "Medium"
 ---
 # Combination Sum II
 

--- a/src/content/data-structures-and-algorithms/topic/backtracking/exercise/combination-sum/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/backtracking/exercise/combination-sum/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Backtracking"
   leetcodeUrl: "https://leetcode.com/problems/combination-sum/"
+  difficulty: "Medium"
 ---
 # Combination Sum
 

--- a/src/content/data-structures-and-algorithms/topic/backtracking/exercise/generate-parentheses/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/backtracking/exercise/generate-parentheses/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Backtracking"
   leetcodeUrl: "https://leetcode.com/problems/generate-parentheses/"
+  difficulty: "Medium"
 ---
 # Generate Parentheses
 

--- a/src/content/data-structures-and-algorithms/topic/backtracking/exercise/letter-combinations-of-a-phone-number/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/backtracking/exercise/letter-combinations-of-a-phone-number/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Backtracking"
   leetcodeUrl: "https://leetcode.com/problems/letter-combinations-of-a-phone-number/"
+  difficulty: "Medium"
 ---
 # Letter Combinations of a Phone Number
 

--- a/src/content/data-structures-and-algorithms/topic/backtracking/exercise/n-queens/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/backtracking/exercise/n-queens/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Backtracking"
   leetcodeUrl: "https://leetcode.com/problems/n-queens/"
+  difficulty: "Hard"
 ---
 # N-Queens
 

--- a/src/content/data-structures-and-algorithms/topic/backtracking/exercise/palindrome-partitioning/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/backtracking/exercise/palindrome-partitioning/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Backtracking"
   leetcodeUrl: "https://leetcode.com/problems/palindrome-partitioning/"
+  difficulty: "Medium"
 ---
 # Palindrome Partitioning
 

--- a/src/content/data-structures-and-algorithms/topic/backtracking/exercise/permutations/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/backtracking/exercise/permutations/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Backtracking"
   leetcodeUrl: "https://leetcode.com/problems/permutations/"
+  difficulty: "Medium"
 ---
 # Permutations
 

--- a/src/content/data-structures-and-algorithms/topic/backtracking/exercise/subsets/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/backtracking/exercise/subsets/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Backtracking"
   leetcodeUrl: "https://leetcode.com/problems/subsets/"
+  difficulty: "Medium"
 ---
 # Subsets
 

--- a/src/content/data-structures-and-algorithms/topic/binary-search-tree/exercise/calendar-1/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/binary-search-tree/exercise/calendar-1/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Ordered Set / BST"
   leetcodeUrl: "https://leetcode.com/problems/my-calendar-i/"
+  difficulty: "Medium"
 ---
 # My Calendar I
 

--- a/src/content/data-structures-and-algorithms/topic/binary-search-tree/exercise/calendar-2/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/binary-search-tree/exercise/calendar-2/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Ordered Set / BST"
   leetcodeUrl: "https://leetcode.com/problems/my-calendar-ii/"
+  difficulty: "Medium"
 ---
 # My Calendar II
 

--- a/src/content/data-structures-and-algorithms/topic/binary-search-tree/exercise/stock-price-fluctuation/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/binary-search-tree/exercise/stock-price-fluctuation/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "BST / Map"
   leetcodeUrl: "https://leetcode.com/problems/stock-price-fluctuation/"
+  difficulty: "Medium"
 ---
 # Stock Price Fluctuation
 

--- a/src/content/data-structures-and-algorithms/topic/binary-search-tree/exercise/trim-a-binary-search-tree/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/binary-search-tree/exercise/trim-a-binary-search-tree/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "BST"
   leetcodeUrl: "https://leetcode.com/problems/trim-a-binary-search-tree/"
+  difficulty: "Medium"
 ---
 # Trim a Binary Search Tree
 

--- a/src/content/data-structures-and-algorithms/topic/binary-search/exercise/find-first-and-last-position-of-element-in-sorted-array/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/binary-search/exercise/find-first-and-last-position-of-element-in-sorted-array/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Binary Search"
   leetcodeUrl: "https://leetcode.com/problems/find-first-and-last-position-of-element-in-sorted-array/"
+  difficulty: "Medium"
 ---
 # Find First and Last Position of Element in Sorted Array
 

--- a/src/content/data-structures-and-algorithms/topic/binary-search/exercise/find-in-mountain-array/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/binary-search/exercise/find-in-mountain-array/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Binary Search"
   leetcodeUrl: "https://leetcode.com/problems/find-in-mountain-array/"
+  difficulty: "Hard"
 ---
 # Find in Mountain Array
 

--- a/src/content/data-structures-and-algorithms/topic/binary-search/exercise/find-minimum-in-rotated-sorted-array/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/binary-search/exercise/find-minimum-in-rotated-sorted-array/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Binary Search"
   leetcodeUrl: "https://leetcode.com/problems/find-minimum-in-rotated-sorted-array/"
+  difficulty: "Medium"
 ---
 # Find Minimum in Rotated Sorted Array
 

--- a/src/content/data-structures-and-algorithms/topic/binary-search/exercise/find-peak-element/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/binary-search/exercise/find-peak-element/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Binary Search"
   leetcodeUrl: "https://leetcode.com/problems/find-peak-element/"
+  difficulty: "Medium"
 ---
 # Find Peak Element
 

--- a/src/content/data-structures-and-algorithms/topic/binary-search/exercise/koko-eating-bananas/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/binary-search/exercise/koko-eating-bananas/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Binary Search on Answer"
   leetcodeUrl: "https://leetcode.com/problems/koko-eating-bananas/"
+  difficulty: "Medium"
 ---
 # Koko Eating Bananas
 

--- a/src/content/data-structures-and-algorithms/topic/binary-search/exercise/median-of-two-sorted-arrays/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/binary-search/exercise/median-of-two-sorted-arrays/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Binary Search"
   leetcodeUrl: "https://leetcode.com/problems/median-of-two-sorted-arrays/"
+  difficulty: "Hard"
 ---
 # Median of Two Sorted Arrays
 

--- a/src/content/data-structures-and-algorithms/topic/binary-search/exercise/random-pick-with-weight/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/binary-search/exercise/random-pick-with-weight/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Binary Search"
   leetcodeUrl: "https://leetcode.com/problems/random-pick-with-weight/"
+  difficulty: "Medium"
 ---
 # Random Pick with Weight
 

--- a/src/content/data-structures-and-algorithms/topic/binary-search/exercise/search-a-2D-matrix/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/binary-search/exercise/search-a-2D-matrix/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Binary Search"
   leetcodeUrl: "https://leetcode.com/problems/search-a-2d-matrix/"
+  difficulty: "Medium"
 ---
 # Search a 2D Matrix
 

--- a/src/content/data-structures-and-algorithms/topic/binary-search/exercise/search-in-rotated-sorted-array/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/binary-search/exercise/search-in-rotated-sorted-array/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Binary Search"
   leetcodeUrl: "https://leetcode.com/problems/search-in-rotated-sorted-array/"
+  difficulty: "Medium"
 ---
 # Search in Rotated Sorted Array
 

--- a/src/content/data-structures-and-algorithms/topic/binary-search/exercise/search-insert-position/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/binary-search/exercise/search-insert-position/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Binary Search"
   leetcodeUrl: "https://leetcode.com/problems/search-insert-position/"
+  difficulty: "Easy"
 ---
 # Search Insert Position
 

--- a/src/content/data-structures-and-algorithms/topic/bit-manipulation/exercise/bitwise-and-of-numbers-range/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/bit-manipulation/exercise/bitwise-and-of-numbers-range/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Common Prefix Masking"
   leetcodeUrl: "https://leetcode.com/problems/bitwise-and-of-numbers-range/"
+  difficulty: "Medium"
 ---
 # Bitwise AND of Numbers Range
 

--- a/src/content/data-structures-and-algorithms/topic/bit-manipulation/exercise/counting-bits/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/bit-manipulation/exercise/counting-bits/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "DP + Bit Count Relation"
   leetcodeUrl: "https://leetcode.com/problems/counting-bits/"
+  difficulty: "Easy"
 ---
 # Counting Bits
 

--- a/src/content/data-structures-and-algorithms/topic/bit-manipulation/exercise/number-of-1-bits/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/bit-manipulation/exercise/number-of-1-bits/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "n & (n - 1) Trick"
   leetcodeUrl: "https://leetcode.com/problems/number-of-1-bits/"
+  difficulty: "Easy"
 ---
 # Number of 1 Bits
 

--- a/src/content/data-structures-and-algorithms/topic/bit-manipulation/exercise/reverse-bits/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/bit-manipulation/exercise/reverse-bits/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Bitwise Reversal"
   leetcodeUrl: "https://leetcode.com/problems/reverse-bits/"
+  difficulty: "Easy"
 ---
 # Reverse Bits
 

--- a/src/content/data-structures-and-algorithms/topic/bit-manipulation/exercise/single-number-III/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/bit-manipulation/exercise/single-number-III/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "XOR + Mask Partition"
   leetcodeUrl: "https://leetcode.com/problems/single-number-iii/"
+  difficulty: "Medium"
 ---
 # Single Number III
 

--- a/src/content/data-structures-and-algorithms/topic/bit-manipulation/exercise/single-number/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/bit-manipulation/exercise/single-number/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "XOR Property"
   leetcodeUrl: "https://leetcode.com/problems/single-number/"
+  difficulty: "Easy"
 ---
 # Single Number
 

--- a/src/content/data-structures-and-algorithms/topic/bit-manipulation/exercise/sum-of-two-integers/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/bit-manipulation/exercise/sum-of-two-integers/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "XOR + Carry"
   leetcodeUrl: "https://leetcode.com/problems/sum-of-two-integers/"
+  difficulty: "Medium"
 ---
 # Sum of Two Integers
 

--- a/src/content/data-structures-and-algorithms/topic/bucket-sort/exercise/maximum-gap/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/bucket-sort/exercise/maximum-gap/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Bucket Sort"
   leetcodeUrl: "https://leetcode.com/problems/maximum-gap/"
+  difficulty: "Medium"
 ---
 # Maximum Gap
 

--- a/src/content/data-structures-and-algorithms/topic/bucket-sort/exercise/sort-characters-by-frequency/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/bucket-sort/exercise/sort-characters-by-frequency/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Bucket Sort"
   leetcodeUrl: "https://leetcode.com/problems/sort-characters-by-frequency/"
+  difficulty: "Medium"
 ---
 # Sort Characters By Frequency
 

--- a/src/content/data-structures-and-algorithms/topic/bucket-sort/exercise/top-k-frequent-words/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/bucket-sort/exercise/top-k-frequent-words/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Bucket Sort"
   leetcodeUrl: "https://leetcode.com/problems/top-k-frequent-words/"
+  difficulty: "Medium"
 ---
 # Top K Frequent Words
 

--- a/src/content/data-structures-and-algorithms/topic/data-structure-design/exercise/design-a-food-rating-system/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/data-structure-design/exercise/design-a-food-rating-system/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "HashMap + Heap (Lazy Deletion)"
   leetcodeUrl: "https://leetcode.com/problems/design-a-food-rating-system/"
+  difficulty: "Medium"
 ---
 # Design a Food Rating System
 

--- a/src/content/data-structures-and-algorithms/topic/data-structure-design/exercise/design-browser-history/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/data-structure-design/exercise/design-browser-history/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Dual Stack Navigation"
   leetcodeUrl: "https://leetcode.com/problems/design-browser-history/"
+  difficulty: "Medium"
 ---
 # Design Browser History
 

--- a/src/content/data-structures-and-algorithms/topic/data-structure-design/exercise/design-twitter/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/data-structure-design/exercise/design-twitter/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "HashMap + Heap (Multi-Entity Aggregation)"
   leetcodeUrl: "https://leetcode.com/problems/design-twitter/"
+  difficulty: "Medium"
 ---
 # Design Twitter
 

--- a/src/content/data-structures-and-algorithms/topic/data-structure-design/exercise/insert-delete-getrandom-o1/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/data-structure-design/exercise/insert-delete-getrandom-o1/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "HashMap + Dynamic Array"
   leetcodeUrl: "https://leetcode.com/problems/insert-delete-getrandom-o1/"
+  difficulty: "Medium"
 ---
 # Insert Delete GetRandom O(1)
 

--- a/src/content/data-structures-and-algorithms/topic/data-structure-design/exercise/lru-cache/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/data-structure-design/exercise/lru-cache/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "HashMap + Doubly Linked List"
   leetcodeUrl: "https://leetcode.com/problems/lru-cache/"
+  difficulty: "Medium"
 ---
 # LRU Cache
 

--- a/src/content/data-structures-and-algorithms/topic/data-structure-design/exercise/maximum-frequency-stack/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/data-structure-design/exercise/maximum-frequency-stack/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Frequency Map + Frequency-Bucketed Stacks"
   leetcodeUrl: "https://leetcode.com/problems/maximum-frequency-stack/"
+  difficulty: "Hard"
 ---
 # Maximum Frequency Stack
 

--- a/src/content/data-structures-and-algorithms/topic/data-structure-design/exercise/snapshot-array/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/data-structure-design/exercise/snapshot-array/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Versioned Storage (HashMap per Index)"
   leetcodeUrl: "https://leetcode.com/problems/snapshot-array/"
+  difficulty: "Medium"
 ---
 # Snapshot Array
 

--- a/src/content/data-structures-and-algorithms/topic/data-structure-design/exercise/time-based-key-value-store/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/data-structure-design/exercise/time-based-key-value-store/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "HashMap + Binary Search"
   leetcodeUrl: "https://leetcode.com/problems/time-based-key-value-store/"
+  difficulty: "Medium"
 ---
 # Time Based Key-Value Store
 

--- a/src/content/data-structures-and-algorithms/topic/graph/exercise/01-matrix/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/graph/exercise/01-matrix/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Multi-source BFS for distance computation"
   leetcodeUrl: "https://leetcode.com/problems/01-matrix/"
+  difficulty: "Medium"
 ---
 # 01 Matrix
 

--- a/src/content/data-structures-and-algorithms/topic/graph/exercise/all-nodes-distance-k-in-binary-tree/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/graph/exercise/all-nodes-distance-k-in-binary-tree/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "DFS parent map construction then BFS from target"
   leetcodeUrl: "https://leetcode.com/problems/all-nodes-distance-k-in-binary-tree/"
+  difficulty: "Medium"
 ---
 # All Nodes Distance K in Binary Tree
 

--- a/src/content/data-structures-and-algorithms/topic/graph/exercise/all-paths-from-source-to-target/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/graph/exercise/all-paths-from-source-to-target/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "DFS path enumeration on DAG"
   leetcodeUrl: "https://leetcode.com/problems/all-paths-from-source-to-target/"
+  difficulty: "Medium"
 ---
 # All Paths From Source to Target
 

--- a/src/content/data-structures-and-algorithms/topic/graph/exercise/bus-routes/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/graph/exercise/bus-routes/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "BFS on route-level graph with stop-to-bus mapping"
   leetcodeUrl: "https://leetcode.com/problems/bus-routes/"
+  difficulty: "Hard"
 ---
 # Bus Routes
 

--- a/src/content/data-structures-and-algorithms/topic/graph/exercise/clone-graph/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/graph/exercise/clone-graph/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "DFS with visited map for graph cloning"
   leetcodeUrl: "https://leetcode.com/problems/clone-graph/"
+  difficulty: "Medium"
 ---
 # Clone Graph
 

--- a/src/content/data-structures-and-algorithms/topic/graph/exercise/employee-importance/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/graph/exercise/employee-importance/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "DFS value propagation on tree-structured graph"
   leetcodeUrl: "https://leetcode.com/problems/employee-importance/"
+  difficulty: "Medium"
 ---
 # Employee Importance
 

--- a/src/content/data-structures-and-algorithms/topic/graph/exercise/is-graph-bipartite/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/graph/exercise/is-graph-bipartite/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "DFS two-coloring for bipartiteness"
   leetcodeUrl: "https://leetcode.com/problems/is-graph-bipartite/"
+  difficulty: "Medium"
 ---
 # Is Graph Bipartite?
 

--- a/src/content/data-structures-and-algorithms/topic/graph/exercise/making-a-large-island/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/graph/exercise/making-a-large-island/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "DFS island labeling with component merging"
   leetcodeUrl: "https://leetcode.com/problems/making-a-large-island/"
+  difficulty: "Hard"
 ---
 # Making A Large Island
 

--- a/src/content/data-structures-and-algorithms/topic/graph/exercise/number-of-islands/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/graph/exercise/number-of-islands/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "DFS flood fill on implicit grid graph"
   leetcodeUrl: "https://leetcode.com/problems/number-of-islands/"
+  difficulty: "Medium"
 ---
 # Number of Islands
 

--- a/src/content/data-structures-and-algorithms/topic/graph/exercise/open-the-lock/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/graph/exercise/open-the-lock/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "BFS on implicit state-space graph"
   leetcodeUrl: "https://leetcode.com/problems/open-the-lock/"
+  difficulty: "Medium"
 ---
 # Open the Lock
 

--- a/src/content/data-structures-and-algorithms/topic/graph/exercise/pacific-atlantic-water-flow/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/graph/exercise/pacific-atlantic-water-flow/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "DFS reverse flow from ocean boundaries"
   leetcodeUrl: "https://leetcode.com/problems/pacific-atlantic-water-flow/"
+  difficulty: "Medium"
 ---
 # Pacific Atlantic Water Flow
 

--- a/src/content/data-structures-and-algorithms/topic/graph/exercise/rotting-oranges/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/graph/exercise/rotting-oranges/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Multi-source BFS simulation"
   leetcodeUrl: "https://leetcode.com/problems/rotting-oranges/"
+  difficulty: "Medium"
 ---
 # Rotting Oranges
 

--- a/src/content/data-structures-and-algorithms/topic/graph/exercise/shortest-path-in-a-grid-with-obstacles-elimination/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/graph/exercise/shortest-path-in-a-grid-with-obstacles-elimination/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "BFS with extended state (position + remaining eliminations)"
   leetcodeUrl: "https://leetcode.com/problems/shortest-path-in-a-grid-with-obstacles-elimination/"
+  difficulty: "Hard"
 ---
 # Shortest Path in a Grid with Obstacles Elimination
 

--- a/src/content/data-structures-and-algorithms/topic/graph/exercise/surrounded-regions/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/graph/exercise/surrounded-regions/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "DFS boundary flood fill"
   leetcodeUrl: "https://leetcode.com/problems/surrounded-regions/"
+  difficulty: "Medium"
 ---
 # Surrounded Regions
 

--- a/src/content/data-structures-and-algorithms/topic/graph/exercise/time-needed-to-inform-all-employees/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/graph/exercise/time-needed-to-inform-all-employees/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "DFS with time propagation on tree graph"
   leetcodeUrl: "https://leetcode.com/problems/time-needed-to-inform-all-employees/"
+  difficulty: "Medium"
 ---
 # Time Needed to Inform All Employees
 

--- a/src/content/data-structures-and-algorithms/topic/graph/exercise/word-ladder/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/graph/exercise/word-ladder/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "BFS on implicit word-transformation graph"
   leetcodeUrl: "https://leetcode.com/problems/word-ladder/"
+  difficulty: "Hard"
 ---
 # Word Ladder
 

--- a/src/content/data-structures-and-algorithms/topic/greedy/exercise/candy/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/greedy/exercise/candy/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Multi-pass greedy with constraint reconciliation"
   leetcodeUrl: "https://leetcode.com/problems/candy/"
+  difficulty: "Hard"
 ---
 # Candy
 

--- a/src/content/data-structures-and-algorithms/topic/greedy/exercise/gas-station/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/greedy/exercise/gas-station/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Single-pass greedy with running surplus"
   leetcodeUrl: "https://leetcode.com/problems/gas-station/"
+  difficulty: "Medium"
 ---
 # Gas Station
 

--- a/src/content/data-structures-and-algorithms/topic/greedy/exercise/jump-game-ii/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/greedy/exercise/jump-game-ii/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "BFS-style greedy range expansion"
   leetcodeUrl: "https://leetcode.com/problems/jump-game-ii/"
+  difficulty: "Medium"
 ---
 # Jump Game II
 

--- a/src/content/data-structures-and-algorithms/topic/greedy/exercise/minimum-add-to-make-parentheses-valid/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/greedy/exercise/minimum-add-to-make-parentheses-valid/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Greedy balance tracking"
   leetcodeUrl: "https://leetcode.com/problems/minimum-add-to-make-parentheses-valid/"
+  difficulty: "Medium"
 ---
 # Minimum Add to Make Parentheses Valid
 

--- a/src/content/data-structures-and-algorithms/topic/greedy/exercise/minimum-cost-to-hire-k-workers/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/greedy/exercise/minimum-cost-to-hire-k-workers/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Greedy ratio sorting with max-heap pruning"
   leetcodeUrl: "https://leetcode.com/problems/minimum-cost-to-hire-k-workers/"
+  difficulty: "Hard"
 ---
 # Minimum Cost to Hire K Workers
 

--- a/src/content/data-structures-and-algorithms/topic/greedy/exercise/minimum-number-of-refueling-stops/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/greedy/exercise/minimum-number-of-refueling-stops/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Greedy deferred refueling with max-heap"
   leetcodeUrl: "https://leetcode.com/problems/minimum-number-of-refueling-stops/"
+  difficulty: "Hard"
 ---
 # Minimum Number of Refueling Stops
 

--- a/src/content/data-structures-and-algorithms/topic/greedy/exercise/task-scheduler/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/greedy/exercise/task-scheduler/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Greedy frequency-based scheduling with heap and cooldown queue"
   leetcodeUrl: "https://leetcode.com/problems/task-scheduler/"
+  difficulty: "Medium"
 ---
 # Task Scheduler
 

--- a/src/content/data-structures-and-algorithms/topic/hashtable/exercise/Isomorphic-strings/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/hashtable/exercise/Isomorphic-strings/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Character Mapping"
   leetcodeUrl: ""
+  difficulty: "Easy"
 ---
 # Isomorphic Strings
 

--- a/src/content/data-structures-and-algorithms/topic/hashtable/exercise/contains-duplicate-II/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/hashtable/exercise/contains-duplicate-II/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Sliding Window + Hash Set"
   leetcodeUrl: "https://leetcode.com/problems/contains-duplicate-ii/"
+  difficulty: "Easy"
 ---
 # Contains Duplicate II
 

--- a/src/content/data-structures-and-algorithms/topic/hashtable/exercise/design-hashmap/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/hashtable/exercise/design-hashmap/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "HashMap Design"
   leetcodeUrl: ""
+  difficulty: "Easy"
 ---
 # Design HashMap
 

--- a/src/content/data-structures-and-algorithms/topic/hashtable/exercise/encode-and-decode-tinyurl/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/hashtable/exercise/encode-and-decode-tinyurl/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Hash Map / Bi-Directional Map"
   leetcodeUrl: "https://leetcode.com/problems/encode-and-decode-tinyurl/"
+  difficulty: "Medium"
 ---
 # Encode and Decode TinyURL
 

--- a/src/content/data-structures-and-algorithms/topic/hashtable/exercise/group-anagrams/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/hashtable/exercise/group-anagrams/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Hash Map with Sorted Key"
   leetcodeUrl: "https://leetcode.com/problems/group-anagrams/"
+  difficulty: "Medium"
 ---
 # Group Anagrams
 

--- a/src/content/data-structures-and-algorithms/topic/hashtable/exercise/longest-consecutive-sequence/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/hashtable/exercise/longest-consecutive-sequence/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Hash Set + Sequence Counting"
   leetcodeUrl: "https://leetcode.com/problems/longest-consecutive-sequence/"
+  difficulty: "Medium"
 ---
 # Longest Consecutive Sequence
 

--- a/src/content/data-structures-and-algorithms/topic/hashtable/exercise/maximum-number-of-balloons/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/hashtable/exercise/maximum-number-of-balloons/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Frequency Counting"
   leetcodeUrl: ""
+  difficulty: "Easy"
 ---
 # Maximum Number of Balloons
 

--- a/src/content/data-structures-and-algorithms/topic/hashtable/exercise/number-of-good-pairs/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/hashtable/exercise/number-of-good-pairs/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Hash Map Counting"
   leetcodeUrl: "https://leetcode.com/problems/number-of-good-pairs/"
+  difficulty: "Easy"
 ---
 # Number of Good Pairs
 

--- a/src/content/data-structures-and-algorithms/topic/hashtable/exercise/number-of-good-ways-to-split-a-string/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/hashtable/exercise/number-of-good-ways-to-split-a-string/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Hash Map + Prefix Counting"
   leetcodeUrl: "https://leetcode.com/problems/number-of-good-ways-to-split-a-string/"
+  difficulty: "Medium"
 ---
 # Number of Good Ways to Split a String
 

--- a/src/content/data-structures-and-algorithms/topic/hashtable/exercise/number-of-matching-subsequences/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/hashtable/exercise/number-of-matching-subsequences/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Hash Map + Buckets"
   leetcodeUrl: "https://leetcode.com/problems/number-of-matching-subsequences/"
+  difficulty: "Medium"
 ---
 # Number of Matching Subsequences
 

--- a/src/content/data-structures-and-algorithms/topic/hashtable/exercise/ransom-note/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/hashtable/exercise/ransom-note/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Hash Map Counting"
   leetcodeUrl: "https://leetcode.com/problems/ransom-note/"
+  difficulty: "Easy"
 ---
 # Ransom Note
 

--- a/src/content/data-structures-and-algorithms/topic/hashtable/exercise/reorganize-string/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/hashtable/exercise/reorganize-string/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Hash Map + Max Heap"
   leetcodeUrl: "https://leetcode.com/problems/reorganize-string/"
+  difficulty: "Medium"
 ---
 # Reorganize String
 

--- a/src/content/data-structures-and-algorithms/topic/hashtable/exercise/split-array-into-consecutive-subsequences/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/hashtable/exercise/split-array-into-consecutive-subsequences/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Hash Map + Greedy"
   leetcodeUrl: ""
+  difficulty: "Medium"
 ---
 # Split Array into Consecutive Subsequences
 

--- a/src/content/data-structures-and-algorithms/topic/heap/exercise/find-median-from-data-stream/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/heap/exercise/find-median-from-data-stream/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Two Heaps"
   leetcodeUrl: "https://leetcode.com/problems/find-median-from-data-stream/"
+  difficulty: "Hard"
 ---
 # Find Median from Data Stream
 

--- a/src/content/data-structures-and-algorithms/topic/heap/exercise/furthest-building-you-can-reach/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/heap/exercise/furthest-building-you-can-reach/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Heap"
   leetcodeUrl: "https://leetcode.com/problems/furthest-building-you-can-reach/"
+  difficulty: "Medium"
 ---
 # Furthest Building You Can Reach
 

--- a/src/content/data-structures-and-algorithms/topic/heap/exercise/ipo/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/heap/exercise/ipo/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Two Heaps"
   leetcodeUrl: "https://leetcode.com/problems/ipo/"
+  difficulty: "Hard"
 ---
 # IPO
 

--- a/src/content/data-structures-and-algorithms/topic/heap/exercise/k-closest-points-to-origin/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/heap/exercise/k-closest-points-to-origin/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Top K Elements"
   leetcodeUrl: "https://leetcode.com/problems/k-closest-points-to-origin/"
+  difficulty: "Medium"
 ---
 # K Closest Points to Origin
 

--- a/src/content/data-structures-and-algorithms/topic/heap/exercise/kth-largest-element-in-a-stream/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/heap/exercise/kth-largest-element-in-a-stream/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Top K Elements"
   leetcodeUrl: "https://leetcode.com/problems/kth-largest-element-in-a-stream/"
+  difficulty: "Easy"
 ---
 # Kth Largest Element in a Stream
 

--- a/src/content/data-structures-and-algorithms/topic/heap/exercise/process-tasks-using-servers/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/heap/exercise/process-tasks-using-servers/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Heap"
   leetcodeUrl: "https://leetcode.com/problems/process-tasks-using-servers/"
+  difficulty: "Medium"
 ---
 # Process Tasks Using Servers
 

--- a/src/content/data-structures-and-algorithms/topic/heap/exercise/single-threaded-cpu/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/heap/exercise/single-threaded-cpu/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Heap"
   leetcodeUrl: "https://leetcode.com/problems/single-threaded-cpu/"
+  difficulty: "Medium"
 ---
 # Single-Threaded CPU
 

--- a/src/content/data-structures-and-algorithms/topic/heap/exercise/sliding-window-median/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/heap/exercise/sliding-window-median/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Two Heaps"
   leetcodeUrl: "https://leetcode.com/problems/sliding-window-median/"
+  difficulty: "Hard"
 ---
 # Sliding Window Median
 

--- a/src/content/data-structures-and-algorithms/topic/heap/exercise/top-k-frequent-elements/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/heap/exercise/top-k-frequent-elements/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Top K Elements"
   leetcodeUrl: "https://leetcode.com/problems/top-k-frequent-elements/"
+  difficulty: "Medium"
 ---
 # Top K Frequent Elements
 

--- a/src/content/data-structures-and-algorithms/topic/intervals/exercise/insert-interval/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/intervals/exercise/insert-interval/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Interval Insertion"
   leetcodeUrl: "https://leetcode.com/problems/insert-interval/"
+  difficulty: "Medium"
 ---
 # Insert Interval
 

--- a/src/content/data-structures-and-algorithms/topic/intervals/exercise/maximum-number-of-events-that-can-be-attended/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/intervals/exercise/maximum-number-of-events-that-can-be-attended/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Greedy + Min-Heap"
   leetcodeUrl: "https://leetcode.com/problems/maximum-number-of-events-that-can-be-attended/"
+  difficulty: "Medium"
 ---
 # Maximum Number Of Events That Can Be Attended
 

--- a/src/content/data-structures-and-algorithms/topic/intervals/exercise/merge-intervals/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/intervals/exercise/merge-intervals/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Interval Merging"
   leetcodeUrl: "https://leetcode.com/problems/merge-intervals/"
+  difficulty: "Medium"
 ---
 # Merge Intervals
 

--- a/src/content/data-structures-and-algorithms/topic/intervals/exercise/minimum-number-of-arrows-to-burst-balloons/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/intervals/exercise/minimum-number-of-arrows-to-burst-balloons/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Greedy Interval Scheduling"
   leetcodeUrl: "https://leetcode.com/problems/minimum-number-of-arrows-to-burst-balloons/"
+  difficulty: "Medium"
 ---
 # Minimum Number of Arrows to Burst Balloons
 

--- a/src/content/data-structures-and-algorithms/topic/intervals/exercise/non-overlapping-intervals/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/intervals/exercise/non-overlapping-intervals/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Greedy Interval Scheduling"
   leetcodeUrl: ""
+  difficulty: "Medium"
 ---
 # Non Overlapping Intervals
 

--- a/src/content/data-structures-and-algorithms/topic/k-way-merge/exercise/find-k-pairs-with-smallest-sums/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/k-way-merge/exercise/find-k-pairs-with-smallest-sums/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "k-way-merge"
   leetcodeUrl: "https://leetcode.com/problems/find-k-pairs-with-smallest-sums/"
+  difficulty: "Medium"
 ---
 
 # Find K Pairs with Smallest Sums

--- a/src/content/data-structures-and-algorithms/topic/k-way-merge/exercise/kth-smallest-element-in-a-sorted-matrix/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/k-way-merge/exercise/kth-smallest-element-in-a-sorted-matrix/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "k-way-merge"
   leetcodeUrl: "https://leetcode.com/problems/kth-smallest-element-in-a-sorted-matrix/"
+  difficulty: "Medium"
 ---
 
 # Kth Smallest Element in a Sorted Matrix

--- a/src/content/data-structures-and-algorithms/topic/k-way-merge/exercise/merge-k-sorted-lists/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/k-way-merge/exercise/merge-k-sorted-lists/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "k-way-merge"
   leetcodeUrl: "https://leetcode.com/problems/merge-k-sorted-lists/"
+  difficulty: "Hard"
 ---
 # Merge k Sorted Lists
 

--- a/src/content/data-structures-and-algorithms/topic/k-way-merge/exercise/smallest-range-covering-elements-from-k-lists/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/k-way-merge/exercise/smallest-range-covering-elements-from-k-lists/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "k-way-merge"
   leetcodeUrl: "https://leetcode.com/problems/smallest-range-covering-elements-from-k-lists/"
+  difficulty: "Hard"
 ---
 # Smallest Range Covering Elements from K Lists
 

--- a/src/content/data-structures-and-algorithms/topic/kadane-algorithm/exercise/best-sightseeing-pair/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/kadane-algorithm/exercise/best-sightseeing-pair/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Kadane-style Transformation"
   leetcodeUrl: "https://leetcode.com/problems/best-sightseeing-pair/"
+  difficulty: "Medium"
 ---
 # Best Sightseeing Pair
 

--- a/src/content/data-structures-and-algorithms/topic/kadane-algorithm/exercise/max-product-subarray/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/kadane-algorithm/exercise/max-product-subarray/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Kadane-style Tracking of Max/Min"
   leetcodeUrl: "https://leetcode.com/problems/maximum-product-subarray/"
+  difficulty: "Medium"
 ---
 # Maximum Product Subarray
 

--- a/src/content/data-structures-and-algorithms/topic/kadane-algorithm/exercise/max-subarray-sum-circular/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/kadane-algorithm/exercise/max-subarray-sum-circular/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Kadane + Total Sum Trick"
   leetcodeUrl: "https://leetcode.com/problems/maximum-sum-circular-subarray/"
+  difficulty: "Medium"
 ---
 # Maximum Sum Circular Subarray
 

--- a/src/content/data-structures-and-algorithms/topic/kadane-algorithm/exercise/maximum-subarray/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/kadane-algorithm/exercise/maximum-subarray/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Kadane's Algorithm"
   leetcodeUrl: "https://leetcode.com/problems/maximum-subarray/"
+  difficulty: "Medium"
 ---
 # Maximum Subarray
 

--- a/src/content/data-structures-and-algorithms/topic/linked-list/exercise/add-two-numbers/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/linked-list/exercise/add-two-numbers/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Digit-by-Digit Addition"
   leetcodeUrl: "https://leetcode.com/problems/add-two-numbers/"
+  difficulty: "Medium"
 ---
 # Add Two Numbers
 

--- a/src/content/data-structures-and-algorithms/topic/linked-list/exercise/copy-list-with-random-pointer/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/linked-list/exercise/copy-list-with-random-pointer/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Hash Map / In-place Weaving"
   leetcodeUrl: "https://leetcode.com/problems/copy-list-with-random-pointer/"
+  difficulty: "Medium"
 ---
 # Copy List With Random Pointer
 

--- a/src/content/data-structures-and-algorithms/topic/linked-list/exercise/design-linked-list/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/linked-list/exercise/design-linked-list/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Linked List Design"
   leetcodeUrl: "https://leetcode.com/problems/design-linked-list/"
+  difficulty: "Medium"
 ---
 # Design Linked List
 

--- a/src/content/data-structures-and-algorithms/topic/linked-list/exercise/flatten-a-multilevel-doubly-linked-list/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/linked-list/exercise/flatten-a-multilevel-doubly-linked-list/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "DFS / Stack"
   leetcodeUrl: "https://leetcode.com/problems/flatten-a-multilevel-doubly-linked-list/"
+  difficulty: "Medium"
 ---
 # Flatten a Multilevel Doubly Linked List
 

--- a/src/content/data-structures-and-algorithms/topic/linked-list/exercise/intersection-of-two-linked-lists/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/linked-list/exercise/intersection-of-two-linked-lists/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Pointer Traversal"
   leetcodeUrl: "https://leetcode.com/problems/intersection-of-two-linked-lists/"
+  difficulty: "Easy"
 ---
 # Intersection of Two Linked Lists
 

--- a/src/content/data-structures-and-algorithms/topic/linked-list/exercise/partition-list/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/linked-list/exercise/partition-list/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Two Lists + Merge"
   leetcodeUrl: "https://leetcode.com/problems/partition-list/"
+  difficulty: "Medium"
 ---
 # Partition List
 

--- a/src/content/data-structures-and-algorithms/topic/linked-list/exercise/remove-duplicates-from-sorted-list-II/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/linked-list/exercise/remove-duplicates-from-sorted-list-II/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Dummy Node + Traversal"
   leetcodeUrl: "https://leetcode.com/problems/remove-duplicates-from-sorted-list-ii/"
+  difficulty: "Medium"
 ---
 # Remove Duplicates from Sorted List II
 

--- a/src/content/data-structures-and-algorithms/topic/linked-list/exercise/remove-nth-node-from-end-of-list/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/linked-list/exercise/remove-nth-node-from-end-of-list/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Two Pointers + Dummy Node"
   leetcodeUrl: "https://leetcode.com/problems/remove-nth-node-from-end-of-list/"
+  difficulty: "Medium"
 ---
 # Remove Nth Node From End of List
 

--- a/src/content/data-structures-and-algorithms/topic/linked-list/exercise/rotate-list/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/linked-list/exercise/rotate-list/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Pointer Traversal + Modulo"
   leetcodeUrl: ""
+  difficulty: "Medium"
 ---
 # Rotate List
 

--- a/src/content/data-structures-and-algorithms/topic/linked-list/exercise/swap-nodes-in-pairs/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/linked-list/exercise/swap-nodes-in-pairs/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Pointer Manipulation"
   leetcodeUrl: "https://leetcode.com/problems/swap-nodes-in-pairs/"
+  difficulty: "Medium"
 ---
 # Swap Nodes in Pairs
 

--- a/src/content/data-structures-and-algorithms/topic/matrix/exercise/game-of-life/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/matrix/exercise/game-of-life/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "In-place state encoding / simulation"
   leetcodeUrl: "https://leetcode.com/problems/game-of-life/"
+  difficulty: "Medium"
 ---
 # Game of Life
 

--- a/src/content/data-structures-and-algorithms/topic/matrix/exercise/rotateimage/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/matrix/exercise/rotateimage/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "In-place transpose + row reversal"
   leetcodeUrl: "https://leetcode.com/problems/rotate-image/"
+  difficulty: "Medium"
 ---
 # Rotate Image
 

--- a/src/content/data-structures-and-algorithms/topic/matrix/exercise/set-matrix-zeroes/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/matrix/exercise/set-matrix-zeroes/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "In-place markers (first row/column)"
   leetcodeUrl: "https://leetcode.com/problems/set-matrix-zeroes/"
+  difficulty: "Medium"
 ---
 # Set Matrix Zeroes
 

--- a/src/content/data-structures-and-algorithms/topic/matrix/exercise/spiral-matrix/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/matrix/exercise/spiral-matrix/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Directional traversal + boundary shrink"
   leetcodeUrl: "https://leetcode.com/problems/spiral-matrix/"
+  difficulty: "Medium"
 ---
 # Spiral Matrix
 

--- a/src/content/data-structures-and-algorithms/topic/matrix/exercise/valid-sudoku/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/matrix/exercise/valid-sudoku/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Constraint validation (rows, columns, boxes)"
   leetcodeUrl: "https://leetcode.com/problems/valid-sudoku/"
+  difficulty: "Medium"
 ---
 # Valid Sudoku
 

--- a/src/content/data-structures-and-algorithms/topic/merge-sort/exercise/reverse-pairs/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/merge-sort/exercise/reverse-pairs/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Merge Sort + Counting"
   leetcodeUrl: "https://leetcode.com/problems/reverse-pairs/"
+  difficulty: "Hard"
 ---
 # Reverse Pairs
 

--- a/src/content/data-structures-and-algorithms/topic/merge-sort/exercise/sort-list/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/merge-sort/exercise/sort-list/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Merge Sort on Linked List"
   leetcodeUrl: "https://leetcode.com/problems/sort-list/"
+  difficulty: "Medium"
 ---
 # Sort List
 

--- a/src/content/data-structures-and-algorithms/topic/prefix-sum/exercise/contiguous-array/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/prefix-sum/exercise/contiguous-array/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Balance Tracking + Prefix Sum"
   leetcodeUrl: "https://leetcode.com/problems/contiguous-array/"
+  difficulty: "Medium"
 ---
 # Contiguous Array
 

--- a/src/content/data-structures-and-algorithms/topic/prefix-sum/exercise/continuous-subarray-sum/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/prefix-sum/exercise/continuous-subarray-sum/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Prefix Sum + Modulo Constraints"
   leetcodeUrl: "https://leetcode.com/problems/continuous-subarray-sum/"
+  difficulty: "Medium"
 ---
 # Continuous Subarray Sum
 

--- a/src/content/data-structures-and-algorithms/topic/prefix-sum/exercise/range-sum-query-immutable/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/prefix-sum/exercise/range-sum-query-immutable/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Classic Prefix Sum"
   leetcodeUrl: ""
+  difficulty: "Easy"
 ---
 # Range Sum Query - Immutable
 

--- a/src/content/data-structures-and-algorithms/topic/prefix-sum/exercise/subarray-sum-equals-k/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/prefix-sum/exercise/subarray-sum-equals-k/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Prefix Sum + Hash Map"
   leetcodeUrl: "https://leetcode.com/problems/subarray-sum-equals-k/"
+  difficulty: "Medium"
 ---
 # Subarray Sum Equals K
 

--- a/src/content/data-structures-and-algorithms/topic/prefix-sum/exercise/subarray-sums-divisible-by-k/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/prefix-sum/exercise/subarray-sums-divisible-by-k/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Prefix Sum + Modulo Buckets"
   leetcodeUrl: "https://leetcode.com/problems/subarray-sums-divisible-by-k/"
+  difficulty: "Medium"
 ---
 # Subarray Sums Divisible by K
 

--- a/src/content/data-structures-and-algorithms/topic/queue/exercise/number-of-recent-calls/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/queue/exercise/number-of-recent-calls/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Queue"
   leetcodeUrl: "https://leetcode.com/problems/number-of-recent-calls/"
+  difficulty: "Easy"
 ---
 # Number of Recent Calls
 

--- a/src/content/data-structures-and-algorithms/topic/queue/exercise/reveal-cards-in-increasing-order/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/queue/exercise/reveal-cards-in-increasing-order/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Queue"
   leetcodeUrl: "https://leetcode.com/problems/reveal-cards-in-increasing-order/"
+  difficulty: "Medium"
 ---
 # Reveal Cards In Increasing Order
 

--- a/src/content/data-structures-and-algorithms/topic/queue/exercise/time-needed-to-buy-tickets/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/queue/exercise/time-needed-to-buy-tickets/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Queue"
   leetcodeUrl: "https://leetcode.com/problems/time-needed-to-buy-tickets/"
+  difficulty: "Easy"
 ---
 # Time Needed To Buy Tickets
 

--- a/src/content/data-structures-and-algorithms/topic/quicksort/exercise/kth-largest-element-in-an-array/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/quicksort/exercise/kth-largest-element-in-an-array/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Quick Select"
   leetcodeUrl: "https://leetcode.com/problems/kth-largest-element-in-an-array/"
+  difficulty: "Medium"
 ---
 # Kth Largest Element in an Array
 

--- a/src/content/data-structures-and-algorithms/topic/quicksort/exercise/sort-colors/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/quicksort/exercise/sort-colors/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Quick Sort / Partitioning"
   leetcodeUrl: "https://leetcode.com/problems/sort-colors/"
+  difficulty: "Medium"
 ---
 # Sort Colors
 

--- a/src/content/data-structures-and-algorithms/topic/recursion/exercise/decode-string/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/recursion/exercise/decode-string/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Recursive Descent / Nested Parsing"
   leetcodeUrl: "https://leetcode.com/problems/decode-string/"
+  difficulty: "Medium"
 ---
 # Decode String
 

--- a/src/content/data-structures-and-algorithms/topic/recursion/exercise/merge-two-sorted-lists/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/recursion/exercise/merge-two-sorted-lists/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Structural Recursion on Linked Lists"
   leetcodeUrl: "https://leetcode.com/problems/merge-two-sorted-lists/"
+  difficulty: "Easy"
 ---
 # Merge Two Sorted Lists
 

--- a/src/content/data-structures-and-algorithms/topic/recursion/exercise/pow-x-n/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/recursion/exercise/pow-x-n/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Recursive Exponentiation"
   leetcodeUrl: "https://leetcode.com/problems/powx-n/"
+  difficulty: "Medium"
 ---
 # Pow(x, n)
 

--- a/src/content/data-structures-and-algorithms/topic/sliding-window/exercise/find-all-anagrams-in-a-string/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/sliding-window/exercise/find-all-anagrams-in-a-string/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Fixed Sliding Window"
   leetcodeUrl: "https://leetcode.com/problems/find-all-anagrams-in-a-string/"
+  difficulty: "Medium"
 ---
 # Find All Anagrams In A String
 

--- a/src/content/data-structures-and-algorithms/topic/sliding-window/exercise/longest-repeating-character-replacement/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/sliding-window/exercise/longest-repeating-character-replacement/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Dynamic Sliding Window"
   leetcodeUrl: "https://leetcode.com/problems/longest-repeating-character-replacement/"
+  difficulty: "Medium"
 ---
 # Longest Repeating Character Replacement
 

--- a/src/content/data-structures-and-algorithms/topic/sliding-window/exercise/longest-substring-without-repeating-characters/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/sliding-window/exercise/longest-substring-without-repeating-characters/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Dynamic Sliding Window"
   leetcodeUrl: "https://leetcode.com/problems/longest-substring-without-repeating-characters/"
+  difficulty: "Medium"
 ---
 # Longest Substring Without Repeating Characters
 

--- a/src/content/data-structures-and-algorithms/topic/sliding-window/exercise/max-consecutives-one-III/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/sliding-window/exercise/max-consecutives-one-III/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Dynamic Sliding Window"
   leetcodeUrl: "https://leetcode.com/problems/max-consecutive-ones-iii/"
+  difficulty: "Medium"
 ---
 
 # Max Consecutive Ones III

--- a/src/content/data-structures-and-algorithms/topic/sliding-window/exercise/maximum-average-subarray-I/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/sliding-window/exercise/maximum-average-subarray-I/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Fixed Sliding Window"
   leetcodeUrl: "https://leetcode.com/problems/maximum-average-subarray-i/"
+  difficulty: "Easy"
 ---
 # Maximum Average Subarray I
 

--- a/src/content/data-structures-and-algorithms/topic/sliding-window/exercise/maximum-sum-of-distinct-subarrays-with-length-k/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/sliding-window/exercise/maximum-sum-of-distinct-subarrays-with-length-k/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Fixed Sliding Window"
   leetcodeUrl: "https://leetcode.com/problems/maximum-sum-of-distinct-subarrays-with-length-k/"
+  difficulty: "Medium"
 ---
 # Maximum Sum of Distinct Subarrays With Length K
 

--- a/src/content/data-structures-and-algorithms/topic/sliding-window/exercise/minimum-size-subarray-sum/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/sliding-window/exercise/minimum-size-subarray-sum/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Dynamic Sliding Window"
   leetcodeUrl: ""
+  difficulty: "Medium"
 ---
 # Minimum Size Subarray Sum
 

--- a/src/content/data-structures-and-algorithms/topic/sliding-window/exercise/minimum-window-substring/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/sliding-window/exercise/minimum-window-substring/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Dynamic Sliding Window"
   leetcodeUrl: "https://leetcode.com/problems/minimum-window-substring/"
+  difficulty: "Hard"
 ---
 # Minimum Window Substring
 

--- a/src/content/data-structures-and-algorithms/topic/sliding-window/exercise/permutation-in-string/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/sliding-window/exercise/permutation-in-string/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Fixed Sliding Window"
   leetcodeUrl: "https://leetcode.com/problems/permutation-in-string/"
+  difficulty: "Medium"
 ---
 # Permutation in String
 

--- a/src/content/data-structures-and-algorithms/topic/sliding-window/exercise/substring-with-concatenation-of-all-words/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/sliding-window/exercise/substring-with-concatenation-of-all-words/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Fixed Sliding Window"
   leetcodeUrl: "https://leetcode.com/problems/substring-with-concatenation-of-all-words/"
+  difficulty: "Hard"
 ---
 # Substring with Concatenation of All Words
 

--- a/src/content/data-structures-and-algorithms/topic/stack/exercise/basic-calculator-II/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/stack/exercise/basic-calculator-II/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Stack"
   leetcodeUrl: "https://leetcode.com/problems/basic-calculator-ii/"
+  difficulty: "Medium"
 ---
 # Basic Calculator II
 

--- a/src/content/data-structures-and-algorithms/topic/stack/exercise/evaluate-reverse-polish-notation/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/stack/exercise/evaluate-reverse-polish-notation/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Stack"
   leetcodeUrl: ""
+  difficulty: "Medium"
 ---
 # Evaluate Reverse Polish Notation
 

--- a/src/content/data-structures-and-algorithms/topic/stack/exercise/longest-valid-parentheses/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/stack/exercise/longest-valid-parentheses/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Stack"
   leetcodeUrl: ""
+  difficulty: "Hard"
 ---
 # Longest Valid Parentheses
 

--- a/src/content/data-structures-and-algorithms/topic/stack/exercise/min-stack/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/stack/exercise/min-stack/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Stack"
   leetcodeUrl: "https://leetcode.com/problems/min-stack/"
+  difficulty: "Medium"
 ---
 # Min Stack
 

--- a/src/content/data-structures-and-algorithms/topic/stack/exercise/remove-all-adjacent-duplicates-in-string/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/stack/exercise/remove-all-adjacent-duplicates-in-string/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Stack"
   leetcodeUrl: "https://leetcode.com/problems/remove-all-adjacent-duplicates-in-string/"
+  difficulty: "Easy"
 ---
 # Remove All Adjacent Duplicates In String
 

--- a/src/content/data-structures-and-algorithms/topic/stack/exercise/remove-duplicate-letters/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/stack/exercise/remove-duplicate-letters/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Stack"
   leetcodeUrl: "https://leetcode.com/problems/remove-duplicate-letters/"
+  difficulty: "Medium"
 ---
 # Remove Duplicate Letters
 

--- a/src/content/data-structures-and-algorithms/topic/stack/exercise/removing-stars-from-a-string/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/stack/exercise/removing-stars-from-a-string/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Stack"
   leetcodeUrl: ""
+  difficulty: "Medium"
 ---
 # Removing Stars From a String
 

--- a/src/content/data-structures-and-algorithms/topic/stack/exercise/valid-parentheses/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/stack/exercise/valid-parentheses/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Stack"
   leetcodeUrl: "https://leetcode.com/problems/valid-parentheses/"
+  difficulty: "Easy"
 ---
 # Valid Parentheses
 

--- a/src/content/data-structures-and-algorithms/topic/string/exercise/guess-the-word/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/string/exercise/guess-the-word/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Minimax / Constraint Filtering"
   leetcodeUrl: "https://leetcode.com/problems/guess-the-word/"
+  difficulty: "Hard"
 ---
 # Guess the Word
 

--- a/src/content/data-structures-and-algorithms/topic/string/exercise/is-subsequence/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/string/exercise/is-subsequence/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Two Pointers"
   leetcodeUrl: "https://leetcode.com/problems/is-subsequence/"
+  difficulty: "Easy"
 ---
 # Is Subsequence
 

--- a/src/content/data-structures-and-algorithms/topic/string/exercise/longest-common-prefix/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/string/exercise/longest-common-prefix/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Character Comparison / Prefix Scan"
   leetcodeUrl: "https://leetcode.com/problems/longest-common-prefix/"
+  difficulty: "Easy"
 ---
 # Longest Common Prefix
 

--- a/src/content/data-structures-and-algorithms/topic/string/exercise/reverse-words-in-a-string/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/string/exercise/reverse-words-in-a-string/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Splitting / String Manipulation"
   leetcodeUrl: "https://leetcode.com/problems/reverse-words-in-a-string/"
+  difficulty: "Medium"
 ---
 # Reverse Words in a String
 

--- a/src/content/data-structures-and-algorithms/topic/string/exercise/valid-palindrome/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/string/exercise/valid-palindrome/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Two Pointers / Filtering"
   leetcodeUrl: "https://leetcode.com/problems/valid-palindrome/"
+  difficulty: "Easy"
 ---
 # Valid Palindrome
 

--- a/src/content/data-structures-and-algorithms/topic/string/exercise/zigzag-conversion/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/string/exercise/zigzag-conversion/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Simulation / Index Mapping"
   leetcodeUrl: "https://leetcode.com/problems/zigzag-conversion/"
+  difficulty: "Medium"
 ---
 # Zigzag Conversion
 

--- a/src/content/data-structures-and-algorithms/topic/tree/exercise/01-matrix/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/tree/exercise/01-matrix/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "BFS multi-source on grid"
   leetcodeUrl: "https://leetcode.com/problems/01-matrix/"
+  difficulty: "Medium"
 ---
 # 01 Matrix
 

--- a/src/content/data-structures-and-algorithms/topic/tree/exercise/binary-search-tree-iterator/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/tree/exercise/binary-search-tree-iterator/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "DFS In-order"
   leetcodeUrl: "https://leetcode.com/problems/binary-search-tree-iterator/"
+  difficulty: "Medium"
 ---
 # Binary Search Tree Iterator
 

--- a/src/content/data-structures-and-algorithms/topic/tree/exercise/binary-tree-inorder-traversal/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/tree/exercise/binary-tree-inorder-traversal/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "DFS In-order"
   leetcodeUrl: "https://leetcode.com/problems/binary-tree-inorder-traversal/"
+  difficulty: "Easy"
 ---
 # Binary Tree Inorder Traversal
 

--- a/src/content/data-structures-and-algorithms/topic/tree/exercise/binary-tree-level-order-traversal/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/tree/exercise/binary-tree-level-order-traversal/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "BFS"
   leetcodeUrl: "https://leetcode.com/problems/binary-tree-level-order-traversal/"
+  difficulty: "Medium"
 ---
 # Binary Tree Level Order Traversal
 

--- a/src/content/data-structures-and-algorithms/topic/tree/exercise/binary-tree-maximum-path-sum/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/tree/exercise/binary-tree-maximum-path-sum/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "DFS Post-order"
   leetcodeUrl: "https://leetcode.com/problems/binary-tree-maximum-path-sum/"
+  difficulty: "Hard"
 ---
 # Binary Tree Maximum Path Sum
 

--- a/src/content/data-structures-and-algorithms/topic/tree/exercise/binary-tree-paths/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/tree/exercise/binary-tree-paths/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "DFS Pre-order"
   leetcodeUrl: "https://leetcode.com/problems/binary-tree-paths/"
+  difficulty: "Easy"
 ---
 # Binary Tree Paths
 

--- a/src/content/data-structures-and-algorithms/topic/tree/exercise/binary-tree-postorder-traversal/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/tree/exercise/binary-tree-postorder-traversal/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "DFS Post-order"
   leetcodeUrl: "https://leetcode.com/problems/binary-tree-postorder-traversal/"
+  difficulty: "Easy"
 ---
 # Binary Tree Postorder Traversal
 

--- a/src/content/data-structures-and-algorithms/topic/tree/exercise/binary-tree-preorder-traversal/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/tree/exercise/binary-tree-preorder-traversal/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "DFS Pre-order"
   leetcodeUrl: "https://leetcode.com/problems/binary-tree-preorder-traversal/"
+  difficulty: "Easy"
 ---
 # Binary Tree Preorder Traversal
 

--- a/src/content/data-structures-and-algorithms/topic/tree/exercise/binary-tree-right-side-view/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/tree/exercise/binary-tree-right-side-view/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "BFS"
   leetcodeUrl: "https://leetcode.com/problems/binary-tree-right-side-view/"
+  difficulty: "Medium"
 ---
 # Binary Tree Right Side View
 

--- a/src/content/data-structures-and-algorithms/topic/tree/exercise/binary-tree-zigzag-level-order-traversal/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/tree/exercise/binary-tree-zigzag-level-order-traversal/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "BFS"
   leetcodeUrl: "https://leetcode.com/problems/binary-tree-zigzag-level-order-traversal/"
+  difficulty: "Medium"
 ---
 # Binary Tree Zigzag Level Order Traversal
 

--- a/src/content/data-structures-and-algorithms/topic/tree/exercise/bus-routes/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/tree/exercise/bus-routes/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "BFS on implicit graph"
   leetcodeUrl: "https://leetcode.com/problems/bus-routes/"
+  difficulty: "Hard"
 ---
 # Bus Routes
 

--- a/src/content/data-structures-and-algorithms/topic/tree/exercise/construct-binary-tree-from-inorder-and-postorder-traversal/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/tree/exercise/construct-binary-tree-from-inorder-and-postorder-traversal/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "DFS Post-order"
   leetcodeUrl: "https://leetcode.com/problems/construct-binary-tree-from-inorder-and-postorder-traversal/"
+  difficulty: "Medium"
 ---
 # Construct Binary Tree from Inorder and Postorder Traversal
 

--- a/src/content/data-structures-and-algorithms/topic/tree/exercise/construct-binary-tree-from-preorder-and-inorder-traversal/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/tree/exercise/construct-binary-tree-from-preorder-and-inorder-traversal/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "DFS Pre-order"
   leetcodeUrl: "https://leetcode.com/problems/construct-binary-tree-from-preorder-and-inorder-traversal/"
+  difficulty: "Medium"
 ---
 # Construct Binary Tree from Preorder and Inorder Traversal
 

--- a/src/content/data-structures-and-algorithms/topic/tree/exercise/convert-sorted-array-to-binary-search-tree/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/tree/exercise/convert-sorted-array-to-binary-search-tree/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "DFS Pre-order"
   leetcodeUrl: "https://leetcode.com/problems/convert-sorted-array-to-binary-search-tree/"
+  difficulty: "Easy"
 ---
 # Convert Sorted Array to Binary Search Tree
 

--- a/src/content/data-structures-and-algorithms/topic/tree/exercise/count-complete-tree-nodes/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/tree/exercise/count-complete-tree-nodes/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "DFS Pre-order"
   leetcodeUrl: "https://leetcode.com/problems/count-complete-tree-nodes/"
+  difficulty: "Easy"
 ---
 # Count Complete Tree Nodes
 

--- a/src/content/data-structures-and-algorithms/topic/tree/exercise/delete-nodes-and-return-forest/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/tree/exercise/delete-nodes-and-return-forest/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "DFS Post-order"
   leetcodeUrl: "https://leetcode.com/problems/delete-nodes-and-return-forest/"
+  difficulty: "Medium"
 ---
 # Delete Nodes And Return Forest
 

--- a/src/content/data-structures-and-algorithms/topic/tree/exercise/diameter-of-binary-tree/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/tree/exercise/diameter-of-binary-tree/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "DFS Post-order"
   leetcodeUrl: "https://leetcode.com/problems/diameter-of-binary-tree/"
+  difficulty: "Easy"
 ---
 # Diameter of Binary Tree
 

--- a/src/content/data-structures-and-algorithms/topic/tree/exercise/distribute-coins-in-binary-tree/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/tree/exercise/distribute-coins-in-binary-tree/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "DFS Post-order"
   leetcodeUrl: "https://leetcode.com/problems/distribute-coins-in-binary-tree/"
+  difficulty: "Medium"
 ---
 # Distribute Coins in Binary Tree
 

--- a/src/content/data-structures-and-algorithms/topic/tree/exercise/find-duplicate-subtrees/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/tree/exercise/find-duplicate-subtrees/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "DFS Post-order"
   leetcodeUrl: "https://leetcode.com/problems/find-duplicate-subtrees/"
+  difficulty: "Medium"
 ---
 # Find Duplicate Subtrees
 

--- a/src/content/data-structures-and-algorithms/topic/tree/exercise/flatten-binary-tree-to-linked-list/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/tree/exercise/flatten-binary-tree-to-linked-list/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "DFS Post-order"
   leetcodeUrl: "https://leetcode.com/problems/flatten-binary-tree-to-linked-list/"
+  difficulty: "Medium"
 ---
 # Flatten Binary Tree to Linked List
 

--- a/src/content/data-structures-and-algorithms/topic/tree/exercise/invert-binary-tree/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/tree/exercise/invert-binary-tree/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "DFS Post-order"
   leetcodeUrl: "https://leetcode.com/problems/invert-binary-tree/"
+  difficulty: "Easy"
 ---
 # Invert Binary Tree
 

--- a/src/content/data-structures-and-algorithms/topic/tree/exercise/kth-smallest-element-in-a-bts/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/tree/exercise/kth-smallest-element-in-a-bts/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "DFS In-order"
   leetcodeUrl: "https://leetcode.com/problems/kth-smallest-element-in-a-bst/"
+  difficulty: "Medium"
 ---
 # Kth Smallest Element in a BST
 

--- a/src/content/data-structures-and-algorithms/topic/tree/exercise/lowest-common-ancestor-of-a-binary-tree/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/tree/exercise/lowest-common-ancestor-of-a-binary-tree/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "DFS Post-order"
   leetcodeUrl: "https://leetcode.com/problems/lowest-common-ancestor-of-a-binary-tree/"
+  difficulty: "Medium"
 ---
 # Lowest Common Ancestor of a Binary Tree
 

--- a/src/content/data-structures-and-algorithms/topic/tree/exercise/maximum-difference-between-node-and-ancestor/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/tree/exercise/maximum-difference-between-node-and-ancestor/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "DFS Pre-order"
   leetcodeUrl: "https://leetcode.com/problems/maximum-difference-between-node-and-ancestor/"
+  difficulty: "Medium"
 ---
 # Maximum Difference Between Node and Ancestor
 

--- a/src/content/data-structures-and-algorithms/topic/tree/exercise/maximum-width-of-binary-tree/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/tree/exercise/maximum-width-of-binary-tree/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "BFS"
   leetcodeUrl: "https://leetcode.com/problems/maximum-width-of-binary-tree/"
+  difficulty: "Medium"
 ---
 # Maximum Width of Binary Tree
 

--- a/src/content/data-structures-and-algorithms/topic/tree/exercise/minimum-absolute-difference-in-BST/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/tree/exercise/minimum-absolute-difference-in-BST/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "DFS In-order"
   leetcodeUrl: "https://leetcode.com/problems/minimum-absolute-difference-in-bst/"
+  difficulty: "Easy"
 ---
 # Minimum Absolute Difference in BST
 

--- a/src/content/data-structures-and-algorithms/topic/tree/exercise/minimum-distance-between-BST-nodes/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/tree/exercise/minimum-distance-between-BST-nodes/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "DFS In-order"
   leetcodeUrl: "https://leetcode.com/problems/minimum-distance-between-bst-nodes/"
+  difficulty: "Easy"
 ---
 # Minimum Distance Between BST Nodes
 

--- a/src/content/data-structures-and-algorithms/topic/tree/exercise/open-the-lock/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/tree/exercise/open-the-lock/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "BFS on implicit state-space graph"
   leetcodeUrl: ""
+  difficulty: "Medium"
 ---
 # Open the Lock
 

--- a/src/content/data-structures-and-algorithms/topic/tree/exercise/path-sum-III/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/tree/exercise/path-sum-III/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "DFS Pre-order"
   leetcodeUrl: "https://leetcode.com/problems/path-sum-iii/"
+  difficulty: "Medium"
 ---
 # Path Sum III
 

--- a/src/content/data-structures-and-algorithms/topic/tree/exercise/populating-next-right-pointers-in-each-node-II/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/tree/exercise/populating-next-right-pointers-in-each-node-II/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "BFS"
   leetcodeUrl: "https://leetcode.com/problems/populating-next-right-pointers-in-each-node-ii/"
+  difficulty: "Medium"
 ---
 # Populating Next Right Pointers in Each Node II
 

--- a/src/content/data-structures-and-algorithms/topic/tree/exercise/rotting-oranges/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/tree/exercise/rotting-oranges/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "BFS multi-source on grid"
   leetcodeUrl: "https://leetcode.com/problems/rotting-oranges/"
+  difficulty: "Medium"
 ---
 # Rotting Oranges
 

--- a/src/content/data-structures-and-algorithms/topic/tree/exercise/same-tree/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/tree/exercise/same-tree/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "DFS Pre-order"
   leetcodeUrl: "https://leetcode.com/problems/same-tree/"
+  difficulty: "Easy"
 ---
 # Same Tree
 

--- a/src/content/data-structures-and-algorithms/topic/tree/exercise/serialize-and-deserialize-binary-tree/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/tree/exercise/serialize-and-deserialize-binary-tree/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "DFS Pre-order (serialization)"
   leetcodeUrl: "https://leetcode.com/problems/serialize-and-deserialize-binary-tree/"
+  difficulty: "Hard"
 ---
 # Serialize and Deserialize Binary Tree
 

--- a/src/content/data-structures-and-algorithms/topic/tree/exercise/shortest-path-in-a-grid-with-obstacles-elimination/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/tree/exercise/shortest-path-in-a-grid-with-obstacles-elimination/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "BFS with extended state on grid"
   leetcodeUrl: "https://leetcode.com/problems/shortest-path-in-a-grid-with-obstacles-elimination/"
+  difficulty: "Hard"
 ---
 # Shortest Path in a Grid with Obstacles Elimination
 

--- a/src/content/data-structures-and-algorithms/topic/tree/exercise/symmetric-tree/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/tree/exercise/symmetric-tree/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "DFS Pre-order"
   leetcodeUrl: "https://leetcode.com/problems/symmetric-tree/"
+  difficulty: "Easy"
 ---
 # Symmetric Tree
 

--- a/src/content/data-structures-and-algorithms/topic/tree/exercise/trim-a-binary-search-tree/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/tree/exercise/trim-a-binary-search-tree/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "DFS Pre-order (BST pruning)"
   leetcodeUrl: "https://leetcode.com/problems/trim-a-binary-search-tree/"
+  difficulty: "Medium"
 ---
 # Trim a Binary Search Tree
 

--- a/src/content/data-structures-and-algorithms/topic/tree/exercise/validate-binary-search-tree/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/tree/exercise/validate-binary-search-tree/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "DFS In-order"
   leetcodeUrl: "https://leetcode.com/problems/validate-binary-search-tree/"
+  difficulty: "Medium"
 ---
 # Validate Binary Search Tree
 

--- a/src/content/data-structures-and-algorithms/topic/tree/exercise/word-ladder/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/tree/exercise/word-ladder/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "BFS on implicit state-space graph"
   leetcodeUrl: ""
+  difficulty: "Hard"
 ---
 # Word Ladder
 

--- a/src/content/data-structures-and-algorithms/topic/tries/exercise/design-add-and-search-words-data-structure/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/tries/exercise/design-add-and-search-words-data-structure/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Trie"
   leetcodeUrl: "https://leetcode.com/problems/design-add-and-search-words-data-structure/"
+  difficulty: "Medium"
 ---
 # Design Add and Search Words Data Structure
 

--- a/src/content/data-structures-and-algorithms/topic/tries/exercise/implement-tries-prefix-tree/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/tries/exercise/implement-tries-prefix-tree/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Trie"
   leetcodeUrl: "https://leetcode.com/problems/implement-trie-prefix-tree/"
+  difficulty: "Medium"
 ---
 # Implement Trie (Prefix Tree)
 

--- a/src/content/data-structures-and-algorithms/topic/tries/exercise/longest-word-in-dictionary/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/tries/exercise/longest-word-in-dictionary/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Trie"
   leetcodeUrl: "https://leetcode.com/problems/longest-word-in-dictionary/"
+  difficulty: "Medium"
 ---
 # Longest Word in Dictionary
 

--- a/src/content/data-structures-and-algorithms/topic/tries/exercise/maximum-XOR-of-two-numbers-in-an -array/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/tries/exercise/maximum-XOR-of-two-numbers-in-an -array/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Trie"
   leetcodeUrl: "https://leetcode.com/problems/maximum-xor-of-two-numbers-in-an-array/"
+  difficulty: "Medium"
 ---
 # Maximum XOR of Two Numbers in an Array
 

--- a/src/content/data-structures-and-algorithms/topic/tries/exercise/search-suggestions-system/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/tries/exercise/search-suggestions-system/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Trie"
   leetcodeUrl: ""
+  difficulty: "Medium"
 ---
 
 # Search Suggestions System

--- a/src/content/data-structures-and-algorithms/topic/tries/exercise/word-search-II/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/tries/exercise/word-search-II/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Trie + DFS"
   leetcodeUrl: "https://leetcode.com/problems/word-search-ii/"
+  difficulty: "Hard"
 ---
 # Word Search II
 

--- a/src/content/data-structures-and-algorithms/topic/two-pointers/exercise/3sum/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/two-pointers/exercise/3sum/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Three Pointers / Deduplication"
   leetcodeUrl: "https://leetcode.com/problems/3sum/"
+  difficulty: "Medium"
 ---
 # 3Sum
 

--- a/src/content/data-structures-and-algorithms/topic/two-pointers/exercise/container-with-most-water/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/two-pointers/exercise/container-with-most-water/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Opposite-direction Two Pointers / Optimal Boundaries"
   leetcodeUrl: "https://leetcode.com/problems/container-with-most-water/"
+  difficulty: "Medium"
 ---
 # Container With Most Water
 

--- a/src/content/data-structures-and-algorithms/topic/two-pointers/exercise/merge-sorted-array/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/two-pointers/exercise/merge-sorted-array/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Opposite-direction Two Pointers"
   leetcodeUrl: ""
+  difficulty: "Easy"
 ---
 # Merge Sorted Array
 

--- a/src/content/data-structures-and-algorithms/topic/two-pointers/exercise/trapping-rain-water/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/two-pointers/exercise/trapping-rain-water/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Two Pointers / Boundary Scanning"
   leetcodeUrl: "https://leetcode.com/problems/trapping-rain-water/"
+  difficulty: "Hard"
 ---
 # Trapping Rain Water
 

--- a/src/content/data-structures-and-algorithms/topic/two-pointers/exercise/two-sum-II-input-array-is-sorted/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/two-pointers/exercise/two-sum-II-input-array-is-sorted/content.mdx
@@ -8,6 +8,7 @@ authors: [fabrizio_duroni]
 metadata:
   technique: "Opposite-direction Two Pointers"
   leetcodeUrl: "https://leetcode.com/problems/two-sum-ii-input-array-is-sorted/"
+  difficulty: "Medium"
 ---
 # Two Sum II - Input Array Is Sorted
 

--- a/src/lib/content/data-structures-and-algorithms.ts
+++ b/src/lib/content/data-structures-and-algorithms.ts
@@ -4,8 +4,8 @@ import { slugs } from "@/types/configuration/slug";
 import { ExerciseMetadata } from "@/types/content/data-structures-and-algorithms";
 
 const exerciseMetadataAdapter = (raw: unknown): ExerciseMetadata => {
-  const { technique, leetcodeUrl } = raw as Record<string, string>;
-  return { technique, leetcodeUrl };
+  const { technique, leetcodeUrl, difficulty } = raw as Record<string, string>;
+  return { technique, leetcodeUrl, difficulty: difficulty as ExerciseMetadata["difficulty"] };
 };
 
 export const getAllDataStructuresAndAlgorithmsTopics = (): Content[] =>

--- a/src/types/content/data-structures-and-algorithms.ts
+++ b/src/types/content/data-structures-and-algorithms.ts
@@ -1,4 +1,5 @@
 export type ExerciseMetadata = {
     technique: string;
     leetcodeUrl: string;
+    difficulty: "Easy" | "Medium" | "Hard";
 };


### PR DESCRIPTION
Exercise table difficulty badges

## Description
Redesign the exercise table at the end of each DSA topic article:
- **Before**: 3 columns (Exercise → LeetCode, Technique, Solution → exercise page)
- **After**: 2 columns (Exercise → exercise page, Difficulty with color-coded badge)

The exercise name now links directly to the dedicated exercise page (which already contains technique, LeetCode link, and solution code). Difficulty is shown as a color-coded label: green (Easy), amber (Medium), red (Hard).

Added `difficulty` field to `ExerciseMetadata` type and to all 211 exercise MDX frontmatter files, fetched from LeetCode.

## Motivation and Context
DSA course UX improvement. Since each exercise has its own page with full details, the table can be simplified while adding the useful difficulty signal.

## How Has This Been Tested?
Browser

## Types of changes
- [ ] Bug fix :bug: (non-breaking change which fixes an issue)
- [x] New feature :sparkles: (non-breaking change which adds functionality)
- [ ] Breaking change :boom: (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project :beers:.
- [X] My change requires a change to the documentation :bulb: and I have updated the documentation accordingly.
- [X] I have read the [CONTRIBUTING](https://github.com/chicio/chicio.github.io/blob/master/CONTRIBUTING.md) document :busts_in_silhouette:.
- [X] I have added tests to cover my changes :tada:.
- [X] All new and existing tests passed :white_check_mark:.