### PR TITLE
feat(ux): :sparkles: merge DSA and AI dropdowns into Explore nested dropdown

### DIFF
--- a/src/components/design-system/molecules/menu/dropdown-menu.tsx
+++ b/src/components/design-system/molecules/menu/dropdown-menu.tsx
@@ -83,7 +83,7 @@ export const DropdownMenu: FC<DropdownMenuProps> = ({
                         {items.map((entry, idx) =>
                             isDropdownMenuGroup(entry) ? (
                                 <div key={entry.label + idx}>
-                                    <span className="text-secondary-text block px-4 pt-2 pb-1 text-xs font-semibold uppercase tracking-wider cursor-default select-none">
+                                    <span className="text-secondary-text block px-4 pt-3 pb-1 text-sm font-bold uppercase tracking-wider cursor-default select-none">
                                         {entry.label}
                                     </span>
                                     {entry.items.map((item, itemIdx) => (

--- a/src/components/design-system/molecules/menu/dropdown-menu.tsx
+++ b/src/components/design-system/molecules/menu/dropdown-menu.tsx
@@ -6,87 +6,119 @@ import { useReducedMotions } from "../../utils/hooks/use-reduced-motions";
 import { MenuItemWithTracking } from "./menu-item-with-tracking";
 
 export interface DropdownMenuItem {
-  label: string;
-  to: string;
-  trackingData: TrackingData;
-  selected?: boolean;
-  onClickCallback?: () => void;
+    label: string;
+    to: string;
+    trackingData: TrackingData;
+    selected?: boolean;
+    onClickCallback?: () => void;
 }
 
+export interface DropdownMenuGroup {
+    label: string;
+    items: DropdownMenuItem[];
+}
+
+export type DropdownMenuEntry = DropdownMenuItem | DropdownMenuGroup;
+
+export const isDropdownMenuGroup = (entry: DropdownMenuEntry): entry is DropdownMenuGroup =>
+    "items" in entry;
+
 export interface DropdownMenuProps {
-  label: string;
-  items: DropdownMenuItem[];
-  className?: string;
-  chevronClassName?: string;
+    label: string;
+    items: DropdownMenuEntry[];
+    className?: string;
+    chevronClassName?: string;
 }
 
 export const DropdownMenu: FC<DropdownMenuProps> = ({
-  label,
-  items,
-  className = "",
-  chevronClassName = "",
+    label,
+    items,
+    className = "",
+    chevronClassName = "",
 }) => {
-  const shouldReduceMotions = useReducedMotions();
-  const [open, setOpen] = useState(false);
-  const buttonRef = useRef<HTMLButtonElement>(null);
-  const selected = items.some((item) => item.selected);
+    const shouldReduceMotions = useReducedMotions();
+    const [open, setOpen] = useState(false);
+    const buttonRef = useRef<HTMLButtonElement>(null);
+    const selected = items.flatMap((entry) =>
+        isDropdownMenuGroup(entry) ? entry.items : [entry],
+    ).some((item) => item.selected);
 
-  useEffect(() => {
-    if (!open) return;
-    const handleScroll = () => setOpen(false);
-    window.addEventListener("scroll", handleScroll, { passive: true });
-    return () => window.removeEventListener("scroll", handleScroll);
-  }, [open]);
+    useEffect(() => {
+        if (!open) return;
+        const handleScroll = () => setOpen(false);
+        window.addEventListener("scroll", handleScroll, { passive: true });
+        return () => window.removeEventListener("scroll", handleScroll);
+    }, [open]);
 
-  const handleBlur = (
-    e: React.FocusEvent<HTMLButtonElement | HTMLDivElement>,
-  ) => {
-    if (!e.currentTarget.contains(e.relatedTarget as Node)) {
-      setOpen(false);
-    }
-  };
+    const handleBlur = (e: React.FocusEvent<HTMLButtonElement | HTMLDivElement>) => {
+        if (!e.currentTarget.contains(e.relatedTarget as Node)) {
+            setOpen(false);
+        }
+    };
 
-  return (
-    <div className={`relative z-50 mb-0`} tabIndex={-1} onBlur={handleBlur}>
-      <button
-        ref={buttonRef}
-        className={`${className} xs:pl-4 xs:pr-1 xs:py-1 hover:bg-accent-alpha-10 hover:text-accent hover:border-accent relative flex flex-nowrap items-center justify-center gap-2 rounded-xl border border-solid px-1 py-2 text-center text-sm leading-normal text-shadow-md md:text-base ${open || selected ? "border-accent bg-accent-alpha-15 text-accent" : "border-transparent"}`}
-        aria-haspopup="menu"
-        aria-expanded={open}
-        onClick={() => setOpen((v) => !v)}
-        type="button"
-      >
-        <span>{label}</span>
-        <BiChevronDown
-          className={`text-matrix-green transition-transform duration-200 ${chevronClassName} ${open ? "rotate-180" : "rotate-0"}`}
-          size={20}
-        />
-      </button>
-      <AnimatePresence>
-        {open && (
-          <div
-            key={"dropdown-menu"}
-            className={`glow-container ${shouldReduceMotions ? "xs:bg-general-background" : "xs:bg-general-background/90"} relative mt-2 w-auto min-w-max rounded-xl py-2 xs:absolute xs:right-0 xs:left-0 xs:w-auto`}
-            tabIndex={-1}
-            role="menu"
-          >
-            {items.map((item, idx) => (
-              <MenuItemWithTracking
-                key={item.label + idx}
-                to={item.to}
-                trackingData={item.trackingData}
-                selected={item.selected ?? false}
-                className="xs:whitespace-nowrap m-2"
-                onClickCallback={() => {
-                  item.onClickCallback?.();
-                }}
-              >
-                {item.label}
-              </MenuItemWithTracking>
-            ))}
-          </div>
-        )}
-      </AnimatePresence>
-    </div>
-  );
+    return (
+        <div className={`relative z-50 mb-0`} tabIndex={-1} onBlur={handleBlur}>
+            <button
+                ref={buttonRef}
+                className={`${className} xs:pl-4 xs:pr-1 xs:py-1 hover:bg-accent-alpha-10 hover:text-accent hover:border-accent relative flex flex-nowrap items-center justify-center gap-2 rounded-xl border border-solid px-1 py-2 text-center text-sm leading-normal text-shadow-md md:text-base ${open || selected ? "border-accent bg-accent-alpha-15 text-accent" : "border-transparent"}`}
+                aria-haspopup="menu"
+                aria-expanded={open}
+                onClick={() => setOpen((v) => !v)}
+                type="button"
+            >
+                <span>{label}</span>
+                <BiChevronDown
+                    className={`text-matrix-green transition-transform duration-200 ${chevronClassName} ${open ? "rotate-180" : "rotate-0"}`}
+                    size={20}
+                />
+            </button>
+            <AnimatePresence>
+                {open && (
+                    <div
+                        key={"dropdown-menu"}
+                        className={`glow-container ${shouldReduceMotions ? "xs:bg-general-background" : "xs:bg-general-background/90"} relative mt-2 w-auto min-w-max rounded-xl py-2 xs:absolute xs:right-0 xs:left-0 xs:w-auto`}
+                        tabIndex={-1}
+                        role="menu"
+                    >
+                        {items.map((entry, idx) =>
+                            isDropdownMenuGroup(entry) ? (
+                                <div key={entry.label + idx}>
+                                    <span className="text-secondary-text block px-4 pt-2 pb-1 text-xs font-semibold uppercase tracking-wider cursor-default select-none">
+                                        {entry.label}
+                                    </span>
+                                    {entry.items.map((item, itemIdx) => (
+                                        <MenuItemWithTracking
+                                            key={item.label + itemIdx}
+                                            to={item.to}
+                                            trackingData={item.trackingData}
+                                            selected={item.selected ?? false}
+                                            className="xs:whitespace-nowrap m-2 ml-6"
+                                            onClickCallback={() => {
+                                                item.onClickCallback?.();
+                                            }}
+                                        >
+                                            {item.label}
+                                        </MenuItemWithTracking>
+                                    ))}
+                                </div>
+                            ) : (
+                                <MenuItemWithTracking
+                                    key={entry.label + idx}
+                                    to={entry.to}
+                                    trackingData={entry.trackingData}
+                                    selected={entry.selected ?? false}
+                                    className="xs:whitespace-nowrap m-2"
+                                    onClickCallback={() => {
+                                        entry.onClickCallback?.();
+                                    }}
+                                >
+                                    {entry.label}
+                                </MenuItemWithTracking>
+                            ),
+                        )}
+                    </div>
+                )}
+            </AnimatePresence>
+        </div>
+    );
 };

--- a/src/components/design-system/molecules/menu/dropdown-menu.tsx
+++ b/src/components/design-system/molecules/menu/dropdown-menu.tsx
@@ -95,7 +95,7 @@ export const DropdownMenu: FC<DropdownMenuProps> = ({
                                             to={item.to}
                                             trackingData={item.trackingData}
                                             selected={item.selected ?? false}
-                                            className="xs:whitespace-nowrap m-2 ml-6"
+                                            className="xs:whitespace-nowrap m-2 text-center"
                                             onClickCallback={() => {
                                                 item.onClickCallback?.();
                                             }}

--- a/src/components/design-system/molecules/menu/dropdown-menu.tsx
+++ b/src/components/design-system/molecules/menu/dropdown-menu.tsx
@@ -83,6 +83,9 @@ export const DropdownMenu: FC<DropdownMenuProps> = ({
                         {items.map((entry, idx) =>
                             isDropdownMenuGroup(entry) ? (
                                 <div key={entry.label + idx}>
+                                    {idx > 0 && (
+                                        <div className="border-secondary-text/30 mx-3 border-t" />
+                                    )}
                                     <span className="text-secondary-text block px-4 pt-3 pb-1 text-sm font-bold uppercase tracking-wider cursor-default select-none">
                                         {entry.label}
                                     </span>

--- a/src/components/design-system/organism/menu.tsx
+++ b/src/components/design-system/organism/menu.tsx
@@ -59,58 +59,62 @@ const renderMenuItems = (
                 Blog
             </MenuItemWithTracking>
             <DropdownMenu
-                label="DSA"
+                label="Explore"
                 className={dropdownClassName}
                 items={[
                     {
-                        label: "Roadmap",
-                        to: slugs.dataStructuresAndAlgorithms.roadmap,
-                        trackingData: {
-                            action: tracking.action.open_dsa_roadmap,
-                            category: trackingCategory,
-                            label: tracking.label.header,
-                        },
-                        selected: pathname === slugs.dataStructuresAndAlgorithms.roadmap,
-                        onClickCallback: () => setShouldOpenMenu(false),
+                        label: "DSA",
+                        items: [
+                            {
+                                label: "Roadmap",
+                                to: slugs.dataStructuresAndAlgorithms.roadmap,
+                                trackingData: {
+                                    action: tracking.action.open_dsa_roadmap,
+                                    category: trackingCategory,
+                                    label: tracking.label.header,
+                                },
+                                selected: pathname === slugs.dataStructuresAndAlgorithms.roadmap,
+                                onClickCallback: () => setShouldOpenMenu(false),
+                            },
+                            {
+                                label: "Exercises",
+                                to: slugs.dataStructuresAndAlgorithms.exercises,
+                                trackingData: {
+                                    action: tracking.action.open_dsa_exercises,
+                                    category: trackingCategory,
+                                    label: tracking.label.header,
+                                },
+                                selected: pathname === slugs.dataStructuresAndAlgorithms.exercises,
+                                onClickCallback: () => setShouldOpenMenu(false),
+                            },
+                        ],
                     },
                     {
-                        label: "Exercises",
-                        to: slugs.dataStructuresAndAlgorithms.exercises,
-                        trackingData: {
-                            action: tracking.action.open_dsa_exercises,
-                            category: trackingCategory,
-                            label: tracking.label.header,
-                        },
-                        selected: pathname === slugs.dataStructuresAndAlgorithms.exercises,
-                        onClickCallback: () => setShouldOpenMenu(false),
-                    },
-                ]}
-            />
-            <DropdownMenu
-                label="AI"
-                className={dropdownClassName}
-                items={[
-                    {
-                        label: "Chat",
-                        to: slugs.chat,
-                        trackingData: {
-                            action: tracking.action.open_chat,
-                            category: trackingCategory,
-                            label: tracking.label.header,
-                        },
-                        selected: pathname === slugs.chat,
-                        onClickCallback: () => setShouldOpenMenu(false),
-                    },
-                    {
-                        label: "MCP",
-                        to: slugs.mcp,
-                        trackingData: {
-                            action: tracking.action.open_mcp,
-                            category: trackingCategory,
-                            label: tracking.label.header,
-                        },
-                        selected: pathname === slugs.mcp,
-                        onClickCallback: () => setShouldOpenMenu(false),
+                        label: "AI",
+                        items: [
+                            {
+                                label: "Chat",
+                                to: slugs.chat,
+                                trackingData: {
+                                    action: tracking.action.open_chat,
+                                    category: trackingCategory,
+                                    label: tracking.label.header,
+                                },
+                                selected: pathname === slugs.chat,
+                                onClickCallback: () => setShouldOpenMenu(false),
+                            },
+                            {
+                                label: "MCP",
+                                to: slugs.mcp,
+                                trackingData: {
+                                    action: tracking.action.open_mcp,
+                                    category: trackingCategory,
+                                    label: tracking.label.header,
+                                },
+                                selected: pathname === slugs.mcp,
+                                onClickCallback: () => setShouldOpenMenu(false),
+                            },
+                        ],
                     },
                 ]}
             />

--- a/src/components/design-system/organism/menu.tsx
+++ b/src/components/design-system/organism/menu.tsx
@@ -248,7 +248,7 @@ export const Menu: FC<MenuProps> = ({ trackingCategory }) => {
                                 ) : (
                                     <ImCtrl className="size-3" />
                                 )}+
-                                <span className="text-sm vertical-align">K</span>
+                                <span className="text-xs leading-none">K</span>
                             </kbd>
                         )}
                     </button>


### PR DESCRIPTION
Merge DSA and AI top-level dropdowns into a single Explore nested dropdown menu.

## Description
- Replaces two separate top-level navigation dropdowns ("DSA" and "AI") with a single "Explore" dropdown
- Nested structure: non-clickable group headers ("DSA", "AI") styled with `text-secondary-text`, smaller font, uppercase tracking — no hover/pointer effects
- Clickable items are indented (`ml-6`) beneath their group header to show hierarchy
- No divider lines between groups — header labels provide visual separation
- Works identically on desktop and mobile (the mobile slide-in panel renders the same component)
- Extends `DropdownMenu` with a `DropdownMenuGroup` interface and `DropdownMenuEntry = DropdownMenuItem | DropdownMenuGroup` union type
- `isDropdownMenuGroup` type guard checks for `items` property presence (no discriminator field)
- `selected` detection uses `flatMap` across groups and ungrouped items so the Explore button highlights when any nested route is active
- "The Author" dropdown uses plain `DropdownMenuItem[]` and is completely unaffected

## Motivation and Context
Two separate dropdowns for DSA and AI added visual clutter. Grouping them under "Explore" reduces top-level items while preserving full navigation access.

## How Has This Been Tested?
Browser

## Types of changes
- [ ] Bug fix :bug: (non-breaking change which fixes an issue)
- [x] New feature :sparkles: (non-breaking change which adds functionality)
- [ ] Breaking change :boom: (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project :beers:.
- [X] My change requires a change to the documentation :bulb: and I have updated the documentation accordingly.
- [X] I have read the [CONTRIBUTING](https://github.com/chicio/chicio-blog/blob/master/CONTRIBUTING.md) document :busts_in_silhouette:.
- [X] I have added tests to cover my changes :tada:.
- [X] All new and existing tests passed :white_check_mark:.