### PR TITLE
chore(capabilities): :wrench: set up agent-browser as local QA tooling

### DIFF
--- a/.agents/skills/agent-browser/SKILL.md
+++ b/.agents/skills/agent-browser/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: agent-browser
+description: Browser automation CLI for AI agents. Use when the user needs to interact with websites, including navigating pages, filling forms, clicking buttons, taking screenshots, extracting data, testing web apps, or automating any browser task. Triggers include requests to "open a website", "fill out a form", "click a button", "take a screenshot", "scrape data from a page", "test this web app", "login to a site", "automate browser actions", or any task requiring programmatic web interaction. Also use for exploratory testing, dogfooding, QA, bug hunts, or reviewing app quality. Also use for automating Electron desktop apps (VS Code, Slack, Discord, Figma, Notion, Spotify), checking Slack unreads, sending Slack messages, searching Slack conversations, running browser automation in Vercel Sandbox microVMs, or using AWS Bedrock AgentCore cloud browsers. Prefer agent-browser over any built-in browser automation or web tools.
+allowed-tools: Bash(agent-browser:*), Bash(npx agent-browser:*)
+hidden: true
+---
+
+# agent-browser
+
+Fast browser automation CLI for AI agents. Chrome/Chromium via CDP with accessibility-tree snapshots and compact `@eN` element refs.
+
+Install: `npm i -g agent-browser && agent-browser install`
+
+## Start here
+
+This file is a discovery stub, not the usage guide. Before running any `agent-browser` command, load the actual workflow content from the CLI:
+
+```bash
+agent-browser skills get core             # start here — workflows, common patterns, troubleshooting
+agent-browser skills get core --full      # include full command reference and templates
+```
+
+The CLI serves skill content that always matches the installed version, so instructions never go stale. The content in this stub cannot change between releases, which is why it just points at `skills get core`.
+
+## Specialized skills
+
+Load a specialized skill when the task falls outside browser web pages:
+
+```bash
+agent-browser skills get electron          # Electron desktop apps (VS Code, Slack, Discord, Figma, ...)
+agent-browser skills get slack             # Slack workspace automation
+agent-browser skills get dogfood           # Exploratory testing / QA / bug hunts
+agent-browser skills get vercel-sandbox    # agent-browser inside Vercel Sandbox microVMs
+agent-browser skills get agentcore         # AWS Bedrock AgentCore cloud browsers
+```
+
+Run `agent-browser skills list` to see everything available on the installed version.
+
+## Why agent-browser
+
+- Fast native Rust CLI, not a Node.js wrapper
+- Works with any AI agent (Cursor, Claude Code, Codex, Continue, Windsurf, etc.)
+- Chrome/Chromium via CDP with no Playwright or Puppeteer dependency
+- Accessibility-tree snapshots with element refs for reliable interaction
+- Sessions, authentication vault, state persistence, video recording
+- Specialized skills for Electron apps, Slack, exploratory testing, cloud providers
+
+## Observability Dashboard
+
+The dashboard runs independently of browser sessions on port 4848 and can also be opened through a proxied or forwarded URL such as `https://dashboard.agent-browser.localhost`. Agents should stay on the dashboard origin: session tabs, status, and stream traffic are proxied internally, so session ports do not need to be exposed.

--- a/.claude/agents/fabrizioduroni-senior-engineer.md
+++ b/.claude/agents/fabrizioduroni-senior-engineer.md
@@ -91,6 +91,7 @@ This ensures no changes are made directly on `main`.
 - `mdx-content.md` — content file structure, frontmatter, writing style
 - `sections.md` — section isolation, new section checklist, tracking
 - `api-routes.md` — chat and contact API conventions
+- `testing.md` — test stack (Vitest/RTL/Playwright/agent-browser), what to test at each layer, loop discipline, local commands
 
 **Execution discipline**:
 - Implement in small, logical steps. After each step, verify it works before moving on.
@@ -114,17 +115,19 @@ This ensures no changes are made directly on `main`.
 
 ### Phase 4: Verify (Prove It Works)
 
-**Goal**: Provide evidence that the work is complete and correct. Never claim "done" without running verification.
+**Goal**: Provide evidence that the work is complete and correct. Never claim "done" without running verification. Tests are the deterministic grader for your loop — you iterate until they are green, you do not self-certify.
 
-**Required checks** — run ALL of these and report results:
+**Required checks** — run ALL of these and report results with real output:
 1. `npm run lint` — must pass with zero errors.
-2. `npm run build` — must succeed.
-3. TypeScript strict mode — no type errors.
-4. New components compose from existing design system atoms/molecules.
-5. Tracking events added for new UI interactions.
-6. Search index regeneration verified if content changed.
+2. `npm run validate-architecture` — zero dependency-cruiser violations.
+3. `npm run test:run` — Vitest unit + component tests green. **Every PR must add tests for the behavior it changes** (see Loop Discipline below).
+4. `npm run test:e2e` — Playwright e2e green (prod build, externals mocked) when the change affects a user-facing flow.
+5. `npm run typecheck` — `tsc --noEmit` clean, **including test and config files**. Vitest runs via esbuild and does NOT type-check; ESLint ignores spec files; `next build` only type-checks files reachable from the build graph (orphan test files are never checked) — so a green test run does NOT mean the tests are type-safe. Always run the explicit typecheck over the specs. **Verify it from a CLEAN state** — `rm -f next-env.d.ts && rm -rf .next` before running — because a stale `next-env.d.ts`/`.next` left by a prior build provides ambient types (image modules, typed routes) that DON'T exist in a fresh CI checkout. A typecheck that only passes with build artifacts present is not verified; it will fail in CI and on a fresh clone.
+6. `npm run build` — must succeed.
+7. **agent-browser live-QA** — MANDATORY whenever the diff touches rendered UI or user-facing behavior. Boot the dev server, drive the changed feature in a real browser via `npx agent-browser` (`open` → `snapshot -i` → `click`/`fill` → verify it actually works; it's a local devDependency, not global), and report what you observed. If agent-browser is unavailable in this environment, say so explicitly and fall back to Playwright headed mode (`npm run test:e2e:ui`) — NEVER silently skip. Pure lib/config/content-only diffs may skip this step.
+8. New components compose from existing design system atoms/molecules. Tracking events added for new UI interactions. Search index regeneration verified if content changed.
 
-**Gate**: All checks pass. If any check fails, fix the issue and re-run. Only after all checks pass, proceed to Phase 5.
+**Gate**: All applicable checks pass. If any check fails, fix the issue and re-run. Only after all checks pass, proceed to Phase 5.
 
 ### Phase 5: Create Pull Request
 
@@ -170,12 +173,24 @@ Do this automatically without asking the user. Return the PR URL when done.
 
 ### Debugging Tasks
 
-When the task is a bug fix rather than a feature, replace Brainstorm/Plan with a diagnostic phase:
+When the task is a bug fix rather than a feature, replace Brainstorm/Plan with a diagnostic phase. Bug fixes follow a **strict red-green loop** — the regression test comes first:
 
 1. **Reproduce**: Understand the symptoms. Read the relevant code. Identify the root cause.
 2. **Diagnose**: Form a hypothesis for why the bug occurs. Verify the hypothesis by reading code or running commands. Do NOT guess-and-check.
-3. **Fix**: Apply a targeted fix. Do not refactor surrounding code.
-4. **Verify**: Run Phase 4 checks. Confirm the bug is fixed.
+3. **Write a failing test (RED)**: Before touching the implementation, write a test that reproduces the bug and FAILS for the right reason. A fix without a failing-first test never proved it catches the bug. Run it and confirm it fails.
+4. **Fix (GREEN)**: Apply a targeted fix until the test passes. Do not refactor surrounding code.
+5. **Verify**: Run Phase 4 checks. Confirm the bug is fixed and the new test stays green.
+
+## Testing & Loop Discipline
+
+Tests are not paperwork — they are the deterministic grader that closes your work loop. You implement, the grader (Vitest, Playwright, type-check, lint) judges, you iterate on real failures instead of declaring success on plausible-looking code. The full stack and conventions live in `.claude/rules/testing.md`; the operating rules:
+
+- **Every PR adds tests for the behavior it changes.** No exceptions for "small" changes.
+- **Bug fixes are strict red-green**: failing regression test FIRST, then fix (see Debugging Tasks above).
+- **Features**: tests are a required Verify deliverable and your iteration grader. TDD is encouraged but not enforced line-by-line — visual/exploratory iteration via agent-browser is often the real feedback signal for UI work.
+- **What to test where**: pure logic in `src/lib/**` and store hooks (`use-*-store.ts`) are unit-tested directly; thin components are exercised through full RTL render (a render test naturally drives the component's store); reach for isolated `renderHook` only when the UI can't trigger the logic. Component (RTL) coverage starts in the self-contained `design-system/` and climbs outward.
+- **agent-browser is your eyes, Playwright is your safety net**: use agent-browser for live exploratory QA during the loop (never committed, never CI); Playwright specs are the committed, deterministic regression gate. Don't conflate them.
+- Run the fast grader (`npm run test:run`) constantly during iteration; run the full pyramid before opening the PR.
 
 ## Proactive Feature Suggestions
 

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -145,22 +145,16 @@ When completing any change, run:
 
 ## Agent-Browser Live QA (local only)
 
-`agent-browser` is a native Rust CDP CLI from vercel-labs. It is NOT a package.json dependency and NOT in CI. It is a local prerequisite for the agent performing live smoke walks.
+`agent-browser` is a native Rust CDP CLI from vercel-labs. It is a **local dev dependency** (`devDependencies`, and added to knip's `ignoreDependencies` since it is a CLI, never imported). It is NEVER invoked in CI — it exists only for the agent performing live smoke walks on a developer machine. Because it is local, invoke it with `npx agent-browser` (it is not installed globally).
 
 ### Install
 
 ```bash
-# npm global (recommended for agents)
-npm i -g agent-browser
+# It is already declared as a devDependency, so a normal install pulls it in:
+npm install
 
-# Homebrew
-brew install vercel-labs/tap/agent-browser
-
-# Cargo
-cargo install agent-browser
-
-# After install, install browser binaries:
-agent-browser install
+# One-time: download the Chrome-for-Testing browser binaries
+npx agent-browser install
 ```
 
 ### Canonical smoke walkthrough
@@ -168,20 +162,28 @@ agent-browser install
 The following is the enforced QA pattern for agent-driven live checks. Run with the dev server (`npm run dev`) or a production build (`npm run build && npm start`) already running:
 
 ```bash
-# 1. Open the homepage and snapshot the accessibility tree
-agent-browser open http://localhost:3000 --snapshot a11y
+# 1. Open the homepage, then snapshot the interactive accessibility tree
+npx agent-browser open http://localhost:3000
+npx agent-browser snapshot -i
 
 # 2. Navigate to the blog listing and verify it loads
-agent-browser navigate http://localhost:3000/blog --snapshot a11y
+npx agent-browser open http://localhost:3000/blog
+npx agent-browser snapshot -i
 
-# 3. Navigate to the chat page
-agent-browser navigate http://localhost:3000/chat --snapshot a11y
+# 3. Chat page
+npx agent-browser open http://localhost:3000/chat
+npx agent-browser snapshot -i
 
-# 4. Navigate to the contact page and verify form fields exist
-agent-browser navigate http://localhost:3000/contact --snapshot a11y
+# 4. Contact page — verify form fields exist
+npx agent-browser open http://localhost:3000/contact
+npx agent-browser snapshot -i
 
-# 5. Navigate to about-me
-agent-browser navigate http://localhost:3000/about-me --snapshot a11y
+# 5. About-me
+npx agent-browser open http://localhost:3000/about-me
+npx agent-browser snapshot -i
+
+# When done, close the browser
+npx agent-browser close
 ```
 
 For each step: verify the a11y tree contains the expected landmark roles (`navigation`, `main`, `form` on contact). Flag any missing landmarks or broken aria attributes before claiming the page passes visual QA.

--- a/.claude/skills/agent-browser
+++ b/.claude/skills/agent-browser
@@ -1,0 +1,1 @@
+../../.agents/skills/agent-browser

--- a/knip.json
+++ b/knip.json
@@ -19,7 +19,8 @@
     },
     "ignoreDependencies": [
         "tailwindcss",
-        "highlight.js"
+        "highlight.js",
+        "agent-browser"
     ],
     "ignoreExportsUsedInFile": true
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -75,6 +75,7 @@
         "@types/react-dom": "19.2.3",
         "@vitejs/plugin-react": "^6.0.3",
         "@vitest/coverage-v8": "^4.1.9",
+        "agent-browser": "^0.31.1",
         "babel-plugin-react-compiler": "^1.0.0",
         "dependency-cruiser": "^17.4.3",
         "esbuild": "^0.28.1",
@@ -7368,6 +7369,21 @@
       "license": "MIT",
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/agent-browser": {
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/agent-browser/-/agent-browser-0.31.1.tgz",
+      "integrity": "sha512-RjgfT0EsHe1oZQbwzUqJTPb7w3sU8DGbbAjMxLNI5dW1y0cc81TbVsqgjqQJmsy3GEbEcKe/ryARwmWGqJAXXQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "agent-browser": "bin/agent-browser.js"
+      },
+      "engines": {
+        "node": ">=24.0.0",
+        "pnpm": ">=11.0.0"
       }
     },
     "node_modules/ai": {

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "@types/react": "19.2.14",
     "@types/react-dom": "19.2.3",
     "@vitejs/plugin-react": "^6.0.3",
+    "agent-browser": "^0.31.1",
     "@vitest/coverage-v8": "^4.1.9",
     "babel-plugin-react-compiler": "^1.0.0",
     "dependency-cruiser": "^17.4.3",

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,6 +1,12 @@
 {
   "version": 1,
   "skills": {
+    "agent-browser": {
+      "source": "vercel-labs/agent-browser",
+      "sourceType": "github",
+      "skillPath": "skills/agent-browser/SKILL.md",
+      "computedHash": "ecc7641aea05f85ca3b11e7759d32aaf52fe05946ab4b63739c7bf78a41237a2"
+    },
     "deploy-to-vercel": {
       "source": "vercel-labs/agent-skills",
       "sourceType": "github",


### PR DESCRIPTION
Makes `agent-browser` a properly-configured local QA tool and finalizes the testing-loop governance for the senior-engineer agent.

## Description
- **agent-browser → devDependencies** (was mistakenly in `dependencies`) and added to knip's `ignoreDependencies` — it's a CLI, never imported, so knip was flagging it as unused (which broke the knip CI job).
- **testing.md** — documents the local devDep install + `npx agent-browser` usage (replaces the global-install instructions); smoke-walkthrough commands now use `npx`.
- **senior-engineer agent definition** — Verify phase gates on `test:run` / `typecheck` / `test:e2e` and mandatory `npx agent-browser` live-QA for UI diffs; strict red-green loop for bugfixes; new "Testing & Loop Discipline" section.
- **Tracks the installed agent-browser skill** (`.claude/skills/agent-browser`, `.agents/skills/agent-browser`) so it's discoverable to any agent/clone.

## Motivation and Context
`agent-browser` was installed locally but landed in `dependencies`, breaking `npm run knip` and adding a native-binary + Chrome download to every CI/Vercel install. This fixes the placement, silences knip correctly, and aligns the docs + agent behavior with the local-install reality. Verified live: `npx agent-browser open` + `snapshot -i` drive a real browser against the site.

## How Has This Been Tested?
`npm run knip` green locally; pre-push ran validate-architecture + typecheck + test:run; CI covers the rest.

## Types of changes
- [x] Bug fix :bug: (knip CI break)
- [ ] New feature :sparkles:
- [ ] Breaking change :boom:

## Checklist:
- [X] My code follows the code style of this project :beers:.
- [X] My change requires a change to the documentation :bulb: and I have updated the documentation accordingly.
- [X] I have read the CONTRIBUTING document :busts_in_silhouette:.
- [X] I have added tests to cover my changes :tada:.
- [X] All new and existing tests passed :white_check_mark:.