### PR TITLE
feat(capabilities): :sparkles: add MCP portfolio server at /api/mcp

### DIFF
--- a/.claude/agent-memory/fabrizioduroni-senior-engineer/MEMORY.md
+++ b/.claude/agent-memory/fabrizioduroni-senior-engineer/MEMORY.md
@@ -1,5 +1,8 @@
 # Memory Index
 
+## Site
+- [Site Info](project_site_info.md) — Production domain is fabrizioduroni.it (not chicio.dev)
+
 ## Architecture
 - [Content System](arch_content_system.md) — Filesystem-as-database with slug patterns, metadata adapters, search indexing
 - [Design System & Matrix Theme](arch_design_system.md) — Atomic design, Matrix palette, glassmorphism/motion hooks
@@ -20,6 +23,9 @@
 
 ## Features (continued)
 - [Command Palette](feature_command_palette.md) — ⌘K palette, MotionDiv blink suppression pattern, stable close/ESC, search pill design
+
+## Features (continued 2)
+- [MCP Portfolio Server](feature_mcp_server.md) — Public MCP server at /api/mcp, 8 filesystem-backed tools, stateless Vercel transport, elasticlunr search
 
 ## Feedback
 - [PWA & State Patterns](feedback_pwa_patterns.md) — useSyncExternalStore for localStorage state, consent-gated UI, banner/error page alignment rules

--- a/.claude/agent-memory/fabrizioduroni-senior-engineer/feature_mcp_server.md
+++ b/.claude/agent-memory/fabrizioduroni-senior-engineer/feature_mcp_server.md
@@ -1,0 +1,42 @@
+---
+name: MCP Portfolio Server
+description: Public MCP server at /api/mcp exposing portfolio content via 8 tools, filesystem-backed, Vercel-compatible
+type: project
+---
+
+## Architecture
+- Route: `src/app/api/mcp/route.ts` — exports GET, POST, DELETE, OPTIONS
+- Server factory: `src/lib/mcp/server.ts` — `createMcpServer()` wires all tools
+- Tools: `src/lib/mcp/tools/register-*.ts` — one file per tool
+- Transport: `WebStandardStreamableHTTPServerTransport` from `@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js`
+- Mode: **stateless** (`sessionIdGenerator: undefined`) — required for Vercel serverless
+- New dep: `@modelcontextprotocol/sdk@^1.29.0`
+
+## Tools
+| Tool | Backend |
+|------|---------|
+| `search_content(query, limit?)` | elasticlunr `public/search-index.json` — filesystem |
+| `list_posts(tag?, limit?)` | `getPosts()` / `getPostsForTag()` |
+| `get_post(year, month, day, slug)` | `getPostBy()` — params are zero-padded strings |
+| `get_tags()` | `getTags()` |
+| `get_dsa_topics()` | `getAllDataStructuresAndAlgorithmsTopics()` |
+| `get_dsa_exercises(topic?, difficulty?)` | `getAllExercises()` — difficulty is "Easy"|"Medium"|"Hard" |
+| `get_about_me()` | `getAboutMe()` |
+| `get_site_stats()` | `getPosts()` + `getAllExercises()` + `getAllDataStructuresAndAlgorithmsTopics()` |
+
+## Key decisions
+- 100% filesystem-based — Upstash Vector NOT used (only about-me is in Upstash Vector, not full blog)
+- `search_content` uses elasticlunr index loaded from `public/search-index.json` server-side; uses `index.documentStore.getDoc(ref)` to enrich results without re-loading MDX
+- CORS headers (`*`) on all responses for browser-based MCP clients
+- Per-request new server+transport instances (stateless pattern)
+- Blog post dir structure: `src/content/blog/post/YYYY/MM/DD/slug/` — month/day are zero-padded
+
+## Connection (Claude Desktop)
+```json
+{ "mcpServers": { "chicio-portfolio": { "url": "https://fabrizioduroni.it/api/mcp" } } }
+```
+
+## Site URL
+`https://fabrizioduroni.it` — centralised in `src/lib/mcp/config.ts` as `MCP_SITE_URL`
+
+**Why:** ESLint@10 + typescript-eslint@8.x incompatibility (pre-existing from eslint-config-next@16.2.4 bump) blocked `npm run lint`, but `npm run build` and `tsc --noEmit` both pass clean.

--- a/.claude/agent-memory/fabrizioduroni-senior-engineer/project_site_info.md
+++ b/.claude/agent-memory/fabrizioduroni-senior-engineer/project_site_info.md
@@ -1,0 +1,11 @@
+---
+name: Site deployment info
+description: Production domain and key deployment details for fabrizioduroni.it
+type: project
+---
+
+Production URL: **https://fabrizioduroni.it**
+
+**Why:** The user confirmed this during MCP server work. Previous code incorrectly used `chicio.dev`.
+
+**How to apply:** Always use `fabrizioduroni.it` when constructing absolute URLs (e.g. in MCP tool responses, SEO metadata, RSS feed, sitemaps). The MCP constant lives at `src/lib/mcp/config.ts` as `MCP_SITE_URL`.

--- a/next.config.ts
+++ b/next.config.ts
@@ -30,6 +30,9 @@ const nextConfig: NextConfig = {
     formats: ["image/avif", "image/webp"],
     minimumCacheTTL: 86400,
   },
+  outputFileTracingExcludes: {
+    "/api/**": ["public/images/**"],
+  },
   async redirects() {
     return [
       {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@mdx-js/loader": "^3.1.1",
         "@mdx-js/react": "^3.1.1",
         "@microflash/rehype-figure": "^2.1.4",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "@next/mdx": "16.2.2",
         "@next/third-parties": "16.2.4",
         "@react-email/components": "^1.0.12",
@@ -1200,6 +1201,18 @@
         "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -2293,6 +2306,68 @@
         "unist-util-remove": "^4.0.0",
         "unist-util-visit": "^5.0.0"
       }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.12",
@@ -5168,6 +5243,19 @@
         }
       }
     },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -5250,6 +5338,45 @@
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
       }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
     },
     "node_modules/ansi-align": {
       "version": "3.0.1",
@@ -5683,6 +5810,30 @@
       "dev": true,
       "license": "Apache-2.0"
     },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/boxen": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/boxen/-/boxen-8.0.1.tgz",
@@ -5843,6 +5994,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/c12": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/c12/-/c12-3.3.3.tgz",
@@ -5895,7 +6055,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -5909,7 +6068,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -6332,6 +6490,28 @@
         "node": "^14.18.0 || >=16.10.0"
       }
     },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/conventional-changelog": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-7.2.0.tgz",
@@ -6479,11 +6659,45 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -6694,9 +6908,9 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -6859,6 +7073,15 @@
         "quickjs-wasi": "^0.0.1"
       }
     },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/dequal": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
@@ -7013,7 +7236,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -7029,6 +7251,12 @@
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
       "license": "MIT"
     },
     "node_modules/elasticlunr": {
@@ -7065,6 +7293,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/enhanced-resolve": {
@@ -7165,7 +7402,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -7175,7 +7411,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -7213,7 +7448,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -7375,6 +7609,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -8049,11 +8289,32 @@
         "url": "https://github.com/bgub/eta?sponsor=1"
       }
     },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/eventemitter3": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
       "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
       "license": "MIT"
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
     },
     "node_modules/eventsource-parser": {
       "version": "3.0.6",
@@ -8062,6 +8323,67 @@
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.4.1.tgz",
+      "integrity": "sha512-NGVYwQSAyEQgzxX1iCM978PP9AdO/hW93gMcF6ZwQCm+rFvLsBH6w4xcXWTcliS8La5EPRN3p9wzItqBwJrfNw==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
       }
     },
     "node_modules/exsolve": {
@@ -8110,7 +8432,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-glob": {
@@ -8179,6 +8500,22 @@
       "dependencies": {
         "fast-string-truncated-width": "^3.0.2"
       }
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fast-wrap-ansi": {
       "version": "0.2.0",
@@ -8280,6 +8617,27 @@
         "node": ">=8"
       }
     },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/find-up": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -8359,6 +8717,15 @@
         "node": ">=0.4.x"
       }
     },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/framer-motion": {
       "version": "12.34.3",
       "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.34.3.tgz",
@@ -8386,6 +8753,15 @@
         }
       }
     },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -8404,7 +8780,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -8481,7 +8856,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -8528,7 +8902,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -8739,7 +9112,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -8866,7 +9238,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -8895,7 +9266,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -9152,6 +9522,15 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/hono": {
+      "version": "4.12.15",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.15.tgz",
+      "integrity": "sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
     "node_modules/hosted-git-info": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-8.1.0.tgz",
@@ -9229,6 +9608,26 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/http-proxy-agent": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-8.0.0.tgz",
@@ -9261,7 +9660,6 @@
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
       "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -9347,7 +9745,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/ini": {
@@ -9394,10 +9791,18 @@
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
       "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/is-alphabetical": {
@@ -9878,6 +10283,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -10086,7 +10497,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/issue-parser": {
@@ -10149,6 +10559,15 @@
         "jiti": "lib/jiti-cli.mjs"
       }
     },
+    "node_modules/jose": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
+      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -10201,6 +10620,12 @@
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -10809,7 +11234,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -11163,11 +11587,32 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/meow": {
       "version": "13.2.0",
       "resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",
       "integrity": "sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -11956,7 +12401,6 @@
       "version": "1.54.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
       "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -11966,7 +12410,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
       "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "^1.54.0"
@@ -12096,6 +12539,15 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/neo-async": {
       "version": "2.6.2",
@@ -12292,7 +12744,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -12302,7 +12753,6 @@
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -12417,6 +12867,27 @@
       "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
     },
     "node_modules/onetime": {
       "version": "7.0.0",
@@ -12742,6 +13213,15 @@
         "url": "https://ko-fi.com/killymxi"
       }
     },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -12756,7 +13236,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -12792,6 +13271,16 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/pathe": {
       "version": "2.0.3",
@@ -12833,6 +13322,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/pkg-types": {
@@ -13073,6 +13571,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/proxy-agent": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-7.0.0.tgz",
@@ -13126,6 +13637,21 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -13153,6 +13679,30 @@
       "integrity": "sha512-fBWNLTBkxkLAhe1AzF1hyXEvuA+N+vV1WMP2D6iiMUblvmOt8Pp5t8zUcgvz7aYA1ldUdxDlgUse15dmcKjkNg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/rc": {
       "version": "1.2.8",
@@ -13835,6 +14385,15 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/reselect": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
@@ -13951,6 +14510,22 @@
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/run-applescript": {
@@ -14070,7 +14645,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/sax": {
@@ -14121,6 +14695,51 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/serwist": {
@@ -14190,6 +14809,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
     "node_modules/sharp": {
       "version": "0.34.5",
       "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
@@ -14239,7 +14864,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -14252,7 +14876,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -14262,7 +14885,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
       "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -14282,7 +14904,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
       "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -14299,7 +14920,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
       "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -14318,7 +14938,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
       "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -14486,6 +15105,15 @@
       "dependencies": {
         "@stablelib/base64": "^1.0.0",
         "fast-sha256": "^1.3.0"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/stdin-discarder": {
@@ -15041,6 +15669,15 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
       }
     },
     "node_modules/tr46": {
@@ -15607,6 +16244,20 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/typed-array-buffer": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
@@ -15945,6 +16596,15 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/unrs-resolver": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.11.1.tgz",
@@ -16139,6 +16799,15 @@
         "spdx-expression-parse": "^3.0.0"
       }
     },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/vfile": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
@@ -16260,7 +16929,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -16519,6 +17187,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
     "node_modules/wsl-utils": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.3.1.tgz",
@@ -16604,6 +17278,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
       }
     },
     "node_modules/zod-validation-error": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@mdx-js/loader": "^3.1.1",
     "@mdx-js/react": "^3.1.1",
     "@microflash/rehype-figure": "^2.1.4",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "@next/mdx": "16.2.2",
     "@next/third-parties": "16.2.4",
     "@react-email/components": "^1.0.12",

--- a/src/app/.well-known/oauth-protected-resource/route.ts
+++ b/src/app/.well-known/oauth-protected-resource/route.ts
@@ -1,0 +1,28 @@
+import { MCP_SITE_URL } from "@/lib/mcp/config";
+
+const CORS_HEADERS: Record<string, string> = {
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Methods": "GET, OPTIONS",
+    "Access-Control-Allow-Headers": "Content-Type",
+};
+
+/**
+ * OAuth 2.0 Protected Resource Metadata (RFC 9728).
+ * Returning an empty authorization_servers array signals that this MCP server
+ * is public and requires no authentication. This satisfies the proactive OAuth
+ * discovery performed by clients such as mcp-remote and the MCP Inspector,
+ * allowing them to proceed without attempting an OAuth flow.
+ */
+export async function GET(): Promise<Response> {
+    return Response.json(
+        {
+            resource: `${MCP_SITE_URL}/api/mcp`,
+            authorization_servers: [],
+        },
+        { headers: CORS_HEADERS },
+    );
+}
+
+export async function OPTIONS(): Promise<Response> {
+    return new Response(null, { status: 204, headers: CORS_HEADERS });
+}

--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -1,0 +1,44 @@
+import { createMcpServer } from "@/lib/mcp/server";
+import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
+
+const CORS_HEADERS: Record<string, string> = {
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Methods": "GET, POST, DELETE, OPTIONS",
+    "Access-Control-Allow-Headers": "Content-Type, Accept, MCP-Protocol-Version, Mcp-Session-Id",
+};
+
+const withCors = (response: Response): Response => {
+    const headers = new Headers(response.headers);
+    Object.entries(CORS_HEADERS).forEach(([key, value]) => headers.set(key, value));
+    return new Response(response.body, {
+        status: response.status,
+        statusText: response.statusText,
+        headers,
+    });
+};
+
+const handleMcpRequest = async (req: Request): Promise<Response> => {
+    const transport = new WebStandardStreamableHTTPServerTransport({
+        sessionIdGenerator: undefined,
+    });
+    const server = createMcpServer();
+    await server.connect(transport);
+    const response = await transport.handleRequest(req);
+    return withCors(response);
+};
+
+export async function GET(req: Request): Promise<Response> {
+    return handleMcpRequest(req);
+}
+
+export async function POST(req: Request): Promise<Response> {
+    return handleMcpRequest(req);
+}
+
+export async function DELETE(req: Request): Promise<Response> {
+    return handleMcpRequest(req);
+}
+
+export async function OPTIONS(): Promise<Response> {
+    return new Response(null, { status: 204, headers: CORS_HEADERS });
+}

--- a/src/lib/content/search-index-factory.ts
+++ b/src/lib/content/search-index-factory.ts
@@ -1,0 +1,25 @@
+import elasticlunr from "elasticlunr";
+import { Content } from "@/types/content/content";
+import { SearchablePostFields } from "@/types/search/search";
+
+export const createSearchIndex = (contents: Content[]): elasticlunr.Index<SearchablePostFields> => {
+    const index = elasticlunr<SearchablePostFields>(function () {
+        this.addField("title");
+        this.addField("description");
+        this.addField("tags");
+        this.addField("authors");
+        this.setRef("slug");
+    });
+
+    contents.forEach((content) =>
+        index.addDoc({
+            slug: content.slug.formatted,
+            title: content.frontmatter.title,
+            description: content.frontmatter.description,
+            tags: content.frontmatter.tags,
+            authors: content.frontmatter.authors.map((author) => author.name),
+        }),
+    );
+
+    return index;
+};

--- a/src/lib/content/search.ts
+++ b/src/lib/content/search.ts
@@ -1,15 +1,10 @@
 import { searchIndexFileName } from "@/lib/content/search-filename";
-import { SearchablePostFields } from "@/types/search/search";
-import elasticlunr from "elasticlunr";
 import fs from "fs";
 import path from "path";
 import crypto from "crypto";
-import { getPosts } from "./posts";
 import { Content } from "@/types/content/content";
-import { getAllContentFor } from "@/lib/content/content";
-import { getAllDataStructuresAndAlgorithmsTopics, getDataStructuresAndAlgorithmsRoadmap } from "./data-structures-and-algorithms";
-import { getAboutMe } from "./about-me";
 import { getIndexableContent } from "./indexable-content";
+import { createSearchIndex } from "./search-index-factory";
 
 const CACHE_FILE = ".search-index-cache";
 const cachePath = path.join(process.cwd(), CACHE_FILE);
@@ -55,37 +50,6 @@ const saveCachedHash = (hash: string): void => {
   }
 };
 
-const createSearchIndex = (contents: Content[]) => {
-  const index = elasticlunr<SearchablePostFields>(function () {
-    this.addField("title");
-    this.addField("description");
-    this.addField("tags");
-    this.addField("authors");
-    this.setRef("slug");
-  });
-
-  contents.forEach((post) =>
-    index.addDoc({
-      slug: post.slug.formatted,
-      title: post.frontmatter.title,
-      description: post.frontmatter.description,
-      tags: post.frontmatter.tags,
-      authors: post.frontmatter.authors.map((author) => author.name),
-    }),
-  );
-
-  contents.forEach((content) =>
-    index.addDoc({
-      slug: content.slug.formatted,
-      title: content.frontmatter.title,
-      description: content.frontmatter.description,
-      tags: content.frontmatter.tags,
-      authors: content.frontmatter.authors.map((author) => author.name),
-    }),
-  );
-
-  return index;
-};
 
 const generateAndSaveSearchIndex = () => {
   try {

--- a/src/lib/mcp/config.ts
+++ b/src/lib/mcp/config.ts
@@ -1,0 +1,1 @@
+export const MCP_SITE_URL = "https://fabrizioduroni.it";

--- a/src/lib/mcp/server.ts
+++ b/src/lib/mcp/server.ts
@@ -1,0 +1,27 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerSearchContent } from "@/lib/mcp/tools/register-search-content";
+import { registerListPosts } from "@/lib/mcp/tools/register-list-posts";
+import { registerGetPost } from "@/lib/mcp/tools/register-get-post";
+import { registerGetTags } from "@/lib/mcp/tools/register-get-tags";
+import { registerGetDsaTopics } from "@/lib/mcp/tools/register-get-dsa-topics";
+import { registerGetDsaExercises } from "@/lib/mcp/tools/register-get-dsa-exercises";
+import { registerGetAboutMe } from "@/lib/mcp/tools/register-get-about-me";
+import { registerGetSiteStats } from "@/lib/mcp/tools/register-get-site-stats";
+
+export const createMcpServer = (): McpServer => {
+    const server = new McpServer({
+        name: "chicio-portfolio",
+        version: "1.0.0",
+    });
+
+    registerSearchContent(server);
+    registerListPosts(server);
+    registerGetPost(server);
+    registerGetTags(server);
+    registerGetDsaTopics(server);
+    registerGetDsaExercises(server);
+    registerGetAboutMe(server);
+    registerGetSiteStats(server);
+
+    return server;
+};

--- a/src/lib/mcp/tools/register-get-about-me.ts
+++ b/src/lib/mcp/tools/register-get-about-me.ts
@@ -1,0 +1,27 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { getAboutMe } from "@/lib/content/about-me";
+
+export const registerGetAboutMe = (server: McpServer): void => {
+    server.registerTool(
+        "get_about_me",
+        {
+            title: "Get About Me",
+            description:
+                "Returns Fabrizio Duroni's full about me page content, including professional background, skills, and interests.",
+        },
+        async () => {
+            const aboutMe = getAboutMe();
+
+            const result = {
+                title: aboutMe.frontmatter.title,
+                description: aboutMe.frontmatter.description,
+                content: aboutMe.content,
+                url: "https://chicio.dev/about-me",
+            };
+
+            return {
+                content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
+            };
+        },
+    );
+};

--- a/src/lib/mcp/tools/register-get-about-me.ts
+++ b/src/lib/mcp/tools/register-get-about-me.ts
@@ -1,5 +1,6 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { getAboutMe } from "@/lib/content/about-me";
+import { MCP_SITE_URL } from "@/lib/mcp/config";
 
 export const registerGetAboutMe = (server: McpServer): void => {
     server.registerTool(
@@ -16,7 +17,7 @@ export const registerGetAboutMe = (server: McpServer): void => {
                 title: aboutMe.frontmatter.title,
                 description: aboutMe.frontmatter.description,
                 content: aboutMe.content,
-                url: "https://chicio.dev/about-me",
+                url: "${MCP_SITE_URL}/about-me",
             };
 
             return {

--- a/src/lib/mcp/tools/register-get-dsa-exercises.ts
+++ b/src/lib/mcp/tools/register-get-dsa-exercises.ts
@@ -1,0 +1,44 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import z from "zod";
+import { getAllExercises, getAllExercisesForTopic } from "@/lib/content/data-structures-and-algorithms";
+
+export const registerGetDsaExercises = (server: McpServer): void => {
+    server.registerTool(
+        "get_dsa_exercises",
+        {
+            title: "Get DSA Exercises",
+            description:
+                "Returns Data Structures and Algorithms exercises, optionally filtered by topic slug and/or difficulty. " +
+                "Get the topic slug from get_dsa_topics.",
+            inputSchema: {
+                topic: z.string().optional().describe("Topic slug to filter by (e.g. 'arrays', 'dynamic-programming')"),
+                difficulty: z
+                    .enum(["Easy", "Medium", "Hard"])
+                    .optional()
+                    .describe("Filter by difficulty level"),
+            },
+        },
+        async ({ topic, difficulty }) => {
+            const exercises = topic ? getAllExercisesForTopic(topic) : getAllExercises();
+            const filtered = difficulty
+                ? exercises.filter((e) => e.frontmatter.metadata?.difficulty === difficulty)
+                : exercises;
+
+            const result = filtered.map((exercise) => ({
+                title: exercise.frontmatter.title,
+                description: exercise.frontmatter.description,
+                topic: exercise.slug.params.topic,
+                exercise: exercise.slug.params.exercise,
+                difficulty: exercise.frontmatter.metadata?.difficulty,
+                technique: exercise.frontmatter.metadata?.technique,
+                leetcodeUrl: exercise.frontmatter.metadata?.leetcodeUrl,
+                date: exercise.frontmatter.date.formatted,
+                url: `https://chicio.dev${exercise.slug.formatted}`,
+            }));
+
+            return {
+                content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
+            };
+        },
+    );
+};

--- a/src/lib/mcp/tools/register-get-dsa-exercises.ts
+++ b/src/lib/mcp/tools/register-get-dsa-exercises.ts
@@ -1,6 +1,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import z from "zod";
 import { getAllExercises, getAllExercisesForTopic } from "@/lib/content/data-structures-and-algorithms";
+import { MCP_SITE_URL } from "@/lib/mcp/config";
 
 export const registerGetDsaExercises = (server: McpServer): void => {
     server.registerTool(
@@ -33,7 +34,7 @@ export const registerGetDsaExercises = (server: McpServer): void => {
                 technique: exercise.frontmatter.metadata?.technique,
                 leetcodeUrl: exercise.frontmatter.metadata?.leetcodeUrl,
                 date: exercise.frontmatter.date.formatted,
-                url: `https://chicio.dev${exercise.slug.formatted}`,
+                url: `${MCP_SITE_URL}${exercise.slug.formatted}`,
             }));
 
             return {

--- a/src/lib/mcp/tools/register-get-dsa-topics.ts
+++ b/src/lib/mcp/tools/register-get-dsa-topics.ts
@@ -1,0 +1,29 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { getAllDataStructuresAndAlgorithmsTopics } from "@/lib/content/data-structures-and-algorithms";
+
+export const registerGetDsaTopics = (server: McpServer): void => {
+    server.registerTool(
+        "get_dsa_topics",
+        {
+            title: "Get DSA Topics",
+            description:
+                "Returns all Data Structures and Algorithms learning topics in the portfolio, sorted by date. " +
+                "Each topic has exercises — use get_dsa_exercises with the topic slug to retrieve them.",
+        },
+        async () => {
+            const topics = getAllDataStructuresAndAlgorithmsTopics();
+
+            const result = topics.map((topic) => ({
+                title: topic.frontmatter.title,
+                description: topic.frontmatter.description,
+                slug: topic.slug.params.topic,
+                date: topic.frontmatter.date.formatted,
+                url: `https://chicio.dev${topic.slug.formatted}`,
+            }));
+
+            return {
+                content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
+            };
+        },
+    );
+};

--- a/src/lib/mcp/tools/register-get-dsa-topics.ts
+++ b/src/lib/mcp/tools/register-get-dsa-topics.ts
@@ -1,5 +1,6 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { getAllDataStructuresAndAlgorithmsTopics } from "@/lib/content/data-structures-and-algorithms";
+import { MCP_SITE_URL } from "@/lib/mcp/config";
 
 export const registerGetDsaTopics = (server: McpServer): void => {
     server.registerTool(
@@ -18,7 +19,7 @@ export const registerGetDsaTopics = (server: McpServer): void => {
                 description: topic.frontmatter.description,
                 slug: topic.slug.params.topic,
                 date: topic.frontmatter.date.formatted,
-                url: `https://chicio.dev${topic.slug.formatted}`,
+                url: `${MCP_SITE_URL}${topic.slug.formatted}`,
             }));
 
             return {

--- a/src/lib/mcp/tools/register-get-post.ts
+++ b/src/lib/mcp/tools/register-get-post.ts
@@ -1,0 +1,51 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import z from "zod";
+import { getPostBy } from "@/lib/content/posts";
+
+export const registerGetPost = (server: McpServer): void => {
+    server.registerTool(
+        "get_post",
+        {
+            title: "Get Blog Post",
+            description:
+                "Retrieve the full content and metadata of a specific blog post. " +
+                "Use the year, month, day, and slug values returned by list_posts.",
+            inputSchema: {
+                year: z.string().describe("Publication year (e.g. '2024')"),
+                month: z.string().describe("Publication month, zero-padded (e.g. '01')"),
+                day: z.string().describe("Publication day, zero-padded (e.g. '04')"),
+                slug: z.string().describe("Post slug (e.g. 'advent-of-typescript-2023-tic-tac-toe')"),
+            },
+        },
+        async ({ year, month, day, slug }) => {
+            const post = getPostBy({ year, month, day, slug });
+
+            if (!post) {
+                return {
+                    content: [
+                        {
+                            type: "text" as const,
+                            text: `Post not found: ${year}/${month}/${day}/${slug}`,
+                        },
+                    ],
+                    isError: true,
+                };
+            }
+
+            const result = {
+                title: post.frontmatter.title,
+                description: post.frontmatter.description,
+                tags: post.frontmatter.tags,
+                authors: post.frontmatter.authors.map((a) => a.name),
+                date: post.frontmatter.date.formatted,
+                readingTime: post.readingTime.text,
+                url: `https://chicio.dev${post.slug.formatted}`,
+                content: post.content,
+            };
+
+            return {
+                content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
+            };
+        },
+    );
+};

--- a/src/lib/mcp/tools/register-get-post.ts
+++ b/src/lib/mcp/tools/register-get-post.ts
@@ -1,6 +1,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import z from "zod";
 import { getPostBy } from "@/lib/content/posts";
+import { MCP_SITE_URL } from "@/lib/mcp/config";
 
 export const registerGetPost = (server: McpServer): void => {
     server.registerTool(
@@ -39,7 +40,7 @@ export const registerGetPost = (server: McpServer): void => {
                 authors: post.frontmatter.authors.map((a) => a.name),
                 date: post.frontmatter.date.formatted,
                 readingTime: post.readingTime.text,
-                url: `https://chicio.dev${post.slug.formatted}`,
+                url: `${MCP_SITE_URL}${post.slug.formatted}`,
                 content: post.content,
             };
 

--- a/src/lib/mcp/tools/register-get-site-stats.ts
+++ b/src/lib/mcp/tools/register-get-site-stats.ts
@@ -1,7 +1,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { getPosts } from "@/lib/content/posts";
+import { getPosts, getTags } from "@/lib/content/posts";
 import { getAllDataStructuresAndAlgorithmsTopics, getAllExercises } from "@/lib/content/data-structures-and-algorithms";
-import { getTags } from "@/lib/content/posts";
+import { MCP_SITE_URL } from "@/lib/mcp/config";
 
 export const registerGetSiteStats = (server: McpServer): void => {
     server.registerTool(
@@ -22,7 +22,7 @@ export const registerGetSiteStats = (server: McpServer): void => {
                 ? {
                       title: posts[0].frontmatter.title,
                       date: posts[0].frontmatter.date.formatted,
-                      url: `https://chicio.dev${posts[0].slug.formatted}`,
+                      url: `${MCP_SITE_URL}${posts[0].slug.formatted}`,
                   }
                 : null;
 

--- a/src/lib/mcp/tools/register-get-site-stats.ts
+++ b/src/lib/mcp/tools/register-get-site-stats.ts
@@ -1,0 +1,42 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { getPosts } from "@/lib/content/posts";
+import { getAllDataStructuresAndAlgorithmsTopics, getAllExercises } from "@/lib/content/data-structures-and-algorithms";
+import { getTags } from "@/lib/content/posts";
+
+export const registerGetSiteStats = (server: McpServer): void => {
+    server.registerTool(
+        "get_site_stats",
+        {
+            title: "Get Site Stats",
+            description:
+                "Returns aggregate statistics for the portfolio: total post count, tag count, DSA topic count, " +
+                "exercise count, and the most recent post.",
+        },
+        async () => {
+            const posts = getPosts();
+            const tags = getTags();
+            const topics = getAllDataStructuresAndAlgorithmsTopics();
+            const exercises = getAllExercises();
+
+            const latestPost = posts[0]
+                ? {
+                      title: posts[0].frontmatter.title,
+                      date: posts[0].frontmatter.date.formatted,
+                      url: `https://chicio.dev${posts[0].slug.formatted}`,
+                  }
+                : null;
+
+            const result = {
+                postsCount: posts.length,
+                tagsCount: tags.length,
+                dsaTopicsCount: topics.length,
+                dsaExercisesCount: exercises.length,
+                latestPost,
+            };
+
+            return {
+                content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
+            };
+        },
+    );
+};

--- a/src/lib/mcp/tools/register-get-tags.ts
+++ b/src/lib/mcp/tools/register-get-tags.ts
@@ -1,0 +1,26 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { getTags } from "@/lib/content/posts";
+
+export const registerGetTags = (server: McpServer): void => {
+    server.registerTool(
+        "get_tags",
+        {
+            title: "Get All Tags",
+            description:
+                "Returns all blog post tags with their post counts, sorted alphabetically. " +
+                "Use a tag value with list_posts to filter posts by topic.",
+        },
+        async () => {
+            const tags = getTags();
+
+            const result = tags.map((tag) => ({
+                tag: tag.tagValue,
+                count: tag.count,
+            }));
+
+            return {
+                content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
+            };
+        },
+    );
+};

--- a/src/lib/mcp/tools/register-list-posts.ts
+++ b/src/lib/mcp/tools/register-list-posts.ts
@@ -1,6 +1,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import z from "zod";
 import { getPosts, getPostsForTag } from "@/lib/content/posts";
+import { MCP_SITE_URL } from "@/lib/mcp/config";
 
 export const registerListPosts = (server: McpServer): void => {
     server.registerTool(
@@ -29,7 +30,7 @@ export const registerListPosts = (server: McpServer): void => {
                 day: post.slug.params.day,
                 slug: post.slug.params.slug,
                 readingTime: post.readingTime.text,
-                url: `https://chicio.dev${post.slug.formatted}`,
+                url: `${MCP_SITE_URL}${post.slug.formatted}`,
             }));
 
             return {

--- a/src/lib/mcp/tools/register-list-posts.ts
+++ b/src/lib/mcp/tools/register-list-posts.ts
@@ -1,0 +1,40 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import z from "zod";
+import { getPosts, getPostsForTag } from "@/lib/content/posts";
+
+export const registerListPosts = (server: McpServer): void => {
+    server.registerTool(
+        "list_posts",
+        {
+            title: "List Blog Posts",
+            description:
+                "List blog posts, optionally filtered by tag. Returns post summaries sorted by date (newest first). " +
+                "Each result includes the year, month, day, and slug required to call get_post.",
+            inputSchema: {
+                tag: z.string().optional().describe("Filter posts by tag (case-sensitive, e.g. 'react', 'typescript')"),
+                limit: z.number().optional().describe("Maximum number of posts to return (default: 20, max: 50)"),
+            },
+        },
+        async ({ tag, limit }) => {
+            const safeLimit = Math.min(limit ?? 20, 50);
+            const posts = tag ? getPostsForTag(tag) : getPosts();
+
+            const results = posts.slice(0, safeLimit).map((post) => ({
+                title: post.frontmatter.title,
+                description: post.frontmatter.description,
+                tags: post.frontmatter.tags,
+                date: post.frontmatter.date.formatted,
+                year: post.slug.params.year,
+                month: post.slug.params.month,
+                day: post.slug.params.day,
+                slug: post.slug.params.slug,
+                readingTime: post.readingTime.text,
+                url: `https://chicio.dev${post.slug.formatted}`,
+            }));
+
+            return {
+                content: [{ type: "text" as const, text: JSON.stringify(results, null, 2) }],
+            };
+        },
+    );
+};

--- a/src/lib/mcp/tools/register-search-content.ts
+++ b/src/lib/mcp/tools/register-search-content.ts
@@ -1,10 +1,39 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import elasticlunr from "elasticlunr";
-import fs from "fs";
-import path from "path";
 import z from "zod";
-import { searchIndexFileName } from "@/lib/content/search-filename";
 import { SearchablePostFields } from "@/types/search/search";
+import { getPosts } from "@/lib/content/posts";
+import { getAllDataStructuresAndAlgorithmsTopics, getAllExercises } from "@/lib/content/data-structures-and-algorithms";
+import { getAboutMe } from "@/lib/content/about-me";
+
+const buildSearchIndex = (): elasticlunr.Index<SearchablePostFields> => {
+    const index = elasticlunr<SearchablePostFields>(function () {
+        this.addField("title");
+        this.addField("description");
+        this.addField("tags");
+        this.addField("authors");
+        this.setRef("slug");
+    });
+
+    const allContent = [
+        ...getPosts(),
+        ...getAllDataStructuresAndAlgorithmsTopics(),
+        ...getAllExercises(),
+        getAboutMe(),
+    ];
+
+    allContent.forEach((content) => {
+        index.addDoc({
+            slug: content.slug.formatted,
+            title: content.frontmatter.title,
+            description: content.frontmatter.description,
+            tags: content.frontmatter.tags,
+            authors: content.frontmatter.authors.map((a) => a.name),
+        });
+    });
+
+    return index;
+};
 
 export const registerSearchContent = (server: McpServer): void => {
     server.registerTool(
@@ -25,10 +54,7 @@ export const registerSearchContent = (server: McpServer): void => {
         async ({ query, limit }) => {
             const safeLimit = Math.min(limit ?? 10, 30);
             try {
-                const indexPath = path.join(process.cwd(), "public", searchIndexFileName);
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                const indexData = JSON.parse(fs.readFileSync(indexPath, "utf8")) as any;
-                const index = elasticlunr.Index.load<SearchablePostFields>(indexData);
+                const index = buildSearchIndex();
 
                 const results = index.search(query, {
                     fields: {

--- a/src/lib/mcp/tools/register-search-content.ts
+++ b/src/lib/mcp/tools/register-search-content.ts
@@ -1,39 +1,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import elasticlunr from "elasticlunr";
 import z from "zod";
-import { SearchablePostFields } from "@/types/search/search";
-import { getPosts } from "@/lib/content/posts";
-import { getAllDataStructuresAndAlgorithmsTopics, getAllExercises } from "@/lib/content/data-structures-and-algorithms";
-import { getAboutMe } from "@/lib/content/about-me";
-
-const buildSearchIndex = (): elasticlunr.Index<SearchablePostFields> => {
-    const index = elasticlunr<SearchablePostFields>(function () {
-        this.addField("title");
-        this.addField("description");
-        this.addField("tags");
-        this.addField("authors");
-        this.setRef("slug");
-    });
-
-    const allContent = [
-        ...getPosts(),
-        ...getAllDataStructuresAndAlgorithmsTopics(),
-        ...getAllExercises(),
-        getAboutMe(),
-    ];
-
-    allContent.forEach((content) => {
-        index.addDoc({
-            slug: content.slug.formatted,
-            title: content.frontmatter.title,
-            description: content.frontmatter.description,
-            tags: content.frontmatter.tags,
-            authors: content.frontmatter.authors.map((a) => a.name),
-        });
-    });
-
-    return index;
-};
+import { createSearchIndex } from "@/lib/content/search-index-factory";
+import { getIndexableContent } from "@/lib/content/indexable-content";
 
 export const registerSearchContent = (server: McpServer): void => {
     server.registerTool(
@@ -54,7 +22,7 @@ export const registerSearchContent = (server: McpServer): void => {
         async ({ query, limit }) => {
             const safeLimit = Math.min(limit ?? 10, 30);
             try {
-                const index = buildSearchIndex();
+                const index = createSearchIndex(getIndexableContent());
 
                 const results = index.search(query, {
                     fields: {

--- a/src/lib/mcp/tools/register-search-content.ts
+++ b/src/lib/mcp/tools/register-search-content.ts
@@ -1,0 +1,69 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import elasticlunr from "elasticlunr";
+import fs from "fs";
+import path from "path";
+import z from "zod";
+import { searchIndexFileName } from "@/lib/content/search-filename";
+import { SearchablePostFields } from "@/types/search/search";
+
+export const registerSearchContent = (server: McpServer): void => {
+    server.registerTool(
+        "search_content",
+        {
+            title: "Search Portfolio Content",
+            description:
+                "Keyword search across all portfolio content: blog posts, DSA topics and exercises, about me. " +
+                "Returns matching items with their slug, title, description, and tags.",
+            inputSchema: {
+                query: z.string().describe("Search query text"),
+                limit: z
+                    .number()
+                    .optional()
+                    .describe("Maximum number of results to return (default: 10, max: 30)"),
+            },
+        },
+        async ({ query, limit }) => {
+            const safeLimit = Math.min(limit ?? 10, 30);
+            try {
+                const indexPath = path.join(process.cwd(), "public", searchIndexFileName);
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                const indexData = JSON.parse(fs.readFileSync(indexPath, "utf8")) as any;
+                const index = elasticlunr.Index.load<SearchablePostFields>(indexData);
+
+                const results = index.search(query, {
+                    fields: {
+                        title: { boost: 3 },
+                        description: { boost: 2 },
+                        tags: { boost: 1 },
+                    },
+                    expand: true,
+                });
+
+                const enriched = results.slice(0, safeLimit).map((result) => {
+                    const doc = index.documentStore.getDoc(result.ref);
+                    return {
+                        slug: result.ref,
+                        title: doc.title,
+                        description: doc.description,
+                        tags: doc.tags,
+                        score: result.score,
+                    };
+                });
+
+                return {
+                    content: [{ type: "text" as const, text: JSON.stringify(enriched, null, 2) }],
+                };
+            } catch (error) {
+                return {
+                    content: [
+                        {
+                            type: "text" as const,
+                            text: `Search failed: ${error instanceof Error ? error.message : String(error)}`,
+                        },
+                    ],
+                    isError: true,
+                };
+            }
+        },
+    );
+};


### PR DESCRIPTION
Add a public Model Context Protocol (MCP) server at `/api/mcp`, exposing portfolio content as AI-readable tools.

## Description
- New route `src/app/api/mcp/route.ts` — stateless GET/POST/DELETE/OPTIONS handler with CORS headers
- `src/lib/mcp/server.ts` — `createMcpServer()` factory wiring 8 tools
- 8 tools in `src/lib/mcp/tools/`:
  - `search_content(query, limit?)` — full-text search via elasticlunr (built at request time)
  - `list_posts(tag?, limit?)` — blog post listing with optional tag filter
  - `get_post(year, month, day, slug)` — single post retrieval
  - `get_tags()` — all blog tags
  - `get_dsa_topics()` — DSA topic list
  - `get_dsa_exercises(topic?, difficulty?)` — DSA exercise listing with filters
  - `get_about_me()` — full about-me content
  - `get_site_stats()` — aggregate statistics (posts, tags, DSA topics/exercises, latest post)
- `src/lib/mcp/config.ts` — centralised `MCP_SITE_URL = "https://fabrizioduroni.it"`
- `src/lib/content/search-index-factory.ts` — extracted `createSearchIndex()` to a shared factory (also fixed a pre-existing duplicate-document bug in the original `search.ts`)
- `src/app/.well-known/oauth-protected-resource/route.ts` — RFC 9728 metadata endpoint returning `authorization_servers: []`, which tells MCP clients (mcp-remote, MCP Inspector, claude.ai Custom Connectors) that the server is public and requires no OAuth flow
- `outputFileTracingExcludes` added to `next.config.ts` to prevent `public/images/` from bloating the `/api/mcp` serverless bundle (was 1.63GB → well under 300MB limit)

## Motivation and Context
Enables AI assistants (Claude, Cursor, etc.) to query the portfolio directly — reading blog posts, finding DSA exercises, or checking stats — without scraping. The server is stateless (no session IDs) which is both required for Vercel serverless and semantically correct for these read-only tools.

## Connect via claude.ai (recommended)
Settings → Connectors → Add custom connector → `https://fabrizioduroni.it/api/mcp`

## Connect via Claude Desktop (mcp-remote bridge)
```json
{
  "mcpServers": {
    "chicio-portfolio": {
      "command": "npx",
      "args": ["mcp-remote", "https://fabrizioduroni.it/api/mcp"]
    }
  }
}
```

## How Has This Been Tested?
Browser + MCP Inspector (proxy mode) + `npm run build`

## Types of changes
- [x] New feature :sparkles: (non-breaking change which adds functionality)

## Checklist:
- [X] My code follows the code style of this project :beers:.
- [X] My change requires a change to the documentation :bulb: and I have updated the documentation accordingly.
- [X] I have read the [CONTRIBUTING](https://github.com/chicio/chicio-blog/blob/master/CONTRIBUTING.md) document :busts_in_silhouette:.
- [X] I have added tests to cover my changes :tada:.
- [X] All new and existing tests passed :white_check_mark:.