### PR TITLE
test(capabilities): :white_check_mark: cover design-system organisms and templates

### DIFF
--- a/src/components/design-system/organism/command-palette/command-palette/command-palette.test.tsx
+++ b/src/components/design-system/organism/command-palette/command-palette/command-palette.test.tsx
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import { CommandPalette } from "./command-palette";
+
+const { stableSearchResult, stableHandleSearch, stableResetSearch } = vi.hoisted(() => ({
+    stableSearchResult: { type: "search" as const, results: [] },
+    stableHandleSearch: vi.fn(),
+    stableResetSearch: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+    useRouter: () => ({ push: vi.fn() }),
+    usePathname: () => "/",
+}));
+
+vi.mock("framer-motion", () => ({
+    motion: {
+        div: ({ children, ...props }: React.HTMLAttributes<HTMLDivElement>) => <div {...props}>{children}</div>,
+    },
+    AnimatePresence: ({ children }: React.PropsWithChildren) => <>{children}</>,
+}));
+
+vi.mock("cmdk", () => ({
+    Command: Object.assign(
+        ({
+            children,
+            ...props
+        }: React.HTMLAttributes<HTMLDivElement> & { shouldFilter?: boolean; value?: string; onValueChange?: (v: string) => void }) => (
+            <div {...props}>{children}</div>
+        ),
+        {
+            Input: ({
+                onValueChange,
+                placeholder,
+                ...rest
+            }: React.InputHTMLAttributes<HTMLInputElement> & { onValueChange?: (v: string) => void }) => (
+                <input
+                    placeholder={placeholder}
+                    onChange={(e) => onValueChange?.(e.target.value)}
+                    {...rest}
+                />
+            ),
+            List: ({ children, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+                <div {...props}>{children}</div>
+            ),
+            Group: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
+            Item: ({
+                children,
+                onSelect,
+                value,
+            }: React.PropsWithChildren<{ onSelect?: () => void; value?: string }>) => (
+                <div role="option" aria-label={value} onClick={onSelect}>
+                    {children}
+                </div>
+            ),
+        },
+    ),
+}));
+
+vi.mock("matrix-rain-webgpu", () => ({
+    isWebGPUSupported: () => false,
+}));
+
+vi.mock("@/components/design-system/hooks/use-search", () => ({
+    useSearch: () => ({
+        handleSearch: stableHandleSearch,
+        resetSearch: stableResetSearch,
+        search: stableSearchResult,
+        isPending: false,
+    }),
+}));
+
+vi.mock("@/components/design-system/state/command-palette/command-palette-events", () => ({
+    commandPaletteOpenEvent: "command-palette-open",
+    openCommandPalette: vi.fn(),
+    openMatrixRainPanel: vi.fn(),
+}));
+
+vi.mock("@/components/design-system/state/motion/motion", () => ({
+    writeMotion: vi.fn(),
+    hasMotion: () => true,
+    motionChangeEvent: "motion-change",
+}));
+
+describe("CommandPalette", () => {
+    describe("when closed", () => {
+        it("renders nothing before being opened", () => {
+            const { container } = render(
+                <CommandPalette searchIndexFileName="search.json" chatSlug="/chat" />,
+            );
+            expect(container.firstChild).toBeNull();
+        });
+    });
+
+    describe("when opened via keyboard shortcut", () => {
+        it("renders the search input after Ctrl+K is pressed", () => {
+            render(<CommandPalette searchIndexFileName="search.json" chatSlug="/chat" />);
+            fireEvent.keyDown(window, { key: "k", ctrlKey: true });
+            expect(screen.getByPlaceholderText("type to search_")).toBeInTheDocument();
+        });
+
+        it("shows quick actions when not searching", () => {
+            render(<CommandPalette searchIndexFileName="search.json" chatSlug="/chat" />);
+            fireEvent.keyDown(window, { key: "k", ctrlKey: true });
+            expect(screen.getByText(/Open chat/)).toBeInTheDocument();
+        });
+
+        it("closes on Escape key", () => {
+            render(<CommandPalette searchIndexFileName="search.json" chatSlug="/chat" />);
+            fireEvent.keyDown(window, { key: "k", ctrlKey: true });
+            expect(screen.getByPlaceholderText("type to search_")).toBeInTheDocument();
+            fireEvent.keyDown(window, { key: "Escape" });
+            expect(screen.queryByPlaceholderText("type to search_")).toBeNull();
+        });
+    });
+
+    describe("when opened via custom event", () => {
+        it("renders after the command-palette-open event fires", async () => {
+            render(<CommandPalette searchIndexFileName="search.json" chatSlug="/chat" />);
+            await act(async () => {
+                window.dispatchEvent(new CustomEvent("command-palette-open"));
+            });
+            expect(screen.getByPlaceholderText("type to search_")).toBeInTheDocument();
+        });
+    });
+});

--- a/src/components/design-system/organism/command-palette/command-palette/customize-matrix-rain-item/customize-matrix-rain-item.test.tsx
+++ b/src/components/design-system/organism/command-palette/command-palette/customize-matrix-rain-item/customize-matrix-rain-item.test.tsx
@@ -1,65 +1,78 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { CustomizeMatrixRainItem } from "./customize-matrix-rain-item";
 
-vi.mock("cmdk", () => ({
-    Command: Object.assign(
-        ({ children }: React.PropsWithChildren) => <div>{children}</div>,
-        {
-            Item: ({
-                children,
-                onSelect,
-                value,
-            }: React.PropsWithChildren<{ onSelect?: () => void; value?: string }>) => (
-                <button onClick={onSelect} aria-label={value}>
-                    {children}
-                </button>
-            ),
-        },
-    ),
+const { mockUseWebGpuSupported, mockUseReducedMotions, mockOpenMatrixRainPanel } = vi.hoisted(() => ({
+    mockUseWebGpuSupported: vi.fn(),
+    mockUseReducedMotions: vi.fn(),
+    mockOpenMatrixRainPanel: vi.fn(),
 }));
 
-vi.mock("matrix-rain-webgpu", () => ({
-    isWebGPUSupported: () => true,
+vi.mock("cmdk", () => ({
+    Command: Object.assign(({ children }: React.PropsWithChildren) => <div>{children}</div>, {
+        Item: ({ children, onSelect, value }: React.PropsWithChildren<{ onSelect?: () => void; value?: string }>) => (
+            <button onClick={onSelect} aria-label={value}>
+                {children}
+            </button>
+        ),
+    }),
+}));
+
+vi.mock("@/components/design-system/hooks/use-webgpu-supported", () => ({
+    useWebGpuSupported: mockUseWebGpuSupported,
+}));
+
+vi.mock("@/components/design-system/hooks/use-reduced-motions", () => ({
+    useReducedMotions: mockUseReducedMotions,
 }));
 
 vi.mock("@/components/design-system/state/command-palette/command-palette-events", () => ({
-    openMatrixRainPanel: vi.fn(),
-    commandPaletteOpenEvent: "command-palette-open",
-    openCommandPalette: vi.fn(),
+    openMatrixRainPanel: mockOpenMatrixRainPanel,
 }));
 
+const customizeButton = () => screen.queryByRole("button", { name: "customize matrix rain" });
+
 describe("CustomizeMatrixRainItem", () => {
-    describe("render", () => {
-        it("renders the customize item when WebGPU is supported and motion is enabled", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockUseWebGpuSupported.mockReturnValue(true);
+        mockUseReducedMotions.mockReturnValue(false);
+    });
+
+    describe("visibility", () => {
+        it("renders the item when WebGPU is supported and motion is enabled", () => {
             render(<CustomizeMatrixRainItem onClose={vi.fn()} />);
-            const btn = screen.queryByRole("button", { name: "customize matrix rain" });
-            if (btn) {
-                expect(btn).toBeInTheDocument();
-            }
+            expect(customizeButton()).toBeInTheDocument();
+        });
+
+        it("does not render when WebGPU is unsupported", () => {
+            mockUseWebGpuSupported.mockReturnValue(false);
+            render(<CustomizeMatrixRainItem onClose={vi.fn()} />);
+            expect(customizeButton()).not.toBeInTheDocument();
+        });
+
+        it("does not render when the user prefers reduced motion", () => {
+            mockUseReducedMotions.mockReturnValue(true);
+            render(<CustomizeMatrixRainItem onClose={vi.fn()} />);
+            expect(customizeButton()).not.toBeInTheDocument();
         });
     });
 
     describe("interaction", () => {
-        it("calls onClose when item is selected", async () => {
+        it("calls onClose and opens the matrix rain panel when selected", async () => {
             const onClose = vi.fn();
             render(<CustomizeMatrixRainItem onClose={onClose} />);
-            const btn = screen.queryByRole("button", { name: "customize matrix rain" });
-            if (btn) {
-                await userEvent.click(btn);
-                expect(onClose).toHaveBeenCalledOnce();
-            }
+            await userEvent.click(customizeButton()!);
+            expect(onClose).toHaveBeenCalledOnce();
+            expect(mockOpenMatrixRainPanel).toHaveBeenCalledOnce();
         });
 
-        it("calls onTrack when item is selected", async () => {
+        it("calls onTrack when selected", async () => {
             const onTrack = vi.fn();
             render(<CustomizeMatrixRainItem onClose={vi.fn()} onTrack={onTrack} />);
-            const btn = screen.queryByRole("button", { name: "customize matrix rain" });
-            if (btn) {
-                await userEvent.click(btn);
-                expect(onTrack).toHaveBeenCalledOnce();
-            }
+            await userEvent.click(customizeButton()!);
+            expect(onTrack).toHaveBeenCalledOnce();
         });
     });
 });

--- a/src/components/design-system/organism/command-palette/command-palette/customize-matrix-rain-item/customize-matrix-rain-item.test.tsx
+++ b/src/components/design-system/organism/command-palette/command-palette/customize-matrix-rain-item/customize-matrix-rain-item.test.tsx
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { CustomizeMatrixRainItem } from "./customize-matrix-rain-item";
+
+vi.mock("cmdk", () => ({
+    Command: Object.assign(
+        ({ children }: React.PropsWithChildren) => <div>{children}</div>,
+        {
+            Item: ({
+                children,
+                onSelect,
+                value,
+            }: React.PropsWithChildren<{ onSelect?: () => void; value?: string }>) => (
+                <button onClick={onSelect} aria-label={value}>
+                    {children}
+                </button>
+            ),
+        },
+    ),
+}));
+
+vi.mock("matrix-rain-webgpu", () => ({
+    isWebGPUSupported: () => true,
+}));
+
+vi.mock("@/components/design-system/state/command-palette/command-palette-events", () => ({
+    openMatrixRainPanel: vi.fn(),
+    commandPaletteOpenEvent: "command-palette-open",
+    openCommandPalette: vi.fn(),
+}));
+
+describe("CustomizeMatrixRainItem", () => {
+    describe("render", () => {
+        it("renders the customize item when WebGPU is supported and motion is enabled", () => {
+            render(<CustomizeMatrixRainItem onClose={vi.fn()} />);
+            const btn = screen.queryByRole("button", { name: "customize matrix rain" });
+            if (btn) {
+                expect(btn).toBeInTheDocument();
+            }
+        });
+    });
+
+    describe("interaction", () => {
+        it("calls onClose when item is selected", async () => {
+            const onClose = vi.fn();
+            render(<CustomizeMatrixRainItem onClose={onClose} />);
+            const btn = screen.queryByRole("button", { name: "customize matrix rain" });
+            if (btn) {
+                await userEvent.click(btn);
+                expect(onClose).toHaveBeenCalledOnce();
+            }
+        });
+
+        it("calls onTrack when item is selected", async () => {
+            const onTrack = vi.fn();
+            render(<CustomizeMatrixRainItem onClose={vi.fn()} onTrack={onTrack} />);
+            const btn = screen.queryByRole("button", { name: "customize matrix rain" });
+            if (btn) {
+                await userEvent.click(btn);
+                expect(onTrack).toHaveBeenCalledOnce();
+            }
+        });
+    });
+});

--- a/src/components/design-system/organism/command-palette/command-palette/search-result-item/search-result-item.test.tsx
+++ b/src/components/design-system/organism/command-palette/command-palette/search-result-item/search-result-item.test.tsx
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { SearchResultItem } from "./search-result-item";
+
+vi.mock("cmdk", () => ({
+    Command: Object.assign(
+        ({ children }: React.PropsWithChildren) => <div>{children}</div>,
+        {
+            Item: ({
+                children,
+                onSelect,
+                value,
+            }: React.PropsWithChildren<{ onSelect?: () => void; value?: string }>) => (
+                <div role="option" aria-label={value} onClick={onSelect}>
+                    {children}
+                </div>
+            ),
+        },
+    ),
+}));
+
+describe("SearchResultItem", () => {
+    describe("render", () => {
+        it("renders the title", () => {
+            render(
+                <SearchResultItem
+                    title="Test Article"
+                    description="A great article"
+                    slug="/blog/test"
+                    onSelect={vi.fn()}
+                />,
+            );
+            expect(screen.getByText(/Test Article/)).toBeInTheDocument();
+        });
+
+        it("renders the description", () => {
+            render(
+                <SearchResultItem
+                    title="Test Article"
+                    description="A great article"
+                    slug="/blog/test"
+                    onSelect={vi.fn()}
+                />,
+            );
+            expect(screen.getByText("A great article")).toBeInTheDocument();
+        });
+    });
+
+    describe("interaction", () => {
+        it("calls onSelect with the slug when item is selected", () => {
+            const onSelect = vi.fn();
+            render(
+                <SearchResultItem
+                    title="Test Article"
+                    description="A great article"
+                    slug="/blog/test"
+                    onSelect={onSelect}
+                />,
+            );
+            screen.getByRole("option").click();
+            expect(onSelect).toHaveBeenCalledWith("/blog/test");
+        });
+    });
+});

--- a/src/components/design-system/organism/command-palette/command-palette/toggle-motion-item/toggle-motion-item.test.tsx
+++ b/src/components/design-system/organism/command-palette/command-palette/toggle-motion-item/toggle-motion-item.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ToggleMotionItem } from "./toggle-motion-item";
+
+vi.mock("cmdk", () => ({
+    Command: Object.assign(
+        ({ children }: React.PropsWithChildren) => <div>{children}</div>,
+        {
+            Item: ({
+                children,
+                onSelect,
+                value,
+            }: React.PropsWithChildren<{ onSelect?: () => void; value?: string }>) => (
+                <button onClick={onSelect} aria-label={value}>
+                    {children}
+                </button>
+            ),
+        },
+    ),
+}));
+
+vi.mock("@/components/design-system/state/motion/motion", () => ({
+    writeMotion: vi.fn(),
+    hasMotion: () => true,
+    motionChangeEvent: "motion-change",
+}));
+
+describe("ToggleMotionItem", () => {
+    describe("render", () => {
+        it("renders the toggle animations item", () => {
+            render(<ToggleMotionItem />);
+            expect(screen.getByText(/Toggle Animations/)).toBeInTheDocument();
+        });
+
+        it("shows current motion state label", () => {
+            render(<ToggleMotionItem />);
+            expect(screen.getByText(/\[ON\]|\[OFF\]/)).toBeInTheDocument();
+        });
+    });
+
+    describe("interaction", () => {
+        it("calls onTrack when item is selected", async () => {
+            const onTrack = vi.fn();
+            render(<ToggleMotionItem onTrack={onTrack} />);
+            await userEvent.click(screen.getByRole("button", { name: "toggle animations motion" }));
+            expect(onTrack).toHaveBeenCalledOnce();
+        });
+    });
+});

--- a/src/components/design-system/organism/cookie-consent-banner/cookie-consent-banner.test.tsx
+++ b/src/components/design-system/organism/cookie-consent-banner/cookie-consent-banner.test.tsx
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { CookieConsentBanner } from "./cookie-consent-banner";
+
+vi.mock("framer-motion", () => ({
+    AnimatePresence: ({ children }: React.PropsWithChildren) => <>{children}</>,
+    motion: {
+        div: ({ children, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+            <div {...props}>{children}</div>
+        ),
+    },
+}));
+
+describe("CookieConsentBanner", () => {
+    describe("render", () => {
+        it("renders the consent dialog when not yet decided", () => {
+            render(<CookieConsentBanner decided={false} onAccept={vi.fn()} onReject={vi.fn()} />);
+            expect(screen.getByRole("dialog")).toBeInTheDocument();
+        });
+
+        it("renders the accept button", () => {
+            render(<CookieConsentBanner decided={false} onAccept={vi.fn()} onReject={vi.fn()} />);
+            expect(screen.getByText(/Wake up/)).toBeInTheDocument();
+        });
+
+        it("renders the reject button", () => {
+            render(<CookieConsentBanner decided={false} onAccept={vi.fn()} onReject={vi.fn()} />);
+            expect(screen.getByText(/Sleep/)).toBeInTheDocument();
+        });
+
+        it("renders nothing when already decided", () => {
+            const { container } = render(
+                <CookieConsentBanner decided={true} onAccept={vi.fn()} onReject={vi.fn()} />,
+            );
+            expect(container.querySelector("[role='dialog']")).toBeNull();
+        });
+    });
+
+    describe("interaction", () => {
+        it("calls onAccept when the accept button is clicked", async () => {
+            const onAccept = vi.fn();
+            render(<CookieConsentBanner decided={false} onAccept={onAccept} onReject={vi.fn()} />);
+            await userEvent.click(screen.getByText(/Wake up/));
+            expect(onAccept).toHaveBeenCalledOnce();
+        });
+
+        it("calls onReject when the reject button is clicked", async () => {
+            const onReject = vi.fn();
+            render(<CookieConsentBanner decided={false} onAccept={vi.fn()} onReject={onReject} />);
+            await userEvent.click(screen.getByText(/Sleep/));
+            expect(onReject).toHaveBeenCalledOnce();
+        });
+    });
+});

--- a/src/components/design-system/organism/footer/footer.test.tsx
+++ b/src/components/design-system/organism/footer/footer.test.tsx
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Footer } from "./footer";
+import type { FooterNavHrefs } from "./footer";
+import type { SocialContactLinks } from "./footer";
+
+vi.mock("next/link", () => ({
+    default: ({
+        href,
+        children,
+        ...rest
+    }: React.AnchorHTMLAttributes<HTMLAnchorElement> & { href: string }) => (
+        <a href={href} {...rest}>
+            {children}
+        </a>
+    ),
+}));
+
+const navHrefs: FooterNavHrefs = {
+    blog: "/blog",
+    art: "/art",
+    aboutMe: "/about-me",
+    archive: "/archive",
+    tags: "/tags",
+    contact: "/contact",
+};
+
+const socialLinks: SocialContactLinks = {
+    github: "https://github.com/chicio",
+    linkedin: "https://linkedin.com/in/chicio",
+    medium: "https://medium.com/@chicio",
+    devto: "https://dev.to/chicio",
+    twitter: "https://twitter.com/chicio",
+    facebook: "https://facebook.com/chicio",
+    instagram: "https://instagram.com/chicio",
+};
+
+describe("Footer", () => {
+    describe("render", () => {
+        it("renders the author credit", () => {
+            render(<Footer author="Fabrizio Duroni" navHrefs={navHrefs} socialLinks={socialLinks} />);
+            expect(screen.getByText(/Fabrizio Duroni/)).toBeInTheDocument();
+        });
+
+        it("renders nav links for all sections", () => {
+            render(<Footer author="Fabrizio" navHrefs={navHrefs} socialLinks={socialLinks} />);
+            expect(screen.getByRole("link", { name: "Blog" })).toHaveAttribute("href", "/blog");
+            expect(screen.getByRole("link", { name: "About Me" })).toHaveAttribute("href", "/about-me");
+            expect(screen.getByRole("link", { name: "Home" })).toHaveAttribute("href", "/");
+        });
+
+        it("renders social contacts section", () => {
+            render(<Footer author="Fabrizio" navHrefs={navHrefs} socialLinks={socialLinks} />);
+            expect(screen.getByTitle("Github")).toBeInTheDocument();
+            expect(screen.getByTitle("Linkedin")).toBeInTheDocument();
+        });
+    });
+
+    describe("interaction", () => {
+        it("calls onTrackBlog when Blog nav link is clicked", async () => {
+            const onTrackBlog = vi.fn();
+            render(
+                <Footer
+                    author="Fabrizio"
+                    navHrefs={navHrefs}
+                    socialLinks={socialLinks}
+                    navTracking={{ onTrackBlog }}
+                />,
+            );
+            await userEvent.click(screen.getByRole("link", { name: "Blog" }));
+            expect(onTrackBlog).toHaveBeenCalledOnce();
+        });
+
+        it("calls onTrackGithub when github link is clicked", async () => {
+            const onTrackGithub = vi.fn();
+            render(
+                <Footer
+                    author="Fabrizio"
+                    navHrefs={navHrefs}
+                    socialLinks={socialLinks}
+                    socialTracking={{ onTrackGithub }}
+                />,
+            );
+            const githubLink = screen.getByTitle("Github").closest("a")!;
+            await userEvent.click(githubLink);
+            expect(onTrackGithub).toHaveBeenCalledOnce();
+        });
+    });
+});

--- a/src/components/design-system/organism/header/brand-header/brand-header.test.tsx
+++ b/src/components/design-system/organism/header/brand-header/brand-header.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { BrandHeader } from "./brand-header";
+
+vi.mock("@/components/design-system/molecules/effects/matrix-header-background", () => ({
+    MatrixHeaderBackground: () => <div data-testid="matrix-header-background" />,
+}));
+
+vi.mock("@/components/design-system/atoms/effects/image-glow", () => ({
+    ImageGlow: ({
+        alt,
+        src,
+        ...rest
+    }: React.ImgHTMLAttributes<HTMLImageElement> & { src: string }) => <img alt={alt} src={src} {...rest} />,
+}));
+
+vi.mock("next/image", () => ({
+    default: ({
+        alt,
+        src,
+        ...rest
+    }: React.ImgHTMLAttributes<HTMLImageElement> & { src: string }) => <img alt={alt} src={src} {...rest} />,
+}));
+
+describe("BrandHeader", () => {
+    describe("render", () => {
+        it("renders the site title", () => {
+            render(<BrandHeader big={false} />);
+            expect(screen.getByText(/CHICIO CODING/)).toBeInTheDocument();
+        });
+
+        it("renders the site tagline", () => {
+            render(<BrandHeader big={false} />);
+            expect(screen.getByText(/Pixels\. Code\. Unplugged\./)).toBeInTheDocument();
+        });
+
+        it("renders the logo image", () => {
+            render(<BrandHeader big={false} />);
+            expect(screen.getByAltText("blog logo")).toBeInTheDocument();
+        });
+
+        it("accepts a custom wrapper component", () => {
+            const Wrapper = ({ children }: React.PropsWithChildren) => (
+                <div data-testid="custom-wrapper">{children}</div>
+            );
+            render(<BrandHeader big={false} wrapper={Wrapper} />);
+            expect(screen.getByTestId("custom-wrapper")).toBeInTheDocument();
+        });
+    });
+});

--- a/src/components/design-system/organism/header/generic-header/generic-header.test.tsx
+++ b/src/components/design-system/organism/header/generic-header/generic-header.test.tsx
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { GenericHeader } from "./generic-header";
+
+describe("GenericHeader", () => {
+    const logo = <span data-testid="logo-icon">Icon</span>;
+
+    describe("render", () => {
+        it("renders the title", () => {
+            render(<GenericHeader title="Chat" subtitle="AI assistant" logo={logo} />);
+            expect(screen.getByText("Chat")).toBeInTheDocument();
+        });
+
+        it("renders the subtitle", () => {
+            render(<GenericHeader title="Chat" subtitle="AI assistant" logo={logo} />);
+            expect(screen.getByText("AI assistant")).toBeInTheDocument();
+        });
+
+        it("renders the logo", () => {
+            render(<GenericHeader title="Chat" subtitle="AI assistant" logo={logo} />);
+            expect(screen.getByTestId("logo-icon")).toBeInTheDocument();
+        });
+
+        it("renders nothing when visible is false", () => {
+            const { container } = render(
+                <GenericHeader title="Chat" subtitle="AI assistant" logo={logo} visible={false} />,
+            );
+            expect(container.firstChild).toBeNull();
+        });
+
+        it("renders when visible defaults to true", () => {
+            render(<GenericHeader title="Chat" subtitle="AI assistant" logo={logo} />);
+            expect(screen.getByText("Chat")).toBeInTheDocument();
+        });
+    });
+
+    describe("interaction", () => {
+        it("responds to click (toggles subtitle via store) without throwing", async () => {
+            render(<GenericHeader title="Chat" subtitle="AI assistant" logo={logo} />);
+            const header = screen.getByText("Chat").closest("div")!;
+            await userEvent.click(header);
+            expect(screen.getByText("AI assistant")).toBeInTheDocument();
+        });
+    });
+});

--- a/src/components/design-system/organism/image-carousel/fullscreen-modal/fullscreen-modal.test.tsx
+++ b/src/components/design-system/organism/image-carousel/fullscreen-modal/fullscreen-modal.test.tsx
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { fireEvent } from "@testing-library/react";
+import { FullscreenModal } from "./fullscreen-modal";
+
+vi.mock("next/image", () => ({
+    default: ({
+        alt,
+        src,
+        ...rest
+    }: React.ImgHTMLAttributes<HTMLImageElement> & { src: string; fill?: boolean }) => (
+        <img alt={alt} src={src} {...rest} />
+    ),
+}));
+
+vi.mock("@/components/design-system/atoms/animation/motion-div", () => ({
+    MotionDiv: ({ children, ...props }: React.HTMLAttributes<HTMLDivElement>) => <div {...props}>{children}</div>,
+}));
+
+const images = ["/img1.jpg", "/img2.jpg", "/img3.jpg"];
+
+describe("FullscreenModal", () => {
+    describe("render", () => {
+        it("renders a dialog with aria-modal", () => {
+            render(<FullscreenModal images={images} currentIndex={0} onClose={vi.fn()} alt="Gallery" />);
+            expect(screen.getByRole("dialog")).toBeInTheDocument();
+            expect(screen.getByRole("dialog")).toHaveAttribute("aria-modal", "true");
+        });
+
+        it("renders a close button", () => {
+            render(<FullscreenModal images={images} currentIndex={0} onClose={vi.fn()} alt="Gallery" />);
+            expect(screen.getByRole("button", { name: "Close fullscreen" })).toBeInTheDocument();
+        });
+
+        it("renders navigation buttons for multiple images", () => {
+            render(<FullscreenModal images={images} currentIndex={0} onClose={vi.fn()} alt="Gallery" />);
+            expect(screen.getByRole("button", { name: "Previous image" })).toBeInTheDocument();
+            expect(screen.getByRole("button", { name: "Next image" })).toBeInTheDocument();
+        });
+
+        it("renders all images", () => {
+            render(<FullscreenModal images={images} currentIndex={0} onClose={vi.fn()} alt="Photo" />);
+            expect(screen.getByAltText("Photo - Image 1")).toBeInTheDocument();
+            expect(screen.getByAltText("Photo - Image 2")).toBeInTheDocument();
+        });
+    });
+
+    describe("interaction", () => {
+        it("calls onClose when close button is clicked", async () => {
+            const onClose = vi.fn();
+            render(<FullscreenModal images={images} currentIndex={0} onClose={onClose} alt="Gallery" />);
+            await userEvent.click(screen.getByRole("button", { name: "Close fullscreen" }));
+            expect(onClose).toHaveBeenCalled();
+        });
+
+        it("calls onClose when Escape key is pressed", () => {
+            const onClose = vi.fn();
+            render(<FullscreenModal images={images} currentIndex={0} onClose={onClose} alt="Gallery" />);
+            const dialog = screen.getByRole("dialog");
+            fireEvent.keyDown(dialog, { key: "Escape" });
+            expect(onClose).toHaveBeenCalledOnce();
+        });
+
+        it("navigates to next image when ArrowRight is pressed", () => {
+            const onNavigate = vi.fn();
+            render(
+                <FullscreenModal
+                    images={images}
+                    currentIndex={0}
+                    onClose={vi.fn()}
+                    onNavigate={onNavigate}
+                    alt="Gallery"
+                />,
+            );
+            const dialog = screen.getByRole("dialog");
+            fireEvent.keyDown(dialog, { key: "ArrowRight" });
+            expect(onNavigate).toHaveBeenCalledWith(1);
+        });
+
+        it("navigates to previous image when ArrowLeft is pressed", () => {
+            const onNavigate = vi.fn();
+            render(
+                <FullscreenModal
+                    images={images}
+                    currentIndex={1}
+                    onClose={vi.fn()}
+                    onNavigate={onNavigate}
+                    alt="Gallery"
+                />,
+            );
+            const dialog = screen.getByRole("dialog");
+            fireEvent.keyDown(dialog, { key: "ArrowLeft" });
+            expect(onNavigate).toHaveBeenCalledWith(0);
+        });
+    });
+});

--- a/src/components/design-system/organism/image-carousel/image-carousel.test.tsx
+++ b/src/components/design-system/organism/image-carousel/image-carousel.test.tsx
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ImageCarousel } from "./image-carousel";
+
+vi.mock("next/image", () => ({
+    default: ({
+        alt,
+        src,
+        ...rest
+    }: React.ImgHTMLAttributes<HTMLImageElement> & { src: string }) => (
+        <img alt={alt} src={src} {...rest} />
+    ),
+}));
+
+vi.mock("@/components/design-system/atoms/effects/image-glow", () => ({
+    ImageGlow: ({
+        alt,
+        src,
+        onClick,
+        ...rest
+    }: React.ImgHTMLAttributes<HTMLImageElement> & { src: string }) => (
+        <img alt={alt} src={src} onClick={onClick} {...rest} />
+    ),
+}));
+
+vi.mock("@/components/design-system/atoms/animation/motion-div", () => ({
+    MotionDiv: ({ children, ...props }: React.HTMLAttributes<HTMLDivElement>) => <div {...props}>{children}</div>,
+}));
+
+vi.mock("@/components/design-system/atoms/effects/image-shimmer-placeholder", () => ({
+    imageShimmerPlaceholder: "blur",
+}));
+
+const singleImage = ["/photo.jpg"];
+const multipleImages = ["/img1.jpg", "/img2.jpg", "/img3.jpg"];
+
+describe("ImageCarousel", () => {
+    describe("single image", () => {
+        it("renders the image with correct alt text", () => {
+            render(<ImageCarousel images={singleImage} alt="My Photo" />);
+            expect(screen.getByAltText("My Photo")).toBeInTheDocument();
+        });
+
+        it("renders the caption when provided", () => {
+            render(<ImageCarousel images={singleImage} alt="My Photo" caption="A beautiful scene" />);
+            expect(screen.getByText("A beautiful scene")).toBeInTheDocument();
+        });
+
+        it("does not render navigation buttons for a single image", () => {
+            render(<ImageCarousel images={singleImage} alt="My Photo" />);
+            expect(screen.queryByRole("button", { name: "Previous image" })).toBeNull();
+            expect(screen.queryByRole("button", { name: "Next image" })).toBeNull();
+        });
+    });
+
+    describe("multiple images", () => {
+        it("renders navigation buttons", () => {
+            render(<ImageCarousel images={multipleImages} alt="Gallery" />);
+            expect(screen.getByRole("button", { name: "Previous image" })).toBeInTheDocument();
+            expect(screen.getByRole("button", { name: "Next image" })).toBeInTheDocument();
+        });
+
+        it("renders page indicator buttons", () => {
+            render(<ImageCarousel images={multipleImages} alt="Gallery" />);
+            expect(screen.getByRole("button", { name: "Go to image 1" })).toBeInTheDocument();
+            expect(screen.getByRole("button", { name: "Go to image 2" })).toBeInTheDocument();
+        });
+    });
+
+    describe("fullscreen", () => {
+        it("opens fullscreen modal when single image is clicked", async () => {
+            render(<ImageCarousel images={singleImage} alt="My Photo" />);
+            const img = screen.getByAltText("My Photo");
+            await userEvent.click(img);
+            expect(screen.getByRole("dialog")).toBeInTheDocument();
+        });
+    });
+});

--- a/src/components/design-system/organism/image-carousel/navigation-buttons/navigation-buttons.test.tsx
+++ b/src/components/design-system/organism/image-carousel/navigation-buttons/navigation-buttons.test.tsx
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { NavigationButtons } from "./navigation-buttons";
+
+describe("NavigationButtons", () => {
+    describe("render", () => {
+        it("renders the previous button", () => {
+            render(<NavigationButtons onPrevious={vi.fn()} onNext={vi.fn()} />);
+            expect(screen.getByRole("button", { name: "Previous image" })).toBeInTheDocument();
+        });
+
+        it("renders the next button", () => {
+            render(<NavigationButtons onPrevious={vi.fn()} onNext={vi.fn()} />);
+            expect(screen.getByRole("button", { name: "Next image" })).toBeInTheDocument();
+        });
+    });
+
+    describe("interaction", () => {
+        it("calls onPrevious when previous button is clicked", async () => {
+            const onPrevious = vi.fn();
+            render(<NavigationButtons onPrevious={onPrevious} onNext={vi.fn()} />);
+            await userEvent.click(screen.getByRole("button", { name: "Previous image" }));
+            expect(onPrevious).toHaveBeenCalledOnce();
+        });
+
+        it("calls onNext when next button is clicked", async () => {
+            const onNext = vi.fn();
+            render(<NavigationButtons onPrevious={vi.fn()} onNext={onNext} />);
+            await userEvent.click(screen.getByRole("button", { name: "Next image" }));
+            expect(onNext).toHaveBeenCalledOnce();
+        });
+    });
+});

--- a/src/components/design-system/organism/image-carousel/page-indicators/page-indicator-button/page-indicator-button.test.tsx
+++ b/src/components/design-system/organism/image-carousel/page-indicators/page-indicator-button/page-indicator-button.test.tsx
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { PageIndicatorButton } from "./page-indicator-button";
+
+describe("PageIndicatorButton", () => {
+    describe("render", () => {
+        it("renders a button with the correct aria-label", () => {
+            render(<PageIndicatorButton index={0} isActive={false} onSelect={vi.fn()} />);
+            expect(screen.getByRole("button", { name: "Go to image 1" })).toBeInTheDocument();
+        });
+
+        it("applies active style when isActive is true", () => {
+            render(<PageIndicatorButton index={2} isActive={true} onSelect={vi.fn()} />);
+            const btn = screen.getByRole("button", { name: "Go to image 3" });
+            expect(btn.className).toContain("bg-primary");
+        });
+
+        it("applies inactive style when isActive is false", () => {
+            render(<PageIndicatorButton index={0} isActive={false} onSelect={vi.fn()} />);
+            const btn = screen.getByRole("button", { name: "Go to image 1" });
+            expect(btn.className).toContain("bg-primary-text");
+        });
+    });
+
+    describe("interaction", () => {
+        it("calls onSelect with the index when clicked", async () => {
+            const onSelect = vi.fn();
+            render(<PageIndicatorButton index={3} isActive={false} onSelect={onSelect} />);
+            await userEvent.click(screen.getByRole("button", { name: "Go to image 4" }));
+            expect(onSelect).toHaveBeenCalledWith(3);
+        });
+    });
+});

--- a/src/components/design-system/organism/image-carousel/page-indicators/page-indicators.test.tsx
+++ b/src/components/design-system/organism/image-carousel/page-indicators/page-indicators.test.tsx
@@ -1,0 +1,32 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { PageIndicators } from "./page-indicators";
+
+const images = ["/img1.jpg", "/img2.jpg", "/img3.jpg"];
+
+describe("PageIndicators", () => {
+    describe("render", () => {
+        it("renders a button for each image", () => {
+            render(<PageIndicators images={images} currentIndex={0} onSelect={vi.fn()} />);
+            expect(screen.getByRole("button", { name: "Go to image 1" })).toBeInTheDocument();
+            expect(screen.getByRole("button", { name: "Go to image 2" })).toBeInTheDocument();
+            expect(screen.getByRole("button", { name: "Go to image 3" })).toBeInTheDocument();
+        });
+
+        it("marks the current index button as active", () => {
+            render(<PageIndicators images={images} currentIndex={1} onSelect={vi.fn()} />);
+            const activeBtn = screen.getByRole("button", { name: "Go to image 2" });
+            expect(activeBtn.className).toContain("bg-primary");
+        });
+    });
+
+    describe("interaction", () => {
+        it("calls onSelect with correct index when a button is clicked", async () => {
+            const onSelect = vi.fn();
+            render(<PageIndicators images={images} currentIndex={0} onSelect={onSelect} />);
+            await userEvent.click(screen.getByRole("button", { name: "Go to image 2" }));
+            expect(onSelect).toHaveBeenCalledWith(1);
+        });
+    });
+});

--- a/src/components/design-system/organism/loading-bar/loading-bar.test.tsx
+++ b/src/components/design-system/organism/loading-bar/loading-bar.test.tsx
@@ -1,0 +1,23 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { LoadingBar } from "./loading-bar";
+
+describe("LoadingBar", () => {
+    describe("render", () => {
+        it("renders the default message", () => {
+            render(<LoadingBar />);
+            expect(screen.getByText(/Processing\.\.\./)).toBeInTheDocument();
+        });
+
+        it("renders a custom message when provided", () => {
+            render(<LoadingBar message="Loading data..." />);
+            expect(screen.getByText(/Loading data\.\.\./)).toBeInTheDocument();
+        });
+
+        it("renders the animated progress bar characters", () => {
+            const { container } = render(<LoadingBar />);
+            const divs = container.querySelectorAll("div");
+            expect(divs.length).toBeGreaterThanOrEqual(2);
+        });
+    });
+});

--- a/src/components/design-system/organism/menu/menu.test.tsx
+++ b/src/components/design-system/organism/menu/menu.test.tsx
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Menu } from "./menu";
+import type { MenuNavHrefs } from "./menu";
+
+vi.mock("next/navigation", () => ({
+    usePathname: () => "/",
+    useRouter: () => ({ push: vi.fn() }),
+}));
+
+vi.mock("next/link", () => ({
+    default: ({
+        href,
+        children,
+        ...rest
+    }: React.AnchorHTMLAttributes<HTMLAnchorElement> & { href: string }) => (
+        <a href={href} {...rest}>
+            {children}
+        </a>
+    ),
+}));
+
+vi.mock("@/components/design-system/atoms/animation/motion-div", () => ({
+    MotionDiv: ({ children, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+        <div {...props}>{children}</div>
+    ),
+}));
+
+vi.mock("framer-motion", () => ({
+    AnimatePresence: ({ children }: React.PropsWithChildren) => <>{children}</>,
+    motion: {
+        div: ({ children, ...props }: React.HTMLAttributes<HTMLDivElement>) => <div {...props}>{children}</div>,
+    },
+}));
+
+const navHrefs: MenuNavHrefs = {
+    blog: "/blog",
+    dsaRoadmap: "/dsa/roadmap",
+    dsaExercises: "/dsa/exercises",
+    chat: "/chat",
+    mcp: "/mcp",
+    aboutMe: "/about-me",
+    art: "/art",
+    videogames: "/videogames",
+    contact: "/contact",
+};
+
+describe("Menu", () => {
+    describe("render", () => {
+        it("renders the Home nav link", () => {
+            render(<Menu navHrefs={navHrefs} />);
+            const homeLinks = screen.getAllByRole("link", { name: "Home" });
+            expect(homeLinks.length).toBeGreaterThan(0);
+            expect(homeLinks[0]).toHaveAttribute("href", "/");
+        });
+
+        it("renders the Blog nav link", () => {
+            render(<Menu navHrefs={navHrefs} />);
+            const blogLinks = screen.getAllByRole("link", { name: "Blog" });
+            expect(blogLinks.length).toBeGreaterThan(0);
+            expect(blogLinks[0]).toHaveAttribute("href", "/blog");
+        });
+
+        it("renders the search button", () => {
+            render(<Menu navHrefs={navHrefs} />);
+            expect(screen.getByRole("button", { name: "Open command palette" })).toBeInTheDocument();
+        });
+    });
+
+    describe("interaction", () => {
+        it("calls onPaletteTrigger when search button is clicked", async () => {
+            const onPaletteTrigger = vi.fn();
+            render(<Menu navHrefs={navHrefs} onPaletteTrigger={onPaletteTrigger} />);
+            await userEvent.click(screen.getByRole("button", { name: "Open command palette" }));
+            expect(onPaletteTrigger).toHaveBeenCalledOnce();
+        });
+
+        it("calls tracking callback when a nav link is clicked", async () => {
+            const onTrackBlog = vi.fn();
+            render(<Menu navHrefs={navHrefs} tracking={{ onTrackBlog }} />);
+            const blogLinks = screen.getAllByRole("link", { name: "Blog" });
+            await userEvent.click(blogLinks[0]);
+            expect(onTrackBlog).toHaveBeenCalledOnce();
+        });
+    });
+});

--- a/src/components/design-system/organism/profile-photo/profile-photo.test.tsx
+++ b/src/components/design-system/organism/profile-photo/profile-photo.test.tsx
@@ -1,0 +1,31 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { ProfilePhoto } from "./profile-photo";
+
+vi.mock("next/image", () => ({
+    default: ({
+        alt,
+        src,
+        width,
+        height,
+        ...rest
+    }: React.ImgHTMLAttributes<HTMLImageElement> & { src: string }) => (
+        <img alt={alt} src={src} width={width} height={height} {...rest} />
+    ),
+}));
+
+describe("ProfilePhoto", () => {
+    describe("render", () => {
+        it("renders an image with the author as alt text", () => {
+            render(<ProfilePhoto author="Fabrizio Duroni" />);
+            const img = screen.getByAltText("Fabrizio Duroni");
+            expect(img).toBeInTheDocument();
+        });
+
+        it("renders the author photo path", () => {
+            render(<ProfilePhoto author="Fabrizio" />);
+            const img = screen.getByAltText("Fabrizio");
+            expect(img).toHaveAttribute("src", expect.stringContaining("fabrizio-duroni"));
+        });
+    });
+});

--- a/src/components/design-system/organism/reading-content-progress-bar/reading-content-progress-bar.test.tsx
+++ b/src/components/design-system/organism/reading-content-progress-bar/reading-content-progress-bar.test.tsx
@@ -1,0 +1,25 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { ContentProgressBar } from "./reading-content-progress-bar";
+
+vi.mock("framer-motion", () => ({
+    motion: {
+        div: ({ children, initial: _i, animate: _a, exit: _e, transition: _t, style: _s, ...props }: React.HTMLAttributes<HTMLDivElement> & { initial?: unknown; animate?: unknown; exit?: unknown; transition?: unknown }) => (
+            <div {...props}>{children}</div>
+        ),
+    },
+}));
+
+describe("ContentProgressBar", () => {
+    describe("render", () => {
+        it("renders without throwing", () => {
+            render(<ContentProgressBar contentId="test-content" />);
+            expect(document.body).toBeTruthy();
+        });
+
+        it("renders the terminal progress bar loading message", () => {
+            render(<ContentProgressBar contentId="test-content" />);
+            expect(screen.getByText(/Uploading knowledge/)).toBeInTheDocument();
+        });
+    });
+});

--- a/src/components/design-system/organism/social-contacts/social-contacts.test.tsx
+++ b/src/components/design-system/organism/social-contacts/social-contacts.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { SocialContacts } from "./social-contacts";
+
+vi.mock("next/link", () => ({
+    default: ({
+        href,
+        children,
+        ...rest
+    }: React.AnchorHTMLAttributes<HTMLAnchorElement> & { href: string }) => (
+        <a href={href} {...rest}>
+            {children}
+        </a>
+    ),
+}));
+
+const links = {
+    github: "https://github.com/chicio",
+    linkedin: "https://linkedin.com/in/chicio",
+    medium: "https://medium.com/@chicio",
+    devto: "https://dev.to/chicio",
+    twitter: "https://twitter.com/chicio",
+    facebook: "https://facebook.com/chicio",
+    instagram: "https://instagram.com/chicio",
+};
+
+describe("SocialContacts", () => {
+    describe("render", () => {
+        it("renders social icon links", () => {
+            render(<SocialContacts links={links} contactHref="/contact" />);
+            expect(screen.getByTitle("Github")).toBeInTheDocument();
+            expect(screen.getByTitle("Linkedin")).toBeInTheDocument();
+            expect(screen.getByTitle("Twitter")).toBeInTheDocument();
+        });
+
+        it("renders the contact link pointing to contactHref", () => {
+            render(<SocialContacts links={links} contactHref="/contact" />);
+            const contactLinks = screen.getAllByRole("link");
+            const contactLink = contactLinks.find((l) => l.getAttribute("href") === "/contact");
+            expect(contactLink).toBeDefined();
+        });
+    });
+
+    describe("interaction", () => {
+        it("calls onTrackGithub when github link is clicked", async () => {
+            const onTrackGithub = vi.fn();
+            render(<SocialContacts links={links} contactHref="/contact" onTrackGithub={onTrackGithub} />);
+            const githubLink = screen.getByTitle("Github").closest("a")!;
+            await userEvent.click(githubLink);
+            expect(onTrackGithub).toHaveBeenCalledOnce();
+        });
+
+        it("calls onTrackLinkedin when linkedin link is clicked", async () => {
+            const onTrackLinkedin = vi.fn();
+            render(<SocialContacts links={links} contactHref="/contact" onTrackLinkedin={onTrackLinkedin} />);
+            const linkedinLink = screen.getByTitle("Linkedin").closest("a")!;
+            await userEvent.click(linkedinLink);
+            expect(onTrackLinkedin).toHaveBeenCalledOnce();
+        });
+    });
+});

--- a/src/components/design-system/organism/tracking-optin/tracking-optin.test.tsx
+++ b/src/components/design-system/organism/tracking-optin/tracking-optin.test.tsx
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { TrackingOptIn } from "./tracking-optin";
+
+vi.mock("@next/third-parties/google", () => ({
+    GoogleAnalytics: () => <div data-testid="google-analytics" />,
+}));
+
+vi.mock("@vercel/analytics/next", () => ({
+    Analytics: () => <div data-testid="vercel-analytics" />,
+}));
+
+vi.mock("@vercel/speed-insights/next", () => ({
+    SpeedInsights: () => <div data-testid="speed-insights" />,
+}));
+
+describe("TrackingOptIn", () => {
+    describe("when enabled", () => {
+        it("renders tracking providers", () => {
+            render(<TrackingOptIn enabled={true} />);
+            expect(screen.getByTestId("google-analytics")).toBeInTheDocument();
+            expect(screen.getByTestId("vercel-analytics")).toBeInTheDocument();
+            expect(screen.getByTestId("speed-insights")).toBeInTheDocument();
+        });
+    });
+
+    describe("when disabled", () => {
+        it("renders nothing", () => {
+            const { container } = render(<TrackingOptIn enabled={false} />);
+            expect(container.firstChild).toBeNull();
+        });
+    });
+});

--- a/src/components/design-system/templates/content-page-template/content-page-template.test.tsx
+++ b/src/components/design-system/templates/content-page-template/content-page-template.test.tsx
@@ -1,0 +1,148 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { ContentPageTemplate } from "./content-page-template";
+import type { MenuNavHrefs } from "@/components/design-system/organism/menu";
+import type { FooterNavHrefs, SocialContactLinks } from "@/components/design-system/organism/footer";
+
+vi.mock("next/navigation", () => ({
+    usePathname: () => "/",
+    useRouter: () => ({ push: vi.fn() }),
+}));
+
+vi.mock("next/link", () => ({
+    default: ({
+        href,
+        children,
+        ...rest
+    }: React.AnchorHTMLAttributes<HTMLAnchorElement> & { href: string }) => (
+        <a href={href} {...rest}>
+            {children}
+        </a>
+    ),
+}));
+
+vi.mock("next/image", () => ({
+    default: ({
+        alt,
+        src,
+        ...rest
+    }: React.ImgHTMLAttributes<HTMLImageElement> & { src: string }) => <img alt={alt} src={src} {...rest} />,
+}));
+
+vi.mock("@/components/design-system/atoms/animation/motion-div", () => ({
+    MotionDiv: ({ children, ...props }: React.HTMLAttributes<HTMLDivElement>) => <div {...props}>{children}</div>,
+}));
+
+vi.mock("framer-motion", () => ({
+    AnimatePresence: ({ children }: React.PropsWithChildren) => <>{children}</>,
+    motion: {
+        div: ({ children, initial: _i, animate: _a, exit: _e, transition: _t, style: _s, ...props }: React.HTMLAttributes<HTMLDivElement> & { initial?: unknown; animate?: unknown; exit?: unknown; transition?: unknown }) => (
+            <div {...props}>{children}</div>
+        ),
+        nav: ({ children, initial: _i, animate: _a, exit: _e, transition: _t, style: _s, ...props }: React.HTMLAttributes<HTMLElement> & { initial?: unknown; animate?: unknown; exit?: unknown; transition?: unknown }) => (
+            <nav {...props}>{children}</nav>
+        ),
+    },
+}));
+
+vi.mock("matrix-rain-webgpu", () => ({
+    isWebGPUSupported: () => false,
+    MatrixRainWebGPU: () => <div data-testid="matrix-rain-webgpu" />,
+}));
+
+vi.mock("@/components/design-system/molecules/effects/matrix-header-background", () => ({
+    MatrixHeaderBackground: () => <div data-testid="matrix-header-background" />,
+}));
+
+vi.mock("@/components/design-system/atoms/effects/image-glow", () => ({
+    ImageGlow: ({
+        alt,
+        src,
+        ...rest
+    }: React.ImgHTMLAttributes<HTMLImageElement> & { src: string }) => <img alt={alt} src={src} {...rest} />,
+}));
+
+vi.mock("@/components/design-system/state/command-palette/command-palette-events", () => ({
+    commandPaletteOpenEvent: "command-palette-open",
+    openCommandPalette: vi.fn(),
+    openMatrixRainPanel: vi.fn(),
+}));
+
+vi.mock("@/components/design-system/state/motion/motion", () => ({
+    writeMotion: vi.fn(),
+    hasMotion: () => true,
+    motionChangeEvent: "motion-change",
+}));
+
+const navHrefs: MenuNavHrefs = {
+    blog: "/blog",
+    dsaRoadmap: "/dsa/roadmap",
+    dsaExercises: "/dsa/exercises",
+    chat: "/chat",
+    mcp: "/mcp",
+    aboutMe: "/about-me",
+    art: "/art",
+    videogames: "/videogames",
+    contact: "/contact",
+};
+
+const footerNavHrefs: FooterNavHrefs = {
+    blog: "/blog",
+    art: "/art",
+    aboutMe: "/about-me",
+    archive: "/archive",
+    tags: "/tags",
+    contact: "/contact",
+};
+
+const socialLinks: SocialContactLinks = {
+    github: "https://github.com/chicio",
+    linkedin: "https://linkedin.com/in/chicio",
+    medium: "https://medium.com/@chicio",
+    devto: "https://dev.to/chicio",
+    twitter: "https://twitter.com/chicio",
+    facebook: "https://facebook.com/chicio",
+    instagram: "https://instagram.com/chicio",
+};
+
+describe("ContentPageTemplate", () => {
+    describe("render", () => {
+        it("renders the brand header with site title", () => {
+            render(
+                <ContentPageTemplate
+                    author="Fabrizio"
+                    navHrefs={navHrefs}
+                    footerNavHrefs={footerNavHrefs}
+                    socialLinks={socialLinks}
+                />,
+            );
+            expect(screen.getByText(/CHICIO CODING/)).toBeInTheDocument();
+        });
+
+        it("renders children", () => {
+            render(
+                <ContentPageTemplate
+                    author="Fabrizio"
+                    navHrefs={navHrefs}
+                    footerNavHrefs={footerNavHrefs}
+                    socialLinks={socialLinks}
+                >
+                    <p>Page body</p>
+                </ContentPageTemplate>,
+            );
+            expect(screen.getByText("Page body")).toBeInTheDocument();
+        });
+
+        it("renders the footer", () => {
+            render(
+                <ContentPageTemplate
+                    author="Fabrizio Duroni"
+                    navHrefs={navHrefs}
+                    footerNavHrefs={footerNavHrefs}
+                    socialLinks={socialLinks}
+                />,
+            );
+            expect(screen.getByRole("contentinfo")).toBeInTheDocument();
+        });
+    });
+});

--- a/src/components/design-system/templates/page-template/page-template.test.tsx
+++ b/src/components/design-system/templates/page-template/page-template.test.tsx
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { PageTemplate } from "./page-template";
+import type { MenuNavHrefs } from "@/components/design-system/organism/menu";
+import type { FooterNavHrefs, SocialContactLinks } from "@/components/design-system/organism/footer";
+
+vi.mock("next/navigation", () => ({
+    usePathname: () => "/",
+    useRouter: () => ({ push: vi.fn() }),
+}));
+
+vi.mock("next/link", () => ({
+    default: ({
+        href,
+        children,
+        ...rest
+    }: React.AnchorHTMLAttributes<HTMLAnchorElement> & { href: string }) => (
+        <a href={href} {...rest}>
+            {children}
+        </a>
+    ),
+}));
+
+vi.mock("next/image", () => ({
+    default: ({
+        alt,
+        src,
+        ...rest
+    }: React.ImgHTMLAttributes<HTMLImageElement> & { src: string }) => <img alt={alt} src={src} {...rest} />,
+}));
+
+vi.mock("@/components/design-system/atoms/animation/motion-div", () => ({
+    MotionDiv: ({ children, ...props }: React.HTMLAttributes<HTMLDivElement>) => <div {...props}>{children}</div>,
+}));
+
+vi.mock("framer-motion", () => ({
+    AnimatePresence: ({ children }: React.PropsWithChildren) => <>{children}</>,
+    motion: {
+        div: ({ children, initial: _i, animate: _a, exit: _e, transition: _t, style: _s, ...props }: React.HTMLAttributes<HTMLDivElement> & { initial?: unknown; animate?: unknown; exit?: unknown; transition?: unknown }) => (
+            <div {...props}>{children}</div>
+        ),
+        nav: ({ children, initial: _i, animate: _a, exit: _e, transition: _t, style: _s, ...props }: React.HTMLAttributes<HTMLElement> & { initial?: unknown; animate?: unknown; exit?: unknown; transition?: unknown }) => (
+            <nav {...props}>{children}</nav>
+        ),
+    },
+}));
+
+vi.mock("matrix-rain-webgpu", () => ({
+    isWebGPUSupported: () => false,
+}));
+
+vi.mock("@/components/design-system/state/command-palette/command-palette-events", () => ({
+    commandPaletteOpenEvent: "command-palette-open",
+    openCommandPalette: vi.fn(),
+    openMatrixRainPanel: vi.fn(),
+}));
+
+vi.mock("@/components/design-system/state/motion/motion", () => ({
+    writeMotion: vi.fn(),
+    hasMotion: () => true,
+    motionChangeEvent: "motion-change",
+}));
+
+const navHrefs: MenuNavHrefs = {
+    blog: "/blog",
+    dsaRoadmap: "/dsa/roadmap",
+    dsaExercises: "/dsa/exercises",
+    chat: "/chat",
+    mcp: "/mcp",
+    aboutMe: "/about-me",
+    art: "/art",
+    videogames: "/videogames",
+    contact: "/contact",
+};
+
+const footerNavHrefs: FooterNavHrefs = {
+    blog: "/blog",
+    art: "/art",
+    aboutMe: "/about-me",
+    archive: "/archive",
+    tags: "/tags",
+    contact: "/contact",
+};
+
+const socialLinks: SocialContactLinks = {
+    github: "https://github.com/chicio",
+    linkedin: "https://linkedin.com/in/chicio",
+    medium: "https://medium.com/@chicio",
+    devto: "https://dev.to/chicio",
+    twitter: "https://twitter.com/chicio",
+    facebook: "https://facebook.com/chicio",
+    instagram: "https://instagram.com/chicio",
+};
+
+describe("PageTemplate", () => {
+    describe("render", () => {
+        it("renders the header slot", () => {
+            render(
+                <PageTemplate
+                    header={<div data-testid="header-slot">Header</div>}
+                    author="Fabrizio"
+                    navHrefs={navHrefs}
+                    footerNavHrefs={footerNavHrefs}
+                    socialLinks={socialLinks}
+                />,
+            );
+            expect(screen.getByTestId("header-slot")).toBeInTheDocument();
+        });
+
+        it("renders children content", () => {
+            render(
+                <PageTemplate
+                    header={<div>Header</div>}
+                    author="Fabrizio"
+                    navHrefs={navHrefs}
+                    footerNavHrefs={footerNavHrefs}
+                    socialLinks={socialLinks}
+                >
+                    <p>Page content goes here</p>
+                </PageTemplate>,
+            );
+            expect(screen.getByText("Page content goes here")).toBeInTheDocument();
+        });
+
+        it("renders the footer with author name", () => {
+            render(
+                <PageTemplate
+                    header={<div>Header</div>}
+                    author="Fabrizio Duroni"
+                    navHrefs={navHrefs}
+                    footerNavHrefs={footerNavHrefs}
+                    socialLinks={socialLinks}
+                />,
+            );
+            expect(screen.getByText(/Fabrizio Duroni/)).toBeInTheDocument();
+        });
+
+        it("renders navigation menu", () => {
+            render(
+                <PageTemplate
+                    header={<div>Header</div>}
+                    author="Fabrizio"
+                    navHrefs={navHrefs}
+                    footerNavHrefs={footerNavHrefs}
+                    socialLinks={socialLinks}
+                />,
+            );
+            expect(screen.getAllByRole("link", { name: "Home" }).length).toBeGreaterThan(0);
+        });
+    });
+});

--- a/src/components/design-system/templates/reading-content-page-template/reading-content-page-template.test.tsx
+++ b/src/components/design-system/templates/reading-content-page-template/reading-content-page-template.test.tsx
@@ -1,0 +1,179 @@
+import { describe, it, expect, vi, beforeAll } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { ReadingContentPageTemplate } from "./reading-content-page-template";
+import type { MenuNavHrefs } from "@/components/design-system/organism/menu";
+import type { FooterNavHrefs, SocialContactLinks } from "@/components/design-system/organism/footer";
+
+vi.mock("next/navigation", () => ({
+    usePathname: () => "/",
+    useRouter: () => ({ push: vi.fn() }),
+}));
+
+vi.mock("next/link", () => ({
+    default: ({
+        href,
+        children,
+        ...rest
+    }: React.AnchorHTMLAttributes<HTMLAnchorElement> & { href: string }) => (
+        <a href={href} {...rest}>
+            {children}
+        </a>
+    ),
+}));
+
+vi.mock("next/image", () => ({
+    default: ({
+        alt,
+        src,
+        ...rest
+    }: React.ImgHTMLAttributes<HTMLImageElement> & { src: string }) => <img alt={alt} src={src} {...rest} />,
+}));
+
+vi.mock("@/components/design-system/atoms/animation/motion-div", () => ({
+    MotionDiv: ({ children, ...props }: React.HTMLAttributes<HTMLDivElement>) => <div {...props}>{children}</div>,
+}));
+
+vi.mock("framer-motion", () => ({
+    AnimatePresence: ({ children }: React.PropsWithChildren) => <>{children}</>,
+    motion: {
+        div: ({ children, initial: _i, animate: _a, exit: _e, transition: _t, style: _s, ...props }: React.HTMLAttributes<HTMLDivElement> & { initial?: unknown; animate?: unknown; exit?: unknown; transition?: unknown }) => (
+            <div {...props}>{children}</div>
+        ),
+        nav: ({ children, initial: _i, animate: _a, exit: _e, transition: _t, style: _s, ...props }: React.HTMLAttributes<HTMLElement> & { initial?: unknown; animate?: unknown; exit?: unknown; transition?: unknown }) => (
+            <nav {...props}>{children}</nav>
+        ),
+    },
+}));
+
+vi.mock("matrix-rain-webgpu", () => ({
+    isWebGPUSupported: () => false,
+    MatrixRainWebGPU: () => <div data-testid="matrix-rain-webgpu" />,
+}));
+
+vi.mock("@/components/design-system/molecules/effects/matrix-header-background", () => ({
+    MatrixHeaderBackground: () => <div data-testid="matrix-header-background" />,
+}));
+
+vi.mock("@/components/design-system/atoms/effects/image-glow", () => ({
+    ImageGlow: ({
+        alt,
+        src,
+        ...rest
+    }: React.ImgHTMLAttributes<HTMLImageElement> & { src: string }) => <img alt={alt} src={src} {...rest} />,
+}));
+
+vi.mock("@/components/design-system/state/command-palette/command-palette-events", () => ({
+    commandPaletteOpenEvent: "command-palette-open",
+    openCommandPalette: vi.fn(),
+    openMatrixRainPanel: vi.fn(),
+}));
+
+vi.mock("@/components/design-system/state/motion/motion", () => ({
+    writeMotion: vi.fn(),
+    hasMotion: () => true,
+    motionChangeEvent: "motion-change",
+}));
+
+beforeAll(() => {
+    vi.stubGlobal(
+        "IntersectionObserver",
+        class {
+            observe = vi.fn();
+            unobserve = vi.fn();
+            disconnect = vi.fn();
+        },
+    );
+});
+
+const navHrefs: MenuNavHrefs = {
+    blog: "/blog",
+    dsaRoadmap: "/dsa/roadmap",
+    dsaExercises: "/dsa/exercises",
+    chat: "/chat",
+    mcp: "/mcp",
+    aboutMe: "/about-me",
+    art: "/art",
+    videogames: "/videogames",
+    contact: "/contact",
+};
+
+const footerNavHrefs: FooterNavHrefs = {
+    blog: "/blog",
+    art: "/art",
+    aboutMe: "/about-me",
+    archive: "/archive",
+    tags: "/tags",
+    contact: "/contact",
+};
+
+const socialLinks: SocialContactLinks = {
+    github: "https://github.com/chicio",
+    linkedin: "https://linkedin.com/in/chicio",
+    medium: "https://medium.com/@chicio",
+    devto: "https://dev.to/chicio",
+    twitter: "https://twitter.com/chicio",
+    facebook: "https://facebook.com/chicio",
+    instagram: "https://instagram.com/chicio",
+};
+
+describe("ReadingContentPageTemplate", () => {
+    describe("render", () => {
+        it("renders the reading progress bar", () => {
+            render(
+                <ReadingContentPageTemplate
+                    author="Fabrizio"
+                    navHrefs={navHrefs}
+                    footerNavHrefs={footerNavHrefs}
+                    socialLinks={socialLinks}
+                />,
+            );
+            expect(screen.getByText(/Uploading knowledge/)).toBeInTheDocument();
+        });
+
+        it("renders children content", () => {
+            render(
+                <ReadingContentPageTemplate
+                    author="Fabrizio"
+                    navHrefs={navHrefs}
+                    footerNavHrefs={footerNavHrefs}
+                    socialLinks={socialLinks}
+                >
+                    <article>Article body</article>
+                </ReadingContentPageTemplate>,
+            );
+            expect(screen.getByText("Article body")).toBeInTheDocument();
+        });
+
+        it("renders breadcrumbs when provided", () => {
+            render(
+                <ReadingContentPageTemplate
+                    author="Fabrizio"
+                    navHrefs={navHrefs}
+                    footerNavHrefs={footerNavHrefs}
+                    socialLinks={socialLinks}
+                    breadcrumbs={[
+                        { label: "Blog", href: "/blog", isCurrent: false },
+                        { label: "My Article", href: "/blog/my-article", isCurrent: true },
+                    ]}
+                />,
+            );
+            expect(screen.getAllByText("Blog").length).toBeGreaterThan(0);
+            expect(screen.getAllByText("My Article").length).toBeGreaterThan(0);
+        });
+
+        it("renders beforeContent and afterContent slots", () => {
+            render(
+                <ReadingContentPageTemplate
+                    author="Fabrizio"
+                    navHrefs={navHrefs}
+                    footerNavHrefs={footerNavHrefs}
+                    socialLinks={socialLinks}
+                    beforeContent={<div>Before content</div>}
+                    afterContent={<div>After content</div>}
+                />,
+            );
+            expect(screen.getByText("Before content")).toBeInTheDocument();
+            expect(screen.getByText("After content")).toBeInTheDocument();
+        });
+    });
+});

--- a/tsconfig.typecheck.json
+++ b/tsconfig.typecheck.json
@@ -1,7 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "types": ["node", "mdx", "dom-chromium-ai", "vitest/globals"]
+    "types": ["node", "mdx", "dom-chromium-ai", "vitest/globals", "next/image-types/global"]
   },
   "include": [
     "src/**/*.test.ts",


### PR DESCRIPTION
Add co-located RTL tests for all organism and template component folders — 100% coverage at both tiers with 22 new test files and 154 passing tests total.

## Description

- **19 organism tests**: `command-palette`, `command-palette/search-result-item`, `command-palette/toggle-motion-item`, `command-palette/customize-matrix-rain-item`, `cookie-consent-banner`, `footer`, `header/brand-header`, `header/generic-header`, `image-carousel`, `image-carousel/fullscreen-modal`, `image-carousel/navigation-buttons`, `image-carousel/page-indicators`, `image-carousel/page-indicators/page-indicator-button`, `loading-bar`, `menu`, `profile-photo`, `reading-content-progress-bar`, `social-contacts`, `tracking-optin`
- **3 template tests**: `page-template`, `content-page-template`, `reading-content-page-template`
- **tsconfig.typecheck.json** fix: added `next/image-types/global` to `types` so static PNG imports transitively pulled in from test files resolve without needing a prior `next build` to generate `next-env.d.ts`

Each test follows the RTL conventions: render + interaction via the component (no separate renderHook for the store), framer-motion `motion.*` mocked to strip animation props, jsdom-incompatible deps (matrix-rain-webgpu, cmdk, next/image) mocked per-file. The `ReadingContentPageTemplate` test stubs `IntersectionObserver` via `vi.stubGlobal` for the `Breadcrumb` component. The `CommandPalette` test uses `vi.hoisted()` to stabilize the `useSearch` mock return and avoid infinite re-render loops.

Smoke-only tests (per-test note): none — all tests assert real rendered output.

## Motivation and Context

Delivery 2 of the testing pyramid climb (PR 3/5). Every organism and template component folder now has a co-located test, completing the design-system layer.

## How Has This Been Tested?
Browser

## Types of changes
- [ ] Bug fix :bug: (non-breaking change which fixes an issue)
- [x] New feature :sparkles: (non-breaking change which adds functionality)
- [ ] Breaking change :boom: (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project :beers:.
- [X] My change requires a change to the documentation :bulb: and I have updated the documentation accordingly.
- [X] I have read the [CONTRIBUTING](https://github.com/chicio/chicio-blog/blob/master/CONTRIBUTING.md) document :busts_in_silhouette:.
- [X] I have added tests to cover my changes :tada:.
- [X] All new and existing tests passed :white_check_mark:.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added broad coverage for key interface components and templates, including menus, headers, image browsing, consent prompts, command palette actions, and content pages.
  * Verified common interactions like opening overlays, navigating images, selecting options, and tracking link clicks.
  * Improved confidence in accessibility and keyboard behavior across several screens.

* **Chores**
  * Updated type-checking support for image-related assets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->