### PR TITLE
feat(capabilities): :sparkles: add matrix-rain-webgpu to explore menu and projects

### DIFF
--- a/src/components/design-system/molecules/menu/dropdown-menu/dropdown-menu.tsx
+++ b/src/components/design-system/molecules/menu/dropdown-menu/dropdown-menu.tsx
@@ -13,6 +13,7 @@ interface DropdownMenuItem {
     trackingData: TrackingData;
     selected?: boolean;
     onClickCallback?: () => void;
+    external?: boolean;
 }
 
 interface DropdownMenuGroup {
@@ -86,6 +87,7 @@ export const DropdownMenu: FC<DropdownMenuProps> = ({
                                             selected={item.selected ?? false}
                                             className="xs:whitespace-nowrap m-2 text-center"
                                             onClickCallback={handleItemClick(item.onClickCallback)}
+                                            external={item.external}
                                         >
                                             {item.label}
                                         </MenuItemWithTracking>
@@ -99,6 +101,7 @@ export const DropdownMenu: FC<DropdownMenuProps> = ({
                                     selected={entry.selected ?? false}
                                     className="xs:whitespace-nowrap m-2"
                                     onClickCallback={handleItemClick(entry.onClickCallback)}
+                                    external={entry.external}
                                 >
                                     {entry.label}
                                 </MenuItemWithTracking>

--- a/src/components/design-system/molecules/menu/menu-item-with-tracking/menu-item-with-tracking.tsx
+++ b/src/components/design-system/molecules/menu/menu-item-with-tracking/menu-item-with-tracking.tsx
@@ -11,6 +11,7 @@ type MenuItemWithTrackingProps = TrackingElementProps & {
     children?: ReactNode;
     className?: string;
     onClickCallback?: () => void;
+    external?: boolean;
 };
 
 export const MenuItemWithTracking: FC<MenuItemWithTrackingProps> = ({
@@ -20,6 +21,7 @@ export const MenuItemWithTracking: FC<MenuItemWithTrackingProps> = ({
     trackingData,
     selected,
     onClickCallback,
+    external,
 }) => {
     const { effects } = useMenuItemWithTrackingStore();
     const { handleClick } = effects;
@@ -32,12 +34,27 @@ export const MenuItemWithTracking: FC<MenuItemWithTrackingProps> = ({
     const flex = "flex items-center justify-center";
     const background = selected ? "bg-accent-alpha-15" : "transparent";
     const hover = `hover:bg-accent-alpha-10 hover:text-accent hover:border-accent hover:transition-all hover:duration-300 hover:translate-y-[-1px] hover:shadow-lg`;
+    const composedClassName = `relative ${transition} ${color} ${spacing} ${text} ${border} ${flex} ${background} ${hover}${className ? ` ${className}` : ""}`;
+
+    if (external) {
+        return (
+            <a
+                href={to}
+                target="_blank"
+                rel="noopener noreferrer"
+                className={composedClassName}
+                onClick={handleClick(trackingData, onClickCallback)}
+            >
+                {children}
+            </a>
+        );
+    }
 
     return (
         <Link
             href={to}
             prefetch={false}
-            className={`relative ${transition} ${color} ${spacing} ${text} ${border} ${flex} ${background} ${hover}${className ? ` ${className}` : ""}`}
+            className={composedClassName}
             onClick={handleClick(trackingData, onClickCallback)}
         >
             {children}

--- a/src/components/design-system/organism/menu.tsx
+++ b/src/components/design-system/organism/menu.tsx
@@ -116,6 +116,22 @@ const renderMenuItems = (
                             },
                         ],
                     },
+                    {
+                        label: "Computer Graphics",
+                        items: [
+                            {
+                                label: "Matrix Rain",
+                                to: "https://chicio.github.io/matrix-rain-webgpu/",
+                                external: true,
+                                trackingData: {
+                                    action: tracking.action.open_matrix_rain_webgpu,
+                                    category: trackingCategory,
+                                    label: tracking.label.header,
+                                },
+                                onClickCallback: () => setShouldOpenMenu(false),
+                            },
+                        ],
+                    },
                 ]}
             />
             <DropdownMenu

--- a/src/components/design-system/organism/menu.tsx
+++ b/src/components/design-system/organism/menu.tsx
@@ -90,7 +90,7 @@ const renderMenuItems = (
                         ],
                     },
                     {
-                        label: "AI",
+                        label: "Artificial Intelligence",
                         items: [
                             {
                                 label: "Chat",

--- a/src/content/home/projects.ts
+++ b/src/content/home/projects.ts
@@ -18,6 +18,35 @@ export interface Project {
 }
 
 export const projects: Record<string, Project> = {
+  "react-native-skia-skeleton": {
+    name: "React Native Skia Skeleton",
+    abstract:
+      "A high-performance skeleton loader component for React Native, built with React Native Skia and" +
+      " React Native Reanimated.",
+    description:
+      "Yet another React Native skeleton component, built with React Native Skia and React Native" +
+      " Reanimated. It renders elegant loading placeholders with customizable shapes, shimmer" +
+      " animations, theme support, and right-to-left layouts, with zero dependencies beyond Skia and" +
+      " Reanimated. Works on Android, iOS, and Web.",
+    features: [
+      "Mobile / React Native",
+      "React Native Skia",
+      "React Native Reanimated",
+      "Shimmer skeleton placeholders",
+      "RTL & theme support",
+      "TypeScript",
+    ],
+    callToActions: [
+      {
+        label: "Github",
+        trackingCategory: tracking.category.home,
+        trackingAction: tracking.action.open_react_native_skia_skeleton_github,
+        trackingLabel: tracking.label.body,
+        link: "https://github.com/chicio/react-native-skia-skeleton",
+      },
+    ],
+    image: '/media/content/about-me/projects/react-native-skia-skeleton.png',
+  },
   "matrix-rain-webgpu": {
     name: "Matrix Rain WebGPU",
     abstract:

--- a/src/content/home/projects.ts
+++ b/src/content/home/projects.ts
@@ -18,6 +18,42 @@ export interface Project {
 }
 
 export const projects: Record<string, Project> = {
+  "matrix-rain-webgpu": {
+    name: "Matrix Rain WebGPU",
+    abstract:
+      "GPU-accelerated Matrix-style digital rain effect for React, built with WebGPU and TypeGPU." +
+      " It powers the animated background of this site.",
+    description:
+      "A GPU-accelerated Matrix-style digital rain effect built with WebGPU and TypeGPU, shipped as a" +
+      " customizable React component. It combines GPU-driven simulation, signed-distance-field glyphs," +
+      " depth parallax, bloom, and a CRT post-process. It powers the animated Matrix rain background of" +
+      " this site, with a 2D canvas fallback when WebGPU is unavailable.",
+    features: [
+      "Computer graphics",
+      "WebGPU",
+      "TypeGPU",
+      "GPU-driven simulation",
+      "SDF glyphs, bloom & CRT post-process",
+      "React, TypeScript",
+    ],
+    callToActions: [
+      {
+        label: "Demo",
+        trackingCategory: tracking.category.home,
+        trackingAction: tracking.action.open_matrix_rain_webgpu_demo,
+        trackingLabel: tracking.label.body,
+        link: "https://chicio.github.io/matrix-rain-webgpu/",
+      },
+      {
+        label: "Github",
+        trackingCategory: tracking.category.home,
+        trackingAction: tracking.action.open_matrix_rain_webgpu_github,
+        trackingLabel: tracking.label.body,
+        link: "https://github.com/chicio/matrix-rain-webgpu",
+      },
+    ],
+    image: '/media/content/about-me/projects/matrix-rain-webgpu.png',
+  },
   "spectral-clara-lux-tracer": {
     name: "Spectral Clara Lux Tracer",
     abstract:

--- a/src/types/configuration/tracking.ts
+++ b/src/types/configuration/tracking.ts
@@ -65,6 +65,9 @@ export const tracking = {
     command_palette_search_result_selected: "command_palette_search_result_selected",
     command_palette_open_matrix_rain_panel: "command_palette_open_matrix_rain_panel",
     command_palette_matrix_rain_preset_selected: "command_palette_matrix_rain_preset_selected",
+    open_matrix_rain_webgpu: "open_matrix_rain_webgpu",
+    open_matrix_rain_webgpu_demo: "open_matrix_rain_webgpu_demo",
+    open_matrix_rain_webgpu_github: "open_matrix_rain_webgpu_github",
   },
   category: {
     home: "home",

--- a/src/types/configuration/tracking.ts
+++ b/src/types/configuration/tracking.ts
@@ -68,6 +68,7 @@ export const tracking = {
     open_matrix_rain_webgpu: "open_matrix_rain_webgpu",
     open_matrix_rain_webgpu_demo: "open_matrix_rain_webgpu_demo",
     open_matrix_rain_webgpu_github: "open_matrix_rain_webgpu_github",
+    open_react_native_skia_skeleton_github: "open_react_native_skia_skeleton_github",
   },
   category: {
     home: "home",


### PR DESCRIPTION
Add the matrix-rain-webgpu open-source project to both the Explore navigation menu and the About-me open-source projects list.

## Description
- **Explore menu**: New "Computer Graphics" group (third group after DSA and AI) with a "Matrix Rain" item linking externally to https://chicio.github.io/matrix-rain-webgpu/
- **Menu external-link support**: `DropdownMenuItem` and `MenuItemWithTracking` now accept an optional `external?: boolean` prop; when true, renders `<a target="_blank" rel="noopener noreferrer">` instead of Next.js `<Link>`
- **Projects list**: `matrix-rain-webgpu` added as the first entry in `src/content/home/projects.ts`, with Demo and Github CTAs, full description, and the `matrix-rain-webgpu.png` image asset
- **Tracking**: Three new action keys added to `tracking.ts`: `open_matrix_rain_webgpu`, `open_matrix_rain_webgpu_demo`, `open_matrix_rain_webgpu_github`

## Motivation and Context
The site already uses the `matrix-rain-webgpu` npm package to power its animated background. Surfacing the project in the nav and projects list completes the story for visitors.

## How Has This Been Tested?
Browser

## Types of changes
- [ ] Bug fix :bug: (non-breaking change which fixes an issue)
- [x] New feature :sparkles: (non-breaking change which adds functionality)
- [ ] Breaking change :boom: (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project :beers:.
- [X] My change requires a change to the documentation :bulb: and I have updated the documentation accordingly.
- [X] I have read the [CONTRIBUTING](https://github.com/chicio/chicio-blog/blob/master/CONTRIBUTING.md) document :busts_in_silhouette:.
- [X] I have added tests to cover my changes :tada:.
- [X] All new and existing tests passed :white_check_mark:.