### PR TITLE
fix(ux): :bug: prevent iOS PWA zoom on command palette input

### DIFF
--- a/src/components/design-system/organism/command-palette.tsx
+++ b/src/components/design-system/organism/command-palette.tsx
@@ -145,7 +145,7 @@ export const CommandPalette = () => {
                                     {">"}
                                 </span>
                                 <Command.Input
-                                    className="bg-transparent outline-none text-accent font-mono text-sm flex-1 placeholder:text-accent/40 caret-accent"
+                                    className="bg-transparent outline-none text-accent font-mono text-base flex-1 placeholder:text-accent/40 caret-accent"
                                     placeholder="type to search blog posts_"
                                     onValueChange={(value) => {
                                         setIsSearching(value.trim().length >= 3);


### PR DESCRIPTION
Prevent iOS PWA/Safari from auto-zooming the viewport when the command palette search input is focused.

## Description
- Changed `Command.Input` font size from `text-sm` (14px) to `text-base` (16px)

## Motivation and Context
iOS Safari and iOS PWA mode automatically zoom the viewport when a user focuses any `<input>` with `font-size < 16px`. The command palette's search input used `text-sm` (0.875rem / 14px), which crossed that threshold and triggered unwanted zoom every time the palette was opened on iPhone.

The fix targets the root cause at the input level. No viewport meta changes were made — `maximumScale` suppression would break user-initiated pinch-zoom (accessibility regression).

## How Has This Been Tested?
Browser

## Types of changes
- [x] Bug fix :bug: (non-breaking change which fixes an issue)
- [ ] New feature :sparkles: (non-breaking change which adds functionality)
- [ ] Breaking change :boom: (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project :beers:.
- [X] My change requires a change to the documentation :bulb: and I have updated the documentation accordingly.
- [X] I have read the [CONTRIBUTING](https://github.com/chicio/chicio-blog/blob/master/CONTRIBUTING.md) document :busts_in_silhouette:.
- [X] I have added tests to cover my changes :tada:.
- [X] All new and existing tests passed :white_check_mark:.