### PR TITLE
test(capabilities): :white_check_mark: add shared test-utils render wrapper for features/content tests

### DIFF
--- a/.dependency-cruiser.js
+++ b/.dependency-cruiser.js
@@ -87,7 +87,7 @@ const config = {
     options: {
         doNotFollow: { path: "node_modules" },
         exclude: {
-            path: "\\.(test|spec)\\.(ts|tsx)$",
+            path: "(\\.(test|spec)\\.(ts|tsx)$|src/test-utils/)",
         },
         tsPreCompilationDeps: true,
         tsConfig: { fileName: "tsconfig.json" },

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -24,6 +24,7 @@ const ignores = {
         "vitest.config.ts",
         "vitest.setup.ts",
         "playwright.config.ts",
+        "src/test-utils/**",
     ],
 };
 

--- a/knip.json
+++ b/knip.json
@@ -7,12 +7,14 @@
         "src/types/component-store.ts",
         "tools/eslint/index.js",
         "tools/eslint/rules/*.js",
-        "e2e/**/*.ts"
+        "e2e/**/*.ts",
+        "src/test-utils/index.ts"
     ],
     "project": [
         "src/**/*.{ts,tsx,mdx}",
         "tools/**/*.js",
-        "e2e/**/*.ts"
+        "e2e/**/*.ts",
+        "src/test-utils/**/*.{ts,tsx}"
     ],
     "mdx": {
         "entry": ["src/content/**/content.mdx"]

--- a/src/components/content/blog/post-card/post-card.test.tsx
+++ b/src/components/content/blog/post-card/post-card.test.tsx
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@/test-utils";
+import { PostCard } from "./index";
+import type { Author } from "@/types/content/author";
+
+vi.mock("next/image", () => ({
+    default: ({
+        alt,
+        src,
+        ...rest
+    }: React.ImgHTMLAttributes<HTMLImageElement> & { src: string; alt: string }) => (
+        <img alt={alt} src={src} {...rest} />
+    ),
+}));
+
+vi.mock("next/link", () => ({
+    default: ({
+        href,
+        children,
+        ...rest
+    }: React.AnchorHTMLAttributes<HTMLAnchorElement> & { href: string }) => (
+        <a href={href} {...rest}>
+            {children}
+        </a>
+    ),
+}));
+
+const author: Author = {
+    name: "Fabrizio Duroni",
+    url: "https://fabrizioduroni.it",
+    image: "/media/authors/fabrizio.jpg",
+};
+
+const defaultProps = {
+    big: false,
+    slug: "/blog/test-post",
+    title: "Test Post Title",
+    image: "/media/posts/test.jpg",
+    authors: [author],
+    tags: ["typescript", "testing"],
+    date: "2026-06-28",
+    readingTime: "5 min read",
+    description: "A test post about testing",
+};
+
+describe("PostCard", () => {
+    describe("render", () => {
+        it("renders the post title", () => {
+            render(<PostCard {...defaultProps} />);
+            expect(screen.getAllByText("Test Post Title").length).toBeGreaterThan(0);
+        });
+
+        it("renders the author name", () => {
+            render(<PostCard {...defaultProps} />);
+            expect(screen.getByText("Fabrizio Duroni")).toBeInTheDocument();
+        });
+
+        it("renders links pointing to the post slug", () => {
+            render(<PostCard {...defaultProps} />);
+            const links = screen.getAllByRole("link");
+            const slugLinks = links.filter((l) => l.getAttribute("href") === "/blog/test-post");
+            expect(slugLinks.length).toBeGreaterThan(0);
+        });
+
+        it("renders the post image with correct alt text via next/image mock", () => {
+            render(<PostCard {...defaultProps} />);
+            const img = screen.getByAltText("Test Post Title");
+            expect(img).toBeInTheDocument();
+            expect(img.tagName).toBe("IMG");
+        });
+
+        it("renders the description", () => {
+            render(<PostCard {...defaultProps} />);
+            expect(screen.getByText(/A test post about testing/)).toBeInTheDocument();
+        });
+    });
+
+    describe("big prop", () => {
+        it("renders without error when big is true", () => {
+            render(<PostCard {...defaultProps} big={true} />);
+            expect(screen.getAllByText("Test Post Title").length).toBeGreaterThan(0);
+        });
+    });
+});

--- a/src/components/content/blog/post-card/post-card.test.tsx
+++ b/src/components/content/blog/post-card/post-card.test.tsx
@@ -1,29 +1,10 @@
 import { describe, it, expect, vi } from "vitest";
-import { render, screen } from "@/test-utils";
+import { render, screen, nextImageMock, nextLinkMock } from "@/test-utils";
 import { PostCard } from "./index";
 import type { Author } from "@/types/content/author";
 
-vi.mock("next/image", () => ({
-    default: ({
-        alt,
-        src,
-        ...rest
-    }: React.ImgHTMLAttributes<HTMLImageElement> & { src: string; alt: string }) => (
-        <img alt={alt} src={src} {...rest} />
-    ),
-}));
-
-vi.mock("next/link", () => ({
-    default: ({
-        href,
-        children,
-        ...rest
-    }: React.AnchorHTMLAttributes<HTMLAnchorElement> & { href: string }) => (
-        <a href={href} {...rest}>
-            {children}
-        </a>
-    ),
-}));
+vi.mock("next/image", () => nextImageMock());
+vi.mock("next/link", () => nextLinkMock());
 
 const author: Author = {
     name: "Fabrizio Duroni",

--- a/src/components/features/mdx/code-block/code-block.test.tsx
+++ b/src/components/features/mdx/code-block/code-block.test.tsx
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@/test-utils";
+import { CodeBlock } from "./index";
+
+vi.mock("./copy-code-button", () => ({
+    CopyCodeButton: () => null,
+}));
+
+describe("CodeBlock", () => {
+    describe("render", () => {
+        it("renders a pre element wrapping the supplied children", () => {
+            render(
+                <CodeBlock>
+                    <code>const x = 1;</code>
+                </CodeBlock>,
+            );
+            const pre = document.querySelector("pre");
+            expect(pre).toBeInTheDocument();
+            expect(pre).toHaveTextContent("const x = 1;");
+        });
+
+        it("forwards className to the pre element", () => {
+            render(
+                <CodeBlock className="language-ts">
+                    <code>let y = 2;</code>
+                </CodeBlock>,
+            );
+            const pre = document.querySelector("pre");
+            expect(pre).toHaveClass("language-ts");
+        });
+
+        it("renders the code-block container element", () => {
+            render(<CodeBlock>hello</CodeBlock>);
+            expect(document.getElementById("code-block")).toBeInTheDocument();
+        });
+    });
+
+    describe("clipboard unavailable", () => {
+        it("does not render any copy button when clipboard is absent", () => {
+            render(<CodeBlock>no copy</CodeBlock>);
+            expect(screen.queryByRole("button")).toBeNull();
+        });
+    });
+});

--- a/src/test-utils/index.ts
+++ b/src/test-utils/index.ts
@@ -2,3 +2,4 @@ export * from "./render";
 export { makeNextNavigationMock, defaultNextNavigationMock } from "./next-navigation-mock";
 export type { NavigationMockOptions } from "./next-navigation-mock";
 export { nextLinkMock, nextImageMock } from "./next-module-mocks";
+export { motionDivMock } from "./motion-div-mock";

--- a/src/test-utils/index.ts
+++ b/src/test-utils/index.ts
@@ -1,0 +1,4 @@
+export * from "./render";
+export { makeNextNavigationMock, defaultNextNavigationMock } from "./next-navigation-mock";
+export type { NavigationMockOptions } from "./next-navigation-mock";
+export { nextLinkMock, nextImageMock } from "./next-module-mocks";

--- a/src/test-utils/motion-div-mock.tsx
+++ b/src/test-utils/motion-div-mock.tsx
@@ -1,0 +1,16 @@
+import { type HTMLAttributes } from "react";
+
+/**
+ * Mock factory for the design-system MotionDiv atom. Renders a plain <div> so
+ * framer-motion's animation runtime is not needed in jsdom.
+ *
+ * IMPORTANT — vitest hoisting: vi.mock() is hoisted above imports. Call this
+ * inside the factory lambda, do not pass it as the second argument directly:
+ *
+ *   vi.mock("@/components/design-system/atoms/animation/motion-div", () => motionDivMock());
+ */
+export function motionDivMock() {
+    return {
+        MotionDiv: ({ children, ...props }: HTMLAttributes<HTMLDivElement>) => <div {...props}>{children}</div>,
+    };
+}

--- a/src/test-utils/next-module-mocks.tsx
+++ b/src/test-utils/next-module-mocks.tsx
@@ -1,0 +1,53 @@
+import { type AnchorHTMLAttributes, type ImgHTMLAttributes } from "react";
+
+/**
+ * Mock factory for next/link. Renders a plain <a> tag so that
+ * href, aria-label, and click handlers are testable without
+ * the Next.js router runtime.
+ *
+ * IMPORTANT — vitest hoisting: vi.mock() calls are hoisted before imports.
+ * Do NOT pass this function as the second argument to vi.mock() directly.
+ * Instead, call it inside a factory lambda:
+ *
+ *   vi.mock("next/link", () => nextLinkMock());
+ *
+ * Or inline the mock object for the simplest case (see seed tests).
+ */
+export function nextLinkMock() {
+    return {
+        default: ({
+            href,
+            children,
+            ...rest
+        }: AnchorHTMLAttributes<HTMLAnchorElement> & { href: string }) => (
+            <a href={href} {...rest}>
+                {children}
+            </a>
+        ),
+    };
+}
+
+/**
+ * Mock factory for next/image. Renders a plain <img> tag so that
+ * alt text and src are testable without the Next.js image optimisation
+ * pipeline.
+ *
+ * IMPORTANT — vitest hoisting: vi.mock() calls are hoisted before imports.
+ * Do NOT pass this function as the second argument to vi.mock() directly.
+ * Instead, call it inside a factory lambda:
+ *
+ *   vi.mock("next/image", () => nextImageMock());
+ *
+ * Or inline the mock object for the simplest case (see seed tests).
+ */
+export function nextImageMock() {
+    return {
+        default: ({
+            alt,
+            src,
+            ...rest
+        }: ImgHTMLAttributes<HTMLImageElement> & { src: string; alt: string }) => (
+            <img alt={alt} src={src} {...rest} />
+        ),
+    };
+}

--- a/src/test-utils/next-navigation-mock.ts
+++ b/src/test-utils/next-navigation-mock.ts
@@ -1,0 +1,54 @@
+import { vi } from "vitest";
+
+export interface NavigationMockOptions {
+    pathname?: string;
+    push?: ReturnType<typeof vi.fn>;
+    replace?: ReturnType<typeof vi.fn>;
+    back?: ReturnType<typeof vi.fn>;
+    forward?: ReturnType<typeof vi.fn>;
+    prefetch?: ReturnType<typeof vi.fn>;
+    searchParams?: Record<string, string>;
+}
+
+/**
+ * Returns a factory function suitable for the second argument of
+ * vi.mock("next/navigation", factory), giving every test a deterministic
+ * routing environment with overridable defaults.
+ *
+ * IMPORTANT — vitest hoisting: vi.mock() calls are hoisted before imports.
+ * This function must be invoked inside a factory lambda so it runs after
+ * module resolution:
+ *
+ *   vi.mock("next/navigation", () => makeNextNavigationMock()());
+ *   // — or with overrides —
+ *   vi.mock("next/navigation", () => makeNextNavigationMock({ pathname: "/blog" })());
+ *
+ * The vi.fn() references inside the returned object are stable within a test
+ * file because they are created once per module-graph resolution.
+ */
+export function makeNextNavigationMock(options: NavigationMockOptions = {}) {
+    const {
+        pathname = "/",
+        push = vi.fn(),
+        replace = vi.fn(),
+        back = vi.fn(),
+        forward = vi.fn(),
+        prefetch = vi.fn(),
+        searchParams = {},
+    } = options;
+
+    return () => ({
+        usePathname: () => pathname,
+        useRouter: () => ({ push, replace, back, forward, prefetch }),
+        useSearchParams: () => new URLSearchParams(searchParams),
+        useParams: () => ({}),
+    });
+}
+
+/**
+ * Pre-built factory for the common case (pathname = "/").
+ * Use inside a vi.mock factory lambda:
+ *
+ *   vi.mock("next/navigation", () => defaultNextNavigationMock());
+ */
+export const defaultNextNavigationMock = makeNextNavigationMock();

--- a/src/test-utils/render.tsx
+++ b/src/test-utils/render.tsx
@@ -1,0 +1,22 @@
+import { render as rtlRender } from "@testing-library/react";
+import { type RenderOptions, type RenderResult } from "@testing-library/react";
+import { type ReactElement } from "react";
+
+export * from "@testing-library/react";
+
+/**
+ * Custom render that acts as the single import point for all
+ * features/ and content/ component tests. It re-exports the full
+ * RTL API so tests never need to import from @testing-library/react
+ * directly.
+ *
+ * There are no shared React context providers in this app — all
+ * cross-component state lives in useSyncExternalStore stores. The
+ * wrapper is therefore a thin pass-through today; its value is
+ * centralising the import and providing a stable extension point for
+ * providers that may be added in future (e.g. a Framer Motion
+ * AnimatePresence root for animation testing).
+ */
+export function render(ui: ReactElement, options?: RenderOptions): RenderResult {
+    return rtlRender(ui, options);
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -46,6 +46,7 @@
     "vitest.config.ts",
     "vitest.setup.ts",
     "playwright.config.ts",
-    "e2e"
+    "e2e",
+    "src/test-utils"
   ]
 }

--- a/tsconfig.typecheck.json
+++ b/tsconfig.typecheck.json
@@ -4,6 +4,8 @@
     "types": ["node", "mdx", "dom-chromium-ai", "vitest/globals", "next/image-types/global"]
   },
   "include": [
+    "src/test-utils/**/*.ts",
+    "src/test-utils/**/*.tsx",
     "src/**/*.test.ts",
     "src/**/*.test.tsx",
     "src/**/*.spec.ts",


### PR DESCRIPTION
Establishes `src/test-utils/` as the single import point for features/ and content/ client component RTL tests.

## Description

- `src/test-utils/render.tsx` — custom `render()` that re-exports the full RTL API. Currently a thin pass-through (no shared React context providers needed — all state lives in useSyncExternalStore stores). Stable extension point for future providers.
- `src/test-utils/next-navigation-mock.ts` — `makeNextNavigationMock(options?)` factory and `defaultNextNavigationMock` pre-built factory. Call inside a `vi.mock` lambda: `vi.mock("next/navigation", () => defaultNextNavigationMock())`.
- `src/test-utils/next-module-mocks.tsx` — `nextImageMock()` (plain `<img>`) and `nextLinkMock()` (plain `<a>`) factories. Use as inline `vi.mock` factories.
- `src/test-utils/index.ts` — barrel re-exporting the public API.

Seed tests prove the wrapper works end-to-end:
- `src/components/features/mdx/code-block/code-block.test.tsx` — features/ client component, renders pre element, exercises the wrapper without router/image
- `src/components/content/blog/post-card/post-card.test.tsx` — content/ component using `next/image` and `InternalLink → next/link`, exercises `nextImageMock` and `nextLinkMock`

## Config Exemptions

| File | Change | Reason |
|------|--------|--------|
| `tsconfig.json` | exclude `src/test-utils` | prevents Next.js build type-check from importing @testing-library types |
| `tsconfig.typecheck.json` | include `src/test-utils/**/*.ts(x)` | `npm run typecheck` covers test-utils source |
| `knip.json` | add `src/test-utils/index.ts` as entry + project glob | prevents unused-export false positives |
| `.dependency-cruiser.js` | exclude `src/test-utils/` in path pattern | prevents devDependency / layering rule violations |
| `eslint.config.mjs` | ignore `src/test-utils/**` | consistent with how spec files are handled |

## Motivation and Context

This is Delivery 3 foundational PR. Features/content fan-out PRs that write RTL tests for features/ and content/ components will import from `@/test-utils` instead of duplicating mock setup in every file.

## How Has This Been Tested?

Browser

## Types of changes
- [ ] Bug fix :bug: (non-breaking change which fixes an issue)
- [x] New feature :sparkles: (non-breaking change which adds functionality)
- [ ] Breaking change :boom: (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project :beers:.
- [X] My change requires a change to the documentation :bulb: and I have updated the documentation accordingly.
- [X] I have read the [CONTRIBUTING](https://github.com/chicio/chicio-blog/blob/master/CONTRIBUTING.md) document :busts_in_silhouette:.
- [X] I have added tests to cover my changes :tada:.
- [X] All new and existing tests passed :white_check_mark:.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added shared testing utilities for rendering components and mocking navigation, links, images, and motion elements.
  * Expanded test coverage for post cards and code blocks.

* **Tests**
  * Added new component tests to verify rendering, props, links, images, and clipboard-related behavior.

* **Chores**
  * Updated project tooling to include the new test utilities where needed and exclude them from linting, dependency analysis, and standard type checking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->