### PR TITLE
fix(ux): :lipstick: disable hover scale on brand header and menu glassmorphism

### DIFF
--- a/src/app/css/globals.css
+++ b/src/app/css/globals.css
@@ -498,8 +498,16 @@
         @apply border border-solid border-accent-alpha-40 rounded-xl hover:border-accent active:border-accent focus:border-accent shadow-lg transition-transform duration-300 hover:scale-102 bg-general-background;
     }
 
+    .glassmorphism-lite-no-scale {
+        @apply border border-solid border-accent-alpha-40 rounded-xl hover:border-accent active:border-accent focus:border-accent shadow-lg transition-colors duration-300 bg-general-background;
+    }
+
     .glassmorphism {
         @apply border border-solid border-accent-alpha-40 rounded-xl hover:border-accent active:border-accent focus:border-accent shadow-lg transition-transform duration-300 hover:scale-102 backdrop-blur-sm bg-general-background-alpha-60;
+    }
+
+    .glassmorphism-no-scale {
+        @apply border border-solid border-accent-alpha-40 rounded-xl hover:border-accent active:border-accent focus:border-accent shadow-lg transition-colors duration-300 backdrop-blur-sm bg-general-background-alpha-60;
     }
 }
 

--- a/src/components/design-system/organism/header/brand-header.tsx
+++ b/src/components/design-system/organism/header/brand-header.tsx
@@ -13,7 +13,7 @@ interface BrandHeaderProps {
 }
 
 export const BrandHeader: FC<BrandHeaderProps> = ({ big }) => {
-  const { glassmorphismClass } = useGlassmorphism();
+  const { glassmorphismClass } = useGlassmorphism({ noScale: true });
   const height = big ? "h-auto" : "h-[170px] md:h-[200px]";
   const margins = big ? "mt-14 mb-8" : "mt-12";
 

--- a/src/components/design-system/organism/menu.tsx
+++ b/src/components/design-system/organism/menu.tsx
@@ -209,7 +209,7 @@ export const Menu: FC<MenuProps> = ({ trackingCategory }) => {
     startSearch,
     whiteRabbitEasterEgg,
   );
-  const { glassmorphismClass } = useGlassmorphism();
+  const { glassmorphismClass } = useGlassmorphism({ noScale: true });
   const shouldHideMenu =
     pathname === slugs.chat ? false : direction === ScrollDirection.down;
 

--- a/src/components/design-system/utils/hooks/use-glassmorphism.ts
+++ b/src/components/design-system/utils/hooks/use-glassmorphism.ts
@@ -1,9 +1,19 @@
 import { useReducedMotions } from "./use-reduced-motions";
 
-  export const useGlassmorphism = () => {
+interface UseGlassmorphismOptions {
+    noScale?: boolean;
+}
+
+export const useGlassmorphism = ({ noScale = false }: UseGlassmorphismOptions = {}) => {
     const shouldReduceMotion = useReducedMotions();
 
+    if (noScale) {
+        return {
+            glassmorphismClass: `${!shouldReduceMotion ? "glassmorphism-no-scale" : "glassmorphism-lite-no-scale"}`,
+        };
+    }
+
     return {
-      glassmorphismClass: `${!shouldReduceMotion ? "glassmorphism" : "glassmorphism-lite"}`,
+        glassmorphismClass: `${!shouldReduceMotion ? "glassmorphism" : "glassmorphism-lite"}`,
     };
-  };
+};


### PR DESCRIPTION
Disable hover scale animation on brand header and navigation menu glassmorphism panels.

## Description
- Added `.glassmorphism-no-scale` and `.glassmorphism-lite-no-scale` CSS classes in `globals.css` — identical to their counterparts but using `transition-colors` instead of `transition-transform` and without `hover:scale-102`
- Extended `useGlassmorphism` hook with an optional `noScale` boolean parameter (default: `false`, fully backward-compatible)
- Updated `BrandHeader` and `Menu` to call `useGlassmorphism({ noScale: true })` — all other components keep the existing scale-on-hover behaviour

## Motivation and Context
The header and menu are structural chrome elements that span the full width of the viewport. Scaling them on hover creates an unwanted visual jump. Cards and content blocks benefit from the scale feedback; fixed navigation elements do not.

## How Has This Been Tested?
Browser

## Types of changes
- [x] Bug fix :bug: (non-breaking change which fixes an issue)
- [ ] New feature :sparkles: (non-breaking change which adds functionality)
- [ ] Breaking change :boom: (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project :beers:.
- [X] My change requires a change to the documentation :bulb: and I have updated the documentation accordingly.
- [X] I have read the [CONTRIBUTING](https://github.com/chicio/chicio.github.io/blob/master/CONTRIBUTING.md) document :busts_in_silhouette:.
- [X] I have added tests to cover my changes :tada:.
- [X] All new and existing tests passed :white_check_mark:.