### PR TITLE
test(capabilities): :white_check_mark: add e2e specs for blog, search, DSA, videogames

### DIFF
--- a/e2e/blog.spec.ts
+++ b/e2e/blog.spec.ts
@@ -1,0 +1,71 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Blog section", () => {
+    test.describe("listing page", () => {
+        test("loads and shows post cards", async ({ page }) => {
+            await page.goto("/blog");
+            await expect(page).toHaveURL(/\/blog/);
+            await expect(page.getByRole("heading", { name: "App.js Conf 2026", level: 3 }).first()).toBeVisible();
+        });
+
+        test("shows Read more buttons for posts", async ({ page }) => {
+            await page.goto("/blog");
+            await expect(page.getByRole("button", { name: /read more/i }).first()).toBeVisible();
+        });
+
+        test("clicking a post title navigates to the post page", async ({ page }) => {
+            await page.goto("/blog");
+            await page.getByRole("heading", { name: "App.js Conf 2026", level: 3 }).first().click();
+            await expect(page).toHaveURL(/\/blog\/post\/2026\/06\/01\/app-js-conf-2026/);
+            await expect(page.getByRole("heading", { name: "App.js Conf 2026", level: 1 })).toBeVisible();
+        });
+    });
+
+    test.describe("post page", () => {
+        test("renders the post heading and MDX body", async ({ page }) => {
+            await page.goto("/blog/post/2026/06/01/app-js-conf-2026");
+            await expect(page.getByRole("heading", { name: "App.js Conf 2026", level: 1 })).toBeVisible();
+            await expect(page.getByRole("heading", { name: /some numbers/i })).toBeVisible();
+        });
+
+        test("shows breadcrumb navigation back to blog", async ({ page }) => {
+            await page.goto("/blog/post/2026/06/01/app-js-conf-2026");
+            await expect(page.getByRole("navigation", { name: "Breadcrumb" })).toBeVisible();
+            await expect(page.getByRole("link", { name: "Blog" }).first()).toBeVisible();
+        });
+
+        test("shows post tags", async ({ page }) => {
+            await page.goto("/blog/post/2026/06/01/app-js-conf-2026");
+            await expect(page.getByRole("link", { name: "react native" }).first()).toBeVisible();
+        });
+    });
+
+    test.describe("archive page", () => {
+        test("loads and lists all posts", async ({ page }) => {
+            await page.goto("/blog/archive");
+            await expect(page).toHaveURL(/\/blog\/archive/);
+            await expect(page.getByRole("heading", { name: "Archive", level: 1 })).toBeVisible();
+            await expect(page.getByRole("link", { name: "App.js Conf 2026" })).toBeVisible();
+        });
+
+        test("archive links navigate to post pages", async ({ page }) => {
+            await page.goto("/blog/archive");
+            await page.getByRole("link", { name: "App.js Conf 2026", exact: true }).click();
+            await expect(page).toHaveURL(/\/blog\/post\/2026\/06\/01\/app-js-conf-2026/, { timeout: 10000 });
+        });
+    });
+
+    test.describe("tag page", () => {
+        test("loads and shows posts for the tag", async ({ page }) => {
+            await page.goto("/blog/tag/react-native");
+            await expect(page).toHaveURL(/\/blog\/tag\/react-native/);
+            await expect(page.getByRole("heading", { name: /react native/i, level: 1 })).toBeVisible();
+            await expect(page.getByRole("link", { name: "App.js Conf 2026" })).toBeVisible();
+        });
+
+        test("returns HTTP 200", async ({ page }) => {
+            const response = await page.goto("/blog/tag/react-native");
+            expect(response?.status()).toBe(200);
+        });
+    });
+});

--- a/e2e/blog.spec.ts
+++ b/e2e/blog.spec.ts
@@ -38,6 +38,18 @@ test.describe("Blog section", () => {
             await page.goto("/blog/post/2026/06/01/app-js-conf-2026");
             await expect(page.getByRole("link", { name: "react native" }).first()).toBeVisible();
         });
+
+        test("read next section links navigate to another post", async ({ page }) => {
+            await page.goto("/blog/post/2026/06/01/app-js-conf-2026");
+            const readNext = page.getByRole("heading", { name: "Read next", level: 2 }).locator("..");
+            await expect(readNext).toBeVisible();
+            const firstReadNextPost = readNext.locator('a[href*="/blog/post/"]').first();
+            await expect(firstReadNextPost).toBeVisible();
+            const startUrl = page.url();
+            await firstReadNextPost.click();
+            await expect(page).not.toHaveURL(startUrl, { timeout: 10000 });
+            await expect(page).toHaveURL(/\/blog\/post\//);
+        });
     });
 
     test.describe("archive page", () => {

--- a/e2e/dsa.spec.ts
+++ b/e2e/dsa.spec.ts
@@ -1,0 +1,75 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Data Structures and Algorithms section", () => {
+    test.describe("roadmap page", () => {
+        test("loads and shows the topic table", async ({ page }) => {
+            await page.goto("/data-structures-and-algorithms/roadmap");
+            await expect(page).toHaveURL(/\/data-structures-and-algorithms\/roadmap/);
+            await expect(page.getByRole("heading", { name: "Data Structures and Algorithms", level: 1 })).toBeVisible();
+            await expect(page.getByRole("columnheader", { name: "Topic" }).first()).toBeVisible();
+        });
+
+        test("roadmap table lists known topics", async ({ page }) => {
+            await page.goto("/data-structures-and-algorithms/roadmap");
+            await expect(page.getByRole("cell", { name: "Arrays", exact: true })).toBeVisible();
+            await expect(page.getByRole("cell", { name: "Hashtable", exact: true })).toBeVisible();
+        });
+
+        test("clicking a topic link navigates to the topic page", async ({ page }) => {
+            await page.goto("/data-structures-and-algorithms/roadmap");
+            await page.getByRole("link", { name: "Arrays" }).click();
+            await expect(page).toHaveURL(/\/data-structures-and-algorithms\/topic\/array/);
+            await expect(page.getByRole("heading", { name: "Array", level: 1 })).toBeVisible();
+        });
+    });
+
+    test.describe("topic page", () => {
+        test("loads and renders the topic heading and MDX content", async ({ page }) => {
+            await page.goto("/data-structures-and-algorithms/topic/array");
+            await expect(page).toHaveURL(/\/data-structures-and-algorithms\/topic\/array/);
+            await expect(page.getByRole("heading", { name: "Array", level: 1 })).toBeVisible();
+            await expect(page.getByRole("heading", { name: /what is an array/i })).toBeVisible();
+        });
+
+        test("shows the exercises table", async ({ page }) => {
+            await page.goto("/data-structures-and-algorithms/topic/array");
+            await expect(page.getByRole("heading", { name: /exercises/i })).toBeVisible();
+            await expect(page.getByRole("columnheader", { name: "Exercise" })).toBeVisible();
+            await expect(page.getByRole("link", { name: "Move Zeroes" })).toBeVisible();
+        });
+
+        test("shows breadcrumb navigation", async ({ page }) => {
+            await page.goto("/data-structures-and-algorithms/topic/array");
+            await expect(page.getByRole("navigation", { name: "Breadcrumb" })).toBeVisible();
+            await expect(page.getByRole("link", { name: "DSA" })).toBeVisible();
+        });
+
+        test("clicking an exercise link navigates to the exercise page", async ({ page }) => {
+            await page.goto("/data-structures-and-algorithms/topic/array");
+            await page.getByRole("link", { name: "Move Zeroes" }).click();
+            await expect(page).toHaveURL(/\/data-structures-and-algorithms\/topic\/array\/exercise\/move-zeros/);
+            await expect(page.getByRole("heading", { name: "Move Zeroes", level: 1 })).toBeVisible();
+        });
+    });
+
+    test.describe("exercise page", () => {
+        test("loads and renders the exercise heading and content", async ({ page }) => {
+            await page.goto("/data-structures-and-algorithms/topic/array/exercise/move-zeros");
+            await expect(page).toHaveURL(/\/data-structures-and-algorithms\/topic\/array\/exercise\/move-zeros/);
+            await expect(page.getByRole("heading", { name: "Move Zeroes", level: 1 })).toBeVisible();
+            await expect(page.getByRole("heading", { name: /problem summary/i })).toBeVisible();
+        });
+
+        test("shows breadcrumb with DSA and topic links", async ({ page }) => {
+            await page.goto("/data-structures-and-algorithms/topic/array/exercise/move-zeros");
+            const breadcrumb = page.getByRole("navigation", { name: "Breadcrumb" });
+            await expect(breadcrumb.getByRole("link", { name: "DSA" })).toBeVisible();
+            await expect(breadcrumb.getByRole("link", { name: "Arrays" })).toBeVisible();
+        });
+
+        test("returns HTTP 200", async ({ page }) => {
+            const response = await page.goto("/data-structures-and-algorithms/topic/array/exercise/move-zeros");
+            expect(response?.status()).toBe(200);
+        });
+    });
+});

--- a/e2e/search.spec.ts
+++ b/e2e/search.spec.ts
@@ -1,54 +1,57 @@
-import { test, expect } from "@playwright/test";
+import { test, expect, type Page } from "@playwright/test";
+
+const openPalette = async (page: Page) => {
+    const trigger = page.getByRole("button", { name: "Open command palette" });
+    // The trigger dispatches an open event that sets the palette open (idempotent),
+    // so retrying is safe and rides out the post-hydration timing window.
+    await expect(async () => {
+        await trigger.click();
+        await expect(page.getByRole("combobox")).toBeVisible({ timeout: 2000 });
+    }).toPass({ timeout: 20000 });
+};
+
+// Opens the palette and waits for the client-side search index to finish loading,
+// so a query runs against a populated index rather than an empty one.
+const openPaletteWithIndex = async (page: Page) => {
+    const indexResponse = page.waitForResponse("**/search-index.json");
+    await openPalette(page);
+    await indexResponse;
+};
 
 test.describe("Command palette search", () => {
     test.beforeEach(async ({ page }) => {
         await page.goto("/blog");
-        await page.waitForLoadState("networkidle");
-        const consentDialog = page.getByRole("dialog", { name: /cookie consent/i });
-        if (await consentDialog.isVisible()) {
-            await page.getByRole("button", { name: /wake up/i }).click();
-        }
+        // The cookie-consent banner is client-rendered, so waiting for it confirms the page
+        // has hydrated and clears its overlay before we drive the palette.
+        const acceptConsent = page.getByRole("button", { name: /wake up/i });
+        await expect(acceptConsent).toBeVisible({ timeout: 15000 });
+        await acceptConsent.click();
+        await expect(acceptConsent).toBeHidden();
     });
 
-    test("command palette opens when the trigger button is clicked", async ({ page }) => {
-        await page.getByRole("button", { name: "Open command palette" }).click();
-        await expect(page.getByRole("combobox")).toBeVisible({ timeout: 10000 });
+    test("command palette opens from the menu trigger", async ({ page }) => {
+        await openPalette(page);
     });
 
     test("typing a query shows search results in the listbox", async ({ page }) => {
-        const searchIndexPromise = page.waitForResponse("**/search-index.json");
-        await page.getByRole("button", { name: "Open command palette" }).click();
-        const combobox = page.getByRole("combobox");
-        await expect(combobox).toBeVisible({ timeout: 10000 });
-        await searchIndexPromise;
-        await page.waitForTimeout(300);
-        await combobox.pressSequentially("react", { delay: 50 });
+        await openPaletteWithIndex(page);
+        await page.getByRole("combobox").pressSequentially("react", { delay: 50 });
         const listbox = page.getByRole("listbox", { name: "Suggestions" });
         await expect(listbox).toBeVisible({ timeout: 5000 });
         await expect(listbox.getByRole("option").first()).toBeVisible({ timeout: 10000 });
     });
 
     test("search results include posts matching the query", async ({ page }) => {
-        const searchIndexPromise = page.waitForResponse("**/search-index.json");
-        await page.getByRole("button", { name: "Open command palette" }).click();
-        const combobox = page.getByRole("combobox");
-        await expect(combobox).toBeVisible({ timeout: 10000 });
-        await searchIndexPromise;
-        await page.waitForTimeout(300);
-        await combobox.pressSequentially("react", { delay: 50 });
+        await openPaletteWithIndex(page);
+        await page.getByRole("combobox").pressSequentially("react", { delay: 50 });
         const listbox = page.getByRole("listbox", { name: "Suggestions" });
-        await expect(listbox).toBeVisible({ timeout: 5000 });
-        await expect(listbox.getByRole("option").first()).toContainText(/react/i, { timeout: 10000 });
+        await expect(listbox.getByRole("option").first()).toBeVisible({ timeout: 10000 });
+        await expect(listbox).toContainText(/react/i, { timeout: 10000 });
     });
 
     test("selecting a result navigates to the matching post", async ({ page }) => {
-        const searchIndexPromise = page.waitForResponse("**/search-index.json");
-        await page.getByRole("button", { name: "Open command palette" }).click();
-        const combobox = page.getByRole("combobox");
-        await expect(combobox).toBeVisible({ timeout: 10000 });
-        await searchIndexPromise;
-        await page.waitForTimeout(300);
-        await combobox.pressSequentially("react native", { delay: 50 });
+        await openPaletteWithIndex(page);
+        await page.getByRole("combobox").pressSequentially("react native", { delay: 50 });
         const listbox = page.getByRole("listbox", { name: "Suggestions" });
         await expect(listbox.getByRole("option").first()).toBeVisible({ timeout: 10000 });
         await listbox.getByRole("option").first().click();
@@ -56,9 +59,7 @@ test.describe("Command palette search", () => {
     });
 
     test("palette closes when Escape is pressed", async ({ page }) => {
-        await page.getByRole("button", { name: "Open command palette" }).click();
-        const combobox = page.getByRole("combobox");
-        await expect(combobox).toBeVisible({ timeout: 10000 });
+        await openPalette(page);
         await page.keyboard.press("Escape");
         await expect(page.getByRole("combobox")).not.toBeVisible({ timeout: 5000 });
     });

--- a/e2e/search.spec.ts
+++ b/e2e/search.spec.ts
@@ -1,0 +1,65 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Command palette search", () => {
+    test.beforeEach(async ({ page }) => {
+        await page.goto("/blog");
+        await page.waitForLoadState("networkidle");
+        const consentDialog = page.getByRole("dialog", { name: /cookie consent/i });
+        if (await consentDialog.isVisible()) {
+            await page.getByRole("button", { name: /wake up/i }).click();
+        }
+    });
+
+    test("command palette opens when the trigger button is clicked", async ({ page }) => {
+        await page.getByRole("button", { name: "Open command palette" }).click();
+        await expect(page.getByRole("combobox")).toBeVisible({ timeout: 10000 });
+    });
+
+    test("typing a query shows search results in the listbox", async ({ page }) => {
+        const searchIndexPromise = page.waitForResponse("**/search-index.json");
+        await page.getByRole("button", { name: "Open command palette" }).click();
+        const combobox = page.getByRole("combobox");
+        await expect(combobox).toBeVisible({ timeout: 10000 });
+        await searchIndexPromise;
+        await page.waitForTimeout(300);
+        await combobox.pressSequentially("react", { delay: 50 });
+        const listbox = page.getByRole("listbox", { name: "Suggestions" });
+        await expect(listbox).toBeVisible({ timeout: 5000 });
+        await expect(listbox.getByRole("option").first()).toBeVisible({ timeout: 10000 });
+    });
+
+    test("search results include posts matching the query", async ({ page }) => {
+        const searchIndexPromise = page.waitForResponse("**/search-index.json");
+        await page.getByRole("button", { name: "Open command palette" }).click();
+        const combobox = page.getByRole("combobox");
+        await expect(combobox).toBeVisible({ timeout: 10000 });
+        await searchIndexPromise;
+        await page.waitForTimeout(300);
+        await combobox.pressSequentially("react", { delay: 50 });
+        const listbox = page.getByRole("listbox", { name: "Suggestions" });
+        await expect(listbox).toBeVisible({ timeout: 5000 });
+        await expect(listbox.getByRole("option").first()).toContainText(/react/i, { timeout: 10000 });
+    });
+
+    test("selecting a result navigates to the matching post", async ({ page }) => {
+        const searchIndexPromise = page.waitForResponse("**/search-index.json");
+        await page.getByRole("button", { name: "Open command palette" }).click();
+        const combobox = page.getByRole("combobox");
+        await expect(combobox).toBeVisible({ timeout: 10000 });
+        await searchIndexPromise;
+        await page.waitForTimeout(300);
+        await combobox.pressSequentially("react native", { delay: 50 });
+        const listbox = page.getByRole("listbox", { name: "Suggestions" });
+        await expect(listbox.getByRole("option").first()).toBeVisible({ timeout: 10000 });
+        await listbox.getByRole("option").first().click();
+        await expect(page).toHaveURL(/\/blog\/post\//, { timeout: 10000 });
+    });
+
+    test("palette closes when Escape is pressed", async ({ page }) => {
+        await page.getByRole("button", { name: "Open command palette" }).click();
+        const combobox = page.getByRole("combobox");
+        await expect(combobox).toBeVisible({ timeout: 10000 });
+        await page.keyboard.press("Escape");
+        await expect(page.getByRole("combobox")).not.toBeVisible({ timeout: 5000 });
+    });
+});

--- a/e2e/videogames-and-static.spec.ts
+++ b/e2e/videogames-and-static.spec.ts
@@ -1,0 +1,88 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Videogames section", () => {
+    test.describe("console listing page", () => {
+        test("loads and shows consoles", async ({ page }) => {
+            await page.goto("/videogames");
+            await expect(page).toHaveURL(/\/videogames/);
+            await expect(page.getByRole("heading", { name: /my videogames collection/i, level: 1 })).toBeVisible();
+            await expect(page.getByRole("heading", { name: "Nintendo Switch", level: 2 })).toBeVisible();
+        });
+
+        test("clicking the Nintendo Switch heading navigates to the console page", async ({ page }) => {
+            await page.goto("/videogames");
+            await page.getByRole("heading", { name: "Nintendo Switch", level: 2 }).click();
+            await expect(page).toHaveURL(/\/videogames\/console\/nintendo-switch/);
+            await expect(page.getByRole("heading", { name: "Nintendo Switch", level: 1 })).toBeVisible();
+        });
+    });
+
+    test.describe("console page", () => {
+        test("loads and shows the console heading and hardware specs", async ({ page }) => {
+            await page.goto("/videogames/console/nintendo-switch");
+            await expect(page).toHaveURL(/\/videogames\/console\/nintendo-switch/);
+            await expect(page.getByRole("heading", { name: "Nintendo Switch", level: 1 })).toBeVisible();
+            await expect(page.getByRole("heading", { name: /hardware specs/i })).toBeVisible();
+        });
+
+        test("shows breadcrumb navigation back to videogames", async ({ page }) => {
+            await page.goto("/videogames/console/nintendo-switch");
+            await expect(page.getByRole("navigation", { name: "Breadcrumb" })).toBeVisible();
+            await expect(page.getByRole("link", { name: "Videogames" })).toBeVisible();
+        });
+
+        test("shows the Games section", async ({ page }) => {
+            await page.goto("/videogames/console/nintendo-switch");
+            await expect(page.getByRole("heading", { name: "Games", level: 2 })).toBeVisible();
+        });
+    });
+
+    test.describe("game page", () => {
+        test("loads and renders the game heading", async ({ page }) => {
+            await page.goto("/videogames/console/nintendo-switch/game/super-mario-odyssey");
+            await expect(page).toHaveURL(/\/videogames\/console\/nintendo-switch\/game\/super-mario-odyssey/);
+            await expect(page.getByRole("heading", { name: "Super Mario Odyssey", level: 1 })).toBeVisible();
+        });
+
+        test("shows breadcrumb with videogames and console links", async ({ page }) => {
+            await page.goto("/videogames/console/nintendo-switch/game/super-mario-odyssey");
+            const breadcrumb = page.getByRole("navigation", { name: "Breadcrumb" });
+            await expect(breadcrumb.getByRole("link", { name: "Videogames" })).toBeVisible();
+            await expect(breadcrumb.getByRole("link", { name: "Nintendo Switch" })).toBeVisible();
+        });
+
+        test("returns HTTP 200", async ({ page }) => {
+            const response = await page.goto("/videogames/console/nintendo-switch/game/super-mario-odyssey");
+            expect(response?.status()).toBe(200);
+        });
+    });
+});
+
+test.describe("Static pages smoke checks", () => {
+    test("/about-me loads and returns 200", async ({ page }) => {
+        const response = await page.goto("/about-me");
+        expect(response?.status()).toBe(200);
+        await expect(page).toHaveURL(/\/about-me/);
+        await expect(page.locator("body")).toBeVisible();
+    });
+
+    test("/art loads and returns 200", async ({ page }) => {
+        const response = await page.goto("/art");
+        expect(response?.status()).toBe(200);
+        await expect(page).toHaveURL(/\/art/);
+        await expect(page.locator("body")).toBeVisible();
+    });
+
+    test("/clowns/photos loads and returns 200", async ({ page }) => {
+        const response = await page.goto("/clowns/photos");
+        expect(response?.status()).toBe(200);
+        await expect(page.locator("body")).toBeVisible();
+    });
+
+    test("/cookie-policy loads and shows the policy heading", async ({ page }) => {
+        const response = await page.goto("/cookie-policy");
+        expect(response?.status()).toBe(200);
+        await expect(page).toHaveURL(/\/cookie-policy/);
+        await expect(page.getByRole("heading", { name: /cookies policy/i, level: 1 })).toBeVisible();
+    });
+});


### PR DESCRIPTION
Add committed Playwright e2e specs for four user journeys.

## Description
- `e2e/blog.spec.ts` — blog listing (post cards, navigation), post page (heading, breadcrumb, tags), archive page (listing, link navigation), tag page
- `e2e/search.spec.ts` — command palette open/close, search results via elasticlunr, result selection navigating to post
- `e2e/dsa.spec.ts` — roadmap table, topic page (heading, exercises table, breadcrumb), exercise page with breadcrumb chain, navigation flows
- `e2e/videogames-and-static.spec.ts` — console listing, console page (specs, breadcrumb, games), game page, plus smoke checks for /about-me, /art, /clowns/photos, /cookie-policy

## Motivation and Context
PR 5/5 of Delivery 2 (climb the testing pyramid). Adds the committed Playwright layer covering the main user-facing sections not covered by existing chat/contact/homepage specs.

## Key implementation detail
Search tests wait for `search-index.json` response before typing (elasticlunr loads async) and add a 300ms settle window so React can process `setSearchIndex` before the query fires. Without this, searches return no results because the index isn't loaded yet when typing starts.

## How Has This Been Tested?
Browser — `npm run test:e2e` against dev server: **49 passed, 0 failed**.

## Types of changes
- [ ] Bug fix :bug: (non-breaking change which fixes an issue)
- [x] New feature :sparkles: (non-breaking change which adds functionality)
- [ ] Breaking change :boom: (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project :beers:.
- [X] My change requires a change to the documentation :bulb: and I have updated the documentation accordingly.
- [X] I have read the [CONTRIBUTING](https://github.com/chicio/chicio-blog/blob/master/CONTRIBUTING.md) document :busts_in_silhouette:.
- [X] I have added tests to cover my changes :tada:.
- [X] All new and existing tests passed :white_check_mark:.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded end-to-end coverage across Blog, search, Data Structures & Algorithms, videogames, and several static pages.
  * Added navigation checks for listings, detail pages, breadcrumbs, tags, archive links, and command palette search results.
  * Verified key page content loads correctly and important routes return successful responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->