### PR TITLE
fix(ux): :bug: reset command palette selection when search results update

### DIFF
--- a/src/components/design-system/organism/command-palette/command-palette.tsx
+++ b/src/components/design-system/organism/command-palette/command-palette.tsx
@@ -32,6 +32,7 @@ const GroupLabel: FC<PropsWithChildren> = ({ children }) => (
 const CommandPalette = () => {
     const [open, setOpen] = useState(false);
     const [isSearching, setIsSearching] = useState(false);
+    const [selectedValue, setSelectedValue] = useState("");
 
     const router = useRouter();
     const { glassmorphismClass } = useGlassmorphism({ noScale: true });
@@ -58,7 +59,7 @@ const CommandPalette = () => {
                 action: tracking.action.command_palette_open,
             });
         };
-        
+
         window.addEventListener("keydown", handleKeyDown, true);
         window.addEventListener(commandPaletteOpenEvent, handleOpenEvent);
 
@@ -71,10 +72,10 @@ const CommandPalette = () => {
     useEffect(() => {
         if (!open) {
             return;
-        } 
+        }
 
         const handleEsc = (e: KeyboardEvent) => {
-            if (e.key === "Escape") { 
+            if (e.key === "Escape") {
                 close();
             }
         };
@@ -83,6 +84,10 @@ const CommandPalette = () => {
 
         return () => window.removeEventListener("keydown", handleEsc, true);
     }, [open, close]);
+
+    useEffect(() => {
+        setSelectedValue("");
+    }, [search]);
 
     const handleOpenChat = () => {
         trackWith({
@@ -106,7 +111,7 @@ const CommandPalette = () => {
 
     const hasSearchResults = search.type === "search" && search.results.length > 0;
 
-    if (!open) { 
+    if (!open) {
         return null;
     }
 
@@ -123,7 +128,12 @@ const CommandPalette = () => {
                         transition={{ duration: 0.15, ease: "easeOut" }}
                         onClick={(e) => e.stopPropagation()}
                     >
-                        <Command shouldFilter={false} className="flex flex-col">
+                        <Command
+                            shouldFilter={false}
+                            className="flex flex-col"
+                            value={selectedValue}
+                            onValueChange={setSelectedValue}
+                        >
                             <div className="flex items-center gap-2 px-4 py-3 border-b border-accent/20">
                                 <span className="text-accent font-mono font-bold text-sm text-shadow-md shrink-0">
                                     {">"}
@@ -141,10 +151,7 @@ const CommandPalette = () => {
                                 />
                             </div>
 
-                            <Command.List
-                                key={isSearching ? "search" : "idle"}
-                                className="max-h-[55vh] overflow-y-auto py-2"
-                            >
+                            <Command.List className="max-h-[55vh] overflow-y-auto py-2">
                                 {isSearching && hasSearchResults && (
                                     <Command.Group>
                                         <GroupLabel>Content</GroupLabel>


### PR DESCRIPTION
Reset command palette highlighted item to the first result whenever search results change while typing.

## Description
- Added `selectedValue` state (`useState("")`) to control cmdk's internal selection
- Added `useEffect` with `[search]` dependency that resets `selectedValue` to `""` on every result change — empty string tells cmdk to auto-select the first visible item
- Passed `value={selectedValue}` and `onValueChange={setSelectedValue}` to `<Command>` to make it fully controlled
- Removed the `key={isSearching ? "search" : "idle"}` prop from `<Command.List>` — the controlled value approach handles both search/idle transitions and mid-search result changes, so the remount workaround is no longer needed

## Motivation and Context
With `shouldFilter={false}` (elasticlunr owns filtering), cmdk preserved its internal selection across result set changes. Typing another character would update results but leave the highlight pointing at wherever the previously-selected title appeared in the new list, causing unexpected scroll jumps. The controlled value pattern is the correct cmdk API for this scenario.

## How Has This Been Tested?
Browser

## Types of changes
- [x] Bug fix :bug: (non-breaking change which fixes an issue)
- [ ] New feature :sparkles: (non-breaking change which adds functionality)
- [ ] Breaking change :boom: (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project :beers:.
- [X] My change requires a change to the documentation :bulb: and I have updated the documentation accordingly.
- [X] I have read the [CONTRIBUTING](https://github.com/chicio/chicio-blog/blob/master/CONTRIBUTING.md) document :busts_in_silhouette:.
- [X] I have added tests to cover my changes :tada:.
- [X] All new and existing tests passed :white_check_mark:.