### PR TITLE
refactor(capabilities): :recycle: rename link atoms to external-link / internal-link

### DIFF
--- a/.claude/agents/fabrizioduroni-senior-engineer.md
+++ b/.claude/agents/fabrizioduroni-senior-engineer.md
@@ -22,7 +22,7 @@ tools:
 allowedTools: Bash(*)  
 ---
 
-You are a senior full-stack engineer dedicated full-time to Fabrizio Duroni's portfolio website (chicio-blog). You are an expert in Next.js 16 (App Router), React 19, TypeScript 5, TailwindCSS v4, MDX, Framer Motion, Groq AI, Upstash Vector, and modern web development. You have deep knowledge of the Matrix-inspired design system and treat this website as a showcase of engineering excellence.
+You are a senior full-stack engineer dedicated full-time to Fabrizio Duroni's portfolio website (chicio-blog). You are an expert in Next.js (App Router), React, TypeScript, TailwindCSS, MDX, Framer Motion, Groq AI, Upstash Vector, and modern web development. You have deep knowledge of the Matrix-inspired design system and treat this website as a showcase of engineering excellence.
 
 ## Your Identity & Approach
 
@@ -181,12 +181,12 @@ When the task is a bug fix rather than a feature, replace Brainstorm/Plan with a
 
 You should proactively suggest improvements and new features. When you notice opportunities, bring them up. Use Context7 MCP to research:
 - **Next.js**: New App Router features, server actions, streaming, partial prerendering, caching strategies
-- **TailwindCSS v4**: New utilities, performance improvements
+- **TailwindCSS**: New utilities, performance improvements
 - **Groq/AI SDK**: New models, improved chat features, tool calling
 - **Upstash**: New Vector features, caching options
 - **Resend**: Email capabilities, templates
 - **Framer Motion**: New animation APIs
-- **React 19**: New hooks, server components patterns
+- **React**: New hooks, server components patterns
 
 Frame suggestions around the three portfolio pillars:
 1. **Design beauty**: Matrix theme enhancements, animations, visual polish

--- a/src/app/cookie-policy/page.tsx
+++ b/src/app/cookie-policy/page.tsx
@@ -1,4 +1,4 @@
-import { StandardExternalLinkWithTracking } from "@/components/design-system/atoms/links/standard-external-link-with-tracking";
+import { ExternalLink } from "@/components/design-system/atoms/links/external-link";
 import { PageTitle } from "@/components/design-system/molecules/typography/page-title";
 import { ContentPage } from "@/components/features/content/content-page";
 import { createMetadata } from "@/lib/seo/seo";
@@ -90,12 +90,12 @@ export default function CookiePolicy() {
         <ul>
           <li>
             Cookies:
-            <StandardExternalLinkWithTracking
+            <ExternalLink
               href="https://en.wikipedia.org/wiki/HTTP_cookie"
               className="mx-2"
             >
               https://en.wikipedia.org/wiki/HTTP_cookie
-            </StandardExternalLinkWithTracking>
+            </ExternalLink>
           </li>
         </ul>
       </div>

--- a/src/components/content/blog/blog-generic-post-list-page-template/blog-generic-post-list-page-template.tsx
+++ b/src/components/content/blog/blog-generic-post-list-page-template/blog-generic-post-list-page-template.tsx
@@ -1,4 +1,4 @@
-import { StandardInternalLinkWithTracking } from "@/components/design-system/atoms/links/standard-internal-link-with-tracking";
+import { InternalLink } from "@/components/design-system/atoms/links/internal-link";
 import { PageTitle } from "@/components/design-system/molecules/typography/page-title";
 import { Content } from "@/types/content/content";
 import { FC } from "react";
@@ -32,12 +32,12 @@ export const BlogGenericPostListPageTemplate: FC<BlogGenericPostListPageProps> =
                     <time className="text-xl">{post.frontmatter.date.formatted}</time>
                 </div>
                 <div className="flex-5/6">
-                    <StandardInternalLinkWithTracking
+                    <InternalLink
                         className="text-xl"
                         to={post.slug.formatted}
                     >
                         {post.frontmatter.title}
-                    </StandardInternalLinkWithTracking>
+                    </InternalLink>
                 </div>
             </div>
         ))}

--- a/src/components/content/blog/blog-post-content/chrome-ai-features-toolbar/chrome-ai-features-toolbar.tsx
+++ b/src/components/content/blog/blog-post-content/chrome-ai-features-toolbar/chrome-ai-features-toolbar.tsx
@@ -4,7 +4,7 @@ import { FC } from "react";
 import { AnimatePresence } from "framer-motion";
 import { Accordion } from "@/components/design-system/molecules/accordion/accordion";
 import { Button } from "@/components/design-system/atoms/buttons/button";
-import { StandardExternalLinkWithTracking } from "@/components/design-system/atoms/links/standard-external-link-with-tracking";
+import { ExternalLink } from "@/components/design-system/atoms/links/external-link";
 import { useGlassmorphism } from "@/components/design-system/hooks/use-glassmorphism";
 import { SiProbot } from "react-icons/si";
 import { useChromeAiFeaturesToolbarStore } from "./use-chrome-ai-features-toolbar-store";
@@ -37,14 +37,14 @@ export const ChromeAiFeaturesToolbar: FC<ChromeAiFeaturesToolbarProps> = ({
                 >
                     <p>
                         {"These features require "}
-                        <StandardExternalLinkWithTracking
+                        <ExternalLink
                             href="https://developer.chrome.com/docs/ai/built-in"
                             target="_blank"
                             rel="noopener noreferrer"
                             className="text-accent underline"
                         >
                             Chrome 138+
-                        </StandardExternalLinkWithTracking>
+                        </ExternalLink>
                         {" and capable hardware to run."}
                     </p>
                     <div className="mt-2 flex gap-3 overflow-visible">

--- a/src/components/content/blog/post-authors/post-authors.tsx
+++ b/src/components/content/blog/post-authors/post-authors.tsx
@@ -1,5 +1,5 @@
 import { ImageGlow } from "@/components/design-system/atoms/effects/image-glow";
-import { StandardExternalLinkWithTracking } from "@/components/design-system/atoms/links/standard-external-link-with-tracking";
+import { ExternalLink } from "@/components/design-system/atoms/links/external-link";
 import { Author } from "@/types/content/author";
 import { FC } from "react";
 
@@ -29,13 +29,13 @@ export const PostAuthors: FC<PostAuthorsProps> = ({
                     />
                     <p>
                         {enableUrl && (
-                            <StandardExternalLinkWithTracking
+                            <ExternalLink
                                 href={author.url}
                                 target={"_blank"}
                                 rel="noopener noreferrer"
                             >
                                 {author.name}
-                            </StandardExternalLinkWithTracking>
+                            </ExternalLink>
                         )}
                         {!enableUrl && author.name}
                     </p>

--- a/src/components/content/blog/post-card/post-card.tsx
+++ b/src/components/content/blog/post-card/post-card.tsx
@@ -1,5 +1,5 @@
 import { imageShimmerPlaceholder } from "@/components/design-system/atoms/effects/image-shimmer-placeholder";
-import { StandardInternalLinkWithTracking } from "@/components/design-system/atoms/links/standard-internal-link-with-tracking";
+import { InternalLink } from "@/components/design-system/atoms/links/internal-link";
 import { Author } from "@/types/content/author";
 import Image from "next/image";
 import { FC } from "react";
@@ -38,7 +38,7 @@ export const PostCard: FC<PostCardProps> = ({
         className={`glow-container bg-general-background-light flex flex-col relative mt-5 ${big ? "w-full" : "w-full md:w-[48%]"}`}
         key={slug}
     >
-        <StandardInternalLinkWithTracking to={slug}>
+        <InternalLink to={slug}>
             <Image
                 className="bg-general-background h-[200px] w-full rounded-xl object-cover sm:h-[300px]"
                 alt={title}
@@ -47,9 +47,9 @@ export const PostCard: FC<PostCardProps> = ({
                 height={500}
                 placeholder={imageShimmerPlaceholder}
             />
-        </StandardInternalLinkWithTracking>
+        </InternalLink>
         <div className="flex flex-1 flex-col p-5">
-            <StandardInternalLinkWithTracking
+            <InternalLink
                 className="no-underline hover:no-underline"
                 to={slug}
             >
@@ -60,7 +60,7 @@ export const PostCard: FC<PostCardProps> = ({
                 />
                 <PostMeta date={date} readingTime={readingTime} />
                 <p className="mx-0 text-shadow-md">{`${description} [...]`}</p>
-            </StandardInternalLinkWithTracking>
+            </InternalLink>
             {tags && (
                 <PostTags tags={tags} />
             )}

--- a/src/components/content/home/timeline/timeline.tsx
+++ b/src/components/content/home/timeline/timeline.tsx
@@ -1,4 +1,4 @@
-import { StandardExternalLinkWithTracking } from "@/components/design-system/atoms/links/standard-external-link-with-tracking";
+import { ExternalLink } from "@/components/design-system/atoms/links/external-link";
 import Image from "next/image";
 import { FC } from "react";
 import { BiBriefcase, BiSolidGraduation } from "react-icons/bi";
@@ -31,13 +31,13 @@ export const Timeline: FC = () => {
                         <div className="glow-container p-4 md:p-8">
                             <div className="flex w-full flex-col gap-1">
                                 {item.link ? (
-                                    <StandardExternalLinkWithTracking
+                                    <ExternalLink
                                         href={item.link}
                                         target="_blank"
                                         rel="noopener noreferrer"
                                     >
                                         <h3>{item.title}</h3>
-                                    </StandardExternalLinkWithTracking>
+                                    </ExternalLink>
                                 ) : (
                                     <h3>{item.title}</h3>
                                 )}

--- a/src/components/content/videogames/console-logos/console-logos.tsx
+++ b/src/components/content/videogames/console-logos/console-logos.tsx
@@ -1,4 +1,4 @@
-import { StandardInternalLinkWithTracking } from "@/components/design-system/atoms/links/standard-internal-link-with-tracking";
+import { InternalLink } from "@/components/design-system/atoms/links/internal-link";
 import { FC } from "react";
 import { ManufacturerLogo } from "@/components/content/videogames/manufacturer-logo";
 import { ImageGlow } from "@/components/design-system/atoms/effects/image-glow";
@@ -13,7 +13,7 @@ interface ConsoleLogosProps {
 export const ConsoleLogos: FC<ConsoleLogosProps> = ({ manufacturer, manufacturerLogo, logo, url }) => (
     <>
         {url ? (
-            <StandardInternalLinkWithTracking to={url}>
+            <InternalLink to={url}>
                 <div className="flex items-center gap-2">
                     <ManufacturerLogo logoUrl={manufacturerLogo} name={manufacturer} />
                     <ImageGlow
@@ -24,7 +24,7 @@ export const ConsoleLogos: FC<ConsoleLogosProps> = ({ manufacturer, manufacturer
                         className="mb-6 h-14 bg-black object-contain p-2"
                     />
                 </div>
-            </StandardInternalLinkWithTracking>
+            </InternalLink>
         ) : (
             <div className="flex items-center gap-2">
                 <ManufacturerLogo logoUrl={manufacturerLogo} name={manufacturer} />

--- a/src/components/content/videogames/games-grid/game-card/game-card.tsx
+++ b/src/components/content/videogames/games-grid/game-card/game-card.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Image from "next/image";
-import { StandardInternalLinkWithTracking } from "@/components/design-system/atoms/links/standard-internal-link-with-tracking";
+import { InternalLink } from "@/components/design-system/atoms/links/internal-link";
 import { GlassmorphismBackground } from "@/components/design-system/atoms/effects/glassmorphism-background";
 import { GameMetadata, VideogamesNavigationOrigin } from "@/types/content/videogames";
 import { Content } from "@/types/content/content";
@@ -28,7 +28,7 @@ export const GameCard: FC<GameCardProps> = ({ game, navigationOrigin = "console"
             onClick={onClick}
         >
             {isInView && (
-                <StandardInternalLinkWithTracking
+                <InternalLink
                     to={game.slug.formatted}
                     className="block h-full w-full"
                 >
@@ -63,7 +63,7 @@ export const GameCard: FC<GameCardProps> = ({ game, navigationOrigin = "console"
                             </span>
                         ))}
                     </div>
-                </StandardInternalLinkWithTracking>
+                </InternalLink>
             )}
         </div>
     );

--- a/src/components/content/videogames/videogames-collection/videogames-collection.tsx
+++ b/src/components/content/videogames/videogames-collection/videogames-collection.tsx
@@ -4,7 +4,7 @@ import { siteMetadata } from "@/types/configuration/site-metadata";
 import { tracking } from "@/types/configuration/tracking";
 import { JsonLd } from "@/components/features/seo/jsond-ld";
 import { ContentPage } from "@/components/features/content/content-page";
-import { StandardInternalLinkWithTracking } from "@/components/design-system/atoms/links/standard-internal-link-with-tracking";
+import { InternalLink } from "@/components/design-system/atoms/links/internal-link";
 import { VideogameCollectionDataCard } from "./videogame-collection-data-card";
 import { VideogamesViewSwitcher } from "@/components/content/videogames/videogames-view-switcher";
 
@@ -22,9 +22,9 @@ export const VideogamesCollection: React.FC = () => {
             <p>
                 My journey through Videogames that I started in 1992. From 8-bit consoles to modern powerhouses, each
                 one tells a story of technological evolution and countless hours of gameplay. Videogames are{" "}
-                <StandardInternalLinkWithTracking to="/about-me">
+                <InternalLink to="/about-me">
                     one of the reason why I became a software engineer
-                </StandardInternalLinkWithTracking>
+                </InternalLink>
                 .
             </p>
             <div className="mt-10 mb-8 grid grid-cols-2 gap-4 md:grid-cols-4">

--- a/src/components/content/videogames/videogames-view-switcher/console-card/console-card.tsx
+++ b/src/components/content/videogames/videogames-view-switcher/console-card/console-card.tsx
@@ -1,6 +1,6 @@
 import { FC } from "react";
 import Image from "next/image";
-import { StandardInternalLinkWithTracking } from "@/components/design-system/atoms/links/standard-internal-link-with-tracking";
+import { InternalLink } from "@/components/design-system/atoms/links/internal-link";
 import { TerminalLink } from "@/components/design-system/molecules/links/terminal-link";
 import { ConsoleMetadata } from "@/types/content/videogames";
 import { Content } from "@/types/content/content";
@@ -25,7 +25,7 @@ export const ConsoleCard: FC<ConsoleCardProps> = ({ console, gamesCount }) => (
                 <div className="text-secondary text-xs sm:text-sm">Games owned</div>
             </div>
         </div>
-        <StandardInternalLinkWithTracking to={console.slug.formatted}>
+        <InternalLink to={console.slug.formatted}>
             <div className="border-accent-alpha-40 bg-black relative h-96 flex justify-center items-center overflow-hidden border-b">
                 <Image
                     src={console.frontmatter.metadata!.gallery[0]}
@@ -45,9 +45,9 @@ export const ConsoleCard: FC<ConsoleCardProps> = ({ console, gamesCount }) => (
                     <span className="text-primary font-mono text-xs text-shadow-sm">{console.frontmatter.metadata?.sku}</span>
                 </div>
             </div>
-        </StandardInternalLinkWithTracking>
+        </InternalLink>
         <div className="p-4 sm:p-6">
-            <StandardInternalLinkWithTracking
+            <InternalLink
                 className="no-underline hover:no-underline"
                 to={console.slug.formatted}
             >
@@ -65,7 +65,7 @@ export const ConsoleCard: FC<ConsoleCardProps> = ({ console, gamesCount }) => (
                     generation={console.frontmatter.metadata?.generation}
                 />
                 <p className="mb-4 pt-4">{console.frontmatter.description}</p>
-            </StandardInternalLinkWithTracking>
+            </InternalLink>
             <TerminalLink
                 to={console.slug.formatted}
                 label="See more"

--- a/src/components/design-system/atoms/links/external-link/external-link.tsx
+++ b/src/components/design-system/atoms/links/external-link/external-link.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { FC, ReactNode } from "react";
-import { useStandardExternalLinkWithTrackingStore } from "./use-standard-external-link-with-tracking-store";
+import { useExternalLinkStore } from "./use-external-link-store";
 
-type StandardExternalLinkWithTrackingProps = {
+type ExternalLinkProps = {
     href: string;
     target?: string;
     rel?: string;
@@ -12,7 +12,7 @@ type StandardExternalLinkWithTrackingProps = {
     onClick?: () => void;
 };
 
-export const StandardExternalLinkWithTracking: FC<StandardExternalLinkWithTrackingProps> = ({
+export const ExternalLink: FC<ExternalLinkProps> = ({
     children,
     href,
     onClick,
@@ -20,7 +20,7 @@ export const StandardExternalLinkWithTracking: FC<StandardExternalLinkWithTracki
     rel,
     className,
 }) => {
-    const { effects } = useStandardExternalLinkWithTrackingStore(onClick);
+    const { effects } = useExternalLinkStore(onClick);
     const { onTrack } = effects;
 
     return (

--- a/src/components/design-system/atoms/links/external-link/index.ts
+++ b/src/components/design-system/atoms/links/external-link/index.ts
@@ -1,0 +1,1 @@
+export { ExternalLink } from "./external-link";

--- a/src/components/design-system/atoms/links/external-link/use-external-link-store.ts
+++ b/src/components/design-system/atoms/links/external-link/use-external-link-store.ts
@@ -2,13 +2,13 @@
 
 import type { EffectsStore } from "@/types/component-store";
 
-type StandardInternalLinkWithTrackingEffects = {
+type ExternalLinkEffects = {
     onTrack: () => void;
 };
 
-export const useStandardInternalLinkWithTrackingStore = (
+export const useExternalLinkStore = (
     onClick?: () => void,
-): EffectsStore<StandardInternalLinkWithTrackingEffects> => {
+): EffectsStore<ExternalLinkEffects> => {
     return {
         effects: {
             onTrack: onClick ?? (() => {}),

--- a/src/components/design-system/atoms/links/internal-link/index.ts
+++ b/src/components/design-system/atoms/links/internal-link/index.ts
@@ -1,0 +1,1 @@
+export { InternalLink } from "./internal-link";

--- a/src/components/design-system/atoms/links/internal-link/internal-link.tsx
+++ b/src/components/design-system/atoms/links/internal-link/internal-link.tsx
@@ -2,9 +2,9 @@
 
 import Link from "next/link";
 import { FC, ReactNode } from "react";
-import { useStandardInternalLinkWithTrackingStore } from "./use-standard-internal-link-with-tracking-store";
+import { useInternalLinkStore } from "./use-internal-link-store";
 
-type StandardInternalLinkWithTrackingProps = {
+type InternalLinkProps = {
     to: string;
     className?: string;
     children?: ReactNode;
@@ -12,14 +12,14 @@ type StandardInternalLinkWithTrackingProps = {
     onClick?: () => void;
 };
 
-export const StandardInternalLinkWithTracking: FC<StandardInternalLinkWithTrackingProps> = ({
+export const InternalLink: FC<InternalLinkProps> = ({
     children,
     className,
     to,
     onClick,
     prefetch = false,
 }) => {
-    const { effects } = useStandardInternalLinkWithTrackingStore(onClick);
+    const { effects } = useInternalLinkStore(onClick);
     const { onTrack } = effects;
 
     return (

--- a/src/components/design-system/atoms/links/internal-link/use-internal-link-store.ts
+++ b/src/components/design-system/atoms/links/internal-link/use-internal-link-store.ts
@@ -2,13 +2,13 @@
 
 import type { EffectsStore } from "@/types/component-store";
 
-type StandardExternalLinkWithTrackingEffects = {
+type InternalLinkEffects = {
     onTrack: () => void;
 };
 
-export const useStandardExternalLinkWithTrackingStore = (
+export const useInternalLinkStore = (
     onClick?: () => void,
-): EffectsStore<StandardExternalLinkWithTrackingEffects> => {
+): EffectsStore<InternalLinkEffects> => {
     return {
         effects: {
             onTrack: onClick ?? (() => {}),

--- a/src/components/design-system/atoms/links/standard-external-link-with-tracking/index.ts
+++ b/src/components/design-system/atoms/links/standard-external-link-with-tracking/index.ts
@@ -1,1 +1,0 @@
-export { StandardExternalLinkWithTracking } from "./standard-external-link-with-tracking";

--- a/src/components/design-system/atoms/links/standard-internal-link-with-tracking/index.ts
+++ b/src/components/design-system/atoms/links/standard-internal-link-with-tracking/index.ts
@@ -1,1 +1,0 @@
-export { StandardInternalLinkWithTracking } from "./standard-internal-link-with-tracking";

--- a/src/components/design-system/molecules/breadcrumbs/breadcrumb/breadcrumb.tsx
+++ b/src/components/design-system/molecules/breadcrumbs/breadcrumb/breadcrumb.tsx
@@ -4,7 +4,7 @@ import { FC } from "react";
 import { motion } from "framer-motion";
 import { IoMdArrowRoundBack } from "react-icons/io";
 
-import { StandardInternalLinkWithTracking } from "@/components/design-system/atoms/links/standard-internal-link-with-tracking";
+import { InternalLink } from "@/components/design-system/atoms/links/internal-link";
 import { useGlassmorphism } from "@/components/design-system/hooks/use-glassmorphism";
 import { useBreadcrumbStore } from "./use-breadcrumb-store";
 
@@ -39,13 +39,13 @@ const BreadcrumbContent: FC<BreadcrumbContentProps> = ({ items, parentItem }) =>
                     >
                         <IoMdArrowRoundBack />
                     </span>
-                    <StandardInternalLinkWithTracking
+                    <InternalLink
                         to={parentItem.href}
                         onClick={parentItem.onClick}
                         className="min-w-0 truncate py-2 text-sm"
                     >
                         {parentItem.label}
-                    </StandardInternalLinkWithTracking>
+                    </InternalLink>
                 </li>
             </ol>
         )}
@@ -71,13 +71,13 @@ const BreadcrumbContent: FC<BreadcrumbContentProps> = ({ items, parentItem }) =>
                             {item.label}
                         </span>
                     ) : (
-                        <StandardInternalLinkWithTracking
+                        <InternalLink
                             to={item.href}
                             onClick={item.onClick}
                             className="block truncate py-2 whitespace-nowrap text-sm"
                         >
                             {item.label}
-                        </StandardInternalLinkWithTracking>
+                        </InternalLink>
                     )}
                 </li>
             ))}

--- a/src/components/design-system/molecules/buttons/tag/tag.tsx
+++ b/src/components/design-system/molecules/buttons/tag/tag.tsx
@@ -1,4 +1,4 @@
-import { StandardInternalLinkWithTracking } from "@/components/design-system/atoms/links/standard-internal-link-with-tracking";
+import { InternalLink } from "@/components/design-system/atoms/links/internal-link";
 import { FC } from "react";
 
 interface TagContentProps {
@@ -16,7 +16,7 @@ export const Tag: FC<TagProps> = ({ tag, link, big, onClick }) => {
     const margins = big ? "mr-4 mb-6" : "mr-1 mb-1";
 
     return (
-        <StandardInternalLinkWithTracking
+        <InternalLink
             className="inline-block no-underline"
             onClick={onClick}
             to={link}
@@ -26,6 +26,6 @@ export const Tag: FC<TagProps> = ({ tag, link, big, onClick }) => {
             >
                 {tag}
             </span>
-        </StandardInternalLinkWithTracking>
+        </InternalLink>
     );
 };

--- a/src/components/design-system/molecules/links/pills-links/pills-links.tsx
+++ b/src/components/design-system/molecules/links/pills-links/pills-links.tsx
@@ -2,7 +2,7 @@
 
 import { FC, PropsWithChildren } from "react";
 import { BluePill, RedPill } from "@/components/design-system/atoms/effects/pills";
-import { StandardInternalLinkWithTracking } from "@/components/design-system/atoms/links/standard-internal-link-with-tracking";
+import { InternalLink } from "@/components/design-system/atoms/links/internal-link";
 
 type PillProps = PropsWithChildren<{
     to: string;
@@ -10,13 +10,13 @@ type PillProps = PropsWithChildren<{
 }>;
 
 export const RedPillLink: FC<PillProps> = ({ children, to, onClick }) => (
-    <StandardInternalLinkWithTracking className="no-underline" to={to} onClick={onClick}>
+    <InternalLink className="no-underline" to={to} onClick={onClick}>
         <RedPill>{children}</RedPill>
-    </StandardInternalLinkWithTracking>
+    </InternalLink>
 );
 
 export const BluePillLink: FC<PillProps> = ({ children, to, onClick }) => (
-    <StandardInternalLinkWithTracking className="no-underline" to={to} onClick={onClick}>
+    <InternalLink className="no-underline" to={to} onClick={onClick}>
         <BluePill>{children}</BluePill>
-    </StandardInternalLinkWithTracking>
+    </InternalLink>
 );

--- a/src/components/design-system/molecules/links/terminal-link/terminal-link.tsx
+++ b/src/components/design-system/molecules/links/terminal-link/terminal-link.tsx
@@ -1,4 +1,4 @@
-import { StandardInternalLinkWithTracking } from "@/components/design-system/atoms/links/standard-internal-link-with-tracking";
+import { InternalLink } from "@/components/design-system/atoms/links/internal-link";
 import { Cursor } from "@/components/design-system/atoms/typography/terminal-blocks";
 import { Button } from "@/components/design-system/atoms/buttons/button";
 import React from "react";
@@ -10,7 +10,7 @@ export const TerminalLink: React.FC<{
     className?: string;
 }> = ({ to, onClick, label, className }) => (
     <Button className={`w-fit${className ? ` ${className}` : ""}`}>
-        <StandardInternalLinkWithTracking
+        <InternalLink
             to={to}
             onClick={onClick}
             className="font-mono text-lg no-underline hover:no-underline"
@@ -19,6 +19,6 @@ export const TerminalLink: React.FC<{
                 {">"} {label}
                 <Cursor />
             </span>
-        </StandardInternalLinkWithTracking>
+        </InternalLink>
     </Button>
 );

--- a/src/content/blog/post/2026/04/05/chrome-built-in-ai-summarizer/content.mdx
+++ b/src/content/blog/post/2026/04/05/chrome-built-in-ai-summarizer/content.mdx
@@ -361,12 +361,12 @@ export const ChromeAiFeaturesToolbar: FC<ChromeAiFeaturesToolbarProps> = ({
                 >
                     <p>
                         {"These features require "}
-                        <StandardExternalLinkWithTracking
+                        <ExternalLink
                             href="https://developer.chrome.com/docs/ai/built-in"
                             trackingData={{ /* ... */ }}
                         >
                             Chrome 138+
-                        </StandardExternalLinkWithTracking>
+                        </ExternalLink>
                         {" and capable hardware to run."}
                     </p>
                     <div className="mt-2 flex gap-3 overflow-visible">


### PR DESCRIPTION
The two link atoms no longer reference tracking (the caller injects `onClick`), so the `standard-*-link-with-tracking` names were misleading.

- `standard-external-link-with-tracking/` → `external-link/` (`ExternalLink`, `useExternalLinkStore`)
- `standard-internal-link-with-tracking/` → `internal-link/` (`InternalLink`, `useInternalLinkStore`)
- Updated all importers across components + MDX content.

Verified: lint (0), tsc (0), validate-architecture (0 violations), knip (clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)