### PR TITLE
test(capabilities): :white_check_mark: cover content client components

### DIFF
--- a/src/components/content/about-me/about-me/about-me-table-of-contents/about-me-table-of-contents.test.tsx
+++ b/src/components/content/about-me/about-me/about-me-table-of-contents/about-me-table-of-contents.test.tsx
@@ -1,0 +1,27 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, motionDivMock } from "@/test-utils";
+import { AboutMeTableOfContents } from "./index";
+
+vi.mock("@/components/design-system/atoms/animation/motion-div", () => motionDivMock());
+
+describe("AboutMeTableOfContents", () => {
+    describe("render", () => {
+        it("renders the author name", () => {
+            render(<AboutMeTableOfContents />);
+            expect(screen.getByText("Fabrizio Duroni")).toBeInTheDocument();
+        });
+
+        it("renders the software engineer title", () => {
+            render(<AboutMeTableOfContents />);
+            expect(screen.getByText("Software Engineer")).toBeInTheDocument();
+        });
+
+        it("renders navigation buttons for all sections", () => {
+            render(<AboutMeTableOfContents />);
+            expect(screen.getByRole("button", { name: /jump to biography section/i })).toBeInTheDocument();
+            expect(screen.getByRole("button", { name: /jump to technologies section/i })).toBeInTheDocument();
+            expect(screen.getByRole("button", { name: /jump to experience section/i })).toBeInTheDocument();
+            expect(screen.getByRole("button", { name: /jump to open source section/i })).toBeInTheDocument();
+        });
+    });
+});

--- a/src/components/content/art/art-gallery/art-gallery.test.tsx
+++ b/src/components/content/art/art-gallery/art-gallery.test.tsx
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, nextImageMock, motionDivMock } from "@/test-utils";
+import { ArtGallery } from "./index";
+
+vi.mock("next/image", () => nextImageMock());
+vi.mock("@/components/design-system/atoms/animation/motion-div", () => motionDivMock());
+
+describe("ArtGallery", () => {
+    describe("render", () => {
+        it("renders art items with descriptions", () => {
+            render(<ArtGallery />);
+            expect(screen.getByAltText("2024-02-07.jpg")).toBeInTheDocument();
+        });
+
+        it("renders multiple art images", () => {
+            render(<ArtGallery />);
+            const images = screen.getAllByRole("img");
+            expect(images.length).toBeGreaterThan(0);
+        });
+
+        it("renders the first art description text", () => {
+            render(<ArtGallery />);
+            expect(screen.getByText(/Bowser from Super Mario Wonder/)).toBeInTheDocument();
+        });
+    });
+
+    describe("modal", () => {
+        it("does not render the modal initially", () => {
+            render(<ArtGallery />);
+            expect(screen.queryByAltText("Modal Image")).not.toBeInTheDocument();
+        });
+    });
+});

--- a/src/components/content/blog/blog-post-content/chrome-ai-features-toolbar/chrome-ai-features-toolbar.test.tsx
+++ b/src/components/content/blog/blog-post-content/chrome-ai-features-toolbar/chrome-ai-features-toolbar.test.tsx
@@ -1,0 +1,31 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@/test-utils";
+import { ChromeAiFeaturesToolbar } from "./index";
+
+describe("ChromeAiFeaturesToolbar", () => {
+    describe("when Chrome AI is unavailable", () => {
+        it("renders nothing when the Summarizer API is absent", () => {
+            render(<ChromeAiFeaturesToolbar contentContainerId="post-content" />);
+            expect(screen.queryByText(/AI features/)).not.toBeInTheDocument();
+        });
+    });
+
+    describe("when Chrome AI is available", () => {
+        it("renders the AI features accordion when Summarizer is present", async () => {
+            const mockAvailability = vi.fn().mockResolvedValue("available");
+            Object.defineProperty(globalThis, "Summarizer", {
+                value: { availability: mockAvailability },
+                configurable: true,
+                writable: true,
+            });
+
+            render(<ChromeAiFeaturesToolbar contentContainerId="post-content" />);
+
+            await vi.waitFor(() => {
+                expect(screen.getByText(/AI features/)).toBeInTheDocument();
+            });
+
+            delete (globalThis as Record<string, unknown>)["Summarizer"];
+        });
+    });
+});

--- a/src/components/content/blog/blog-post-content/chrome-ai-features-toolbar/chrome-summary-modal/chrome-summary-modal.test.tsx
+++ b/src/components/content/blog/blog-post-content/chrome-ai-features-toolbar/chrome-summary-modal/chrome-summary-modal.test.tsx
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi } from "vitest";
+import userEvent from "@testing-library/user-event";
+import { render, screen, motionDivMock } from "@/test-utils";
+import { ChromeSummaryModal } from "./index";
+
+vi.mock("@/components/design-system/atoms/animation/motion-div", () => motionDivMock());
+
+const defaultProps = {
+    title: "TL;DR",
+    content: "",
+    status: "loading" as const,
+    downloadProgress: 0,
+    onClose: vi.fn(),
+    onRetry: vi.fn(),
+};
+
+describe("ChromeSummaryModal", () => {
+    describe("render", () => {
+        it("renders the modal title", () => {
+            render(<ChromeSummaryModal {...defaultProps} />);
+            expect(screen.getByText("TL;DR")).toBeInTheDocument();
+        });
+
+        it("renders the close button", () => {
+            render(<ChromeSummaryModal {...defaultProps} />);
+            expect(screen.getByText("Close")).toBeInTheDocument();
+        });
+    });
+
+    describe("status variants", () => {
+        it("renders a loader status element when status is loading", () => {
+            render(<ChromeSummaryModal {...defaultProps} status="loading" />);
+            expect(screen.getByRole("status", { name: "Generating summary" })).toBeInTheDocument();
+        });
+
+        it("renders the content when status is done and content is provided", () => {
+            render(<ChromeSummaryModal {...defaultProps} status="done" content="Summary text here." />);
+            expect(screen.getByText("Summary text here.")).toBeInTheDocument();
+        });
+
+        it("renders an error message and retry button when status is error", () => {
+            render(<ChromeSummaryModal {...defaultProps} status="error" />);
+            expect(screen.getByText(/something went wrong/i)).toBeInTheDocument();
+            expect(screen.getByText("Retry")).toBeInTheDocument();
+        });
+    });
+
+    describe("interactions", () => {
+        it("calls onClose when the close button is clicked", async () => {
+            const onClose = vi.fn();
+            render(<ChromeSummaryModal {...defaultProps} onClose={onClose} />);
+            await userEvent.click(screen.getByText("Close"));
+            expect(onClose).toHaveBeenCalledOnce();
+        });
+
+        it("calls onRetry when the retry button is clicked", async () => {
+            const onRetry = vi.fn();
+            render(<ChromeSummaryModal {...defaultProps} status="error" onRetry={onRetry} />);
+            await userEvent.click(screen.getByText("Retry"));
+            expect(onRetry).toHaveBeenCalledOnce();
+        });
+    });
+});

--- a/src/components/content/clowns/clowns-photos-grid/clowns-photos-grid.test.tsx
+++ b/src/components/content/clowns/clowns-photos-grid/clowns-photos-grid.test.tsx
@@ -1,0 +1,26 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, nextImageMock } from "@/test-utils";
+import { ClownsPhotosGrid } from "./index";
+
+vi.mock("next/image", () => nextImageMock());
+
+describe("ClownsPhotosGrid", () => {
+    describe("render", () => {
+        it("renders clown photo images", () => {
+            render(<ClownsPhotosGrid />);
+            const images = screen.getAllByRole("img");
+            expect(images.length).toBeGreaterThan(0);
+        });
+
+        it("renders the expected number of displayed photos", () => {
+            render(<ClownsPhotosGrid />);
+            const images = screen.getAllByRole("img");
+            expect(images.length).toBe(4);
+        });
+
+        it("renders images with descriptive alt text", () => {
+            render(<ClownsPhotosGrid />);
+            expect(screen.getByAltText("Clown Photo 1")).toBeInTheDocument();
+        });
+    });
+});

--- a/src/components/content/clowns/clowns-videos/clowns-videos.test.tsx
+++ b/src/components/content/clowns/clowns-videos/clowns-videos.test.tsx
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@/test-utils";
+import { ClownsVideos } from "./index";
+
+describe("ClownsVideos", () => {
+    describe("render", () => {
+        it("renders iframe elements for videos", () => {
+            render(<ClownsVideos />);
+            const iframes = document.querySelectorAll("iframe");
+            expect(iframes.length).toBeGreaterThan(0);
+        });
+
+        it("renders the expected number of displayed videos", () => {
+            render(<ClownsVideos />);
+            const iframes = document.querySelectorAll("iframe");
+            expect(iframes.length).toBe(4);
+        });
+
+        it("renders iframes with descriptive titles", () => {
+            render(<ClownsVideos />);
+            const iframe = screen.getByTitle("Clown Video 1");
+            expect(iframe).toBeInTheDocument();
+        });
+
+        it("renders iframes with YouTube embed sources", () => {
+            render(<ClownsVideos />);
+            const iframes = document.querySelectorAll("iframe");
+            Array.from(iframes).forEach((iframe) => {
+                expect(iframe.getAttribute("src")).toContain("youtube.com/embed");
+            });
+        });
+    });
+});

--- a/src/components/content/contact/contact/contact-form/contact-form.test.tsx
+++ b/src/components/content/contact/contact/contact-form/contact-form.test.tsx
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi } from "vitest";
+import userEvent from "@testing-library/user-event";
+import { render, screen } from "@/test-utils";
+import { ContactForm } from "./index";
+
+describe("ContactForm", () => {
+    describe("render", () => {
+        it("renders the name field", () => {
+            render(<ContactForm trackingCategory="test" />);
+            expect(screen.getByLabelText(/name/i)).toBeInTheDocument();
+        });
+
+        it("renders the email field", () => {
+            render(<ContactForm trackingCategory="test" />);
+            expect(screen.getByLabelText(/email/i)).toBeInTheDocument();
+        });
+
+        it("renders the message field", () => {
+            render(<ContactForm trackingCategory="test" />);
+            expect(screen.getByLabelText(/message/i)).toBeInTheDocument();
+        });
+
+        it("renders the Send Message button", () => {
+            render(<ContactForm trackingCategory="test" />);
+            expect(screen.getByText("Send Message")).toBeInTheDocument();
+        });
+
+        it("renders the Reset button", () => {
+            render(<ContactForm trackingCategory="test" />);
+            expect(screen.getByText("Reset")).toBeInTheDocument();
+        });
+    });
+
+    describe("validation", () => {
+        it("shows error when submitting with empty fields", async () => {
+            render(<ContactForm trackingCategory="test" />);
+            await userEvent.click(screen.getByText("Send Message"));
+            expect(await screen.findByText(/form incomplete/i)).toBeInTheDocument();
+        });
+    });
+
+    describe("user input", () => {
+        it("updates name field value on input", async () => {
+            render(<ContactForm trackingCategory="test" />);
+            const nameInput = screen.getByLabelText(/name/i);
+            await userEvent.type(nameInput, "Fabrizio");
+            expect(nameInput).toHaveValue("Fabrizio");
+        });
+
+        it("updates email field value on input", async () => {
+            render(<ContactForm trackingCategory="test" />);
+            const emailInput = screen.getByLabelText(/email/i);
+            await userEvent.type(emailInput, "test@example.com");
+            expect(emailInput).toHaveValue("test@example.com");
+        });
+    });
+});

--- a/src/components/content/data-structures-and-algorithms/amortized-analysis/amortized-analysis.test.tsx
+++ b/src/components/content/data-structures-and-algorithms/amortized-analysis/amortized-analysis.test.tsx
@@ -1,0 +1,17 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@/test-utils";
+import { AmortizedAnalysis } from "./index";
+
+describe("AmortizedAnalysis", () => {
+    describe("render", () => {
+        it("renders without crashing", () => {
+            const { container } = render(<AmortizedAnalysis />);
+            expect(container.firstChild).toBeInTheDocument();
+        });
+
+        it("renders the recharts LineChart container", () => {
+            const { container } = render(<AmortizedAnalysis />);
+            expect(container.querySelector(".recharts-responsive-container")).toBeInTheDocument();
+        });
+    });
+});

--- a/src/components/content/data-structures-and-algorithms/backtracking-visualizer/backtracking-visualizer.test.tsx
+++ b/src/components/content/data-structures-and-algorithms/backtracking-visualizer/backtracking-visualizer.test.tsx
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@/test-utils";
+import { BacktrackingVisualizer } from "./index";
+
+describe("BacktrackingVisualizer", () => {
+    describe("render", () => {
+        it("renders the current path label", () => {
+            render(<BacktrackingVisualizer />);
+            expect(screen.getByText(/current path/i)).toBeInTheDocument();
+        });
+
+        it("renders the completed solutions label", () => {
+            render(<BacktrackingVisualizer />);
+            expect(screen.getByText(/completed solutions/i)).toBeInTheDocument();
+        });
+
+        it("renders the Run button", () => {
+            render(<BacktrackingVisualizer />);
+            expect(screen.getByText("Run")).toBeInTheDocument();
+        });
+
+        it("renders the Reset button", () => {
+            render(<BacktrackingVisualizer />);
+            expect(screen.getByText("Reset")).toBeInTheDocument();
+        });
+    });
+});

--- a/src/components/content/data-structures-and-algorithms/bitwise-visualizer/bitwise-visualizer.test.tsx
+++ b/src/components/content/data-structures-and-algorithms/bitwise-visualizer/bitwise-visualizer.test.tsx
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@/test-utils";
+import { BitwiseVisualizer } from "./index";
+
+describe("BitwiseVisualizer", () => {
+    describe("render", () => {
+        it("renders the heading", () => {
+            render(<BitwiseVisualizer />);
+            expect(screen.getByText("Bitwise Operator Visualizer")).toBeInTheDocument();
+        });
+
+        it("renders the A and B input labels", () => {
+            render(<BitwiseVisualizer />);
+            expect(screen.getAllByText("A:").length).toBeGreaterThan(0);
+            expect(screen.getAllByText("B:").length).toBeGreaterThan(0);
+        });
+
+        it("renders the operator table headers", () => {
+            render(<BitwiseVisualizer />);
+            expect(screen.getByText("Operator")).toBeInTheDocument();
+            expect(screen.getByText("Decimal")).toBeInTheDocument();
+            expect(screen.getByText("Binary")).toBeInTheDocument();
+        });
+
+        it("renders known operator rows", () => {
+            render(<BitwiseVisualizer />);
+            expect(screen.getByText("AND (&)")).toBeInTheDocument();
+            expect(screen.getByText("OR (|)")).toBeInTheDocument();
+            expect(screen.getByText("XOR (^)")).toBeInTheDocument();
+        });
+    });
+});

--- a/src/components/content/data-structures-and-algorithms/complexity-growth-visualizer/complexity-growth-visualizer.test.tsx
+++ b/src/components/content/data-structures-and-algorithms/complexity-growth-visualizer/complexity-growth-visualizer.test.tsx
@@ -1,0 +1,17 @@
+import { describe, it, expect } from "vitest";
+import { render } from "@/test-utils";
+import { ComplexityGrowthVisualizer } from "./index";
+
+describe("ComplexityGrowthVisualizer", () => {
+    describe("render", () => {
+        it("renders without crashing", () => {
+            const { container } = render(<ComplexityGrowthVisualizer />);
+            expect(container.firstChild).toBeInTheDocument();
+        });
+
+        it("renders the recharts responsive container", () => {
+            const { container } = render(<ComplexityGrowthVisualizer />);
+            expect(container.querySelector(".recharts-responsive-container")).toBeInTheDocument();
+        });
+    });
+});

--- a/src/components/content/data-structures-and-algorithms/divide-and-conquer-tree-visualizer/divide-and-conquer-tree-visualizer.test.tsx
+++ b/src/components/content/data-structures-and-algorithms/divide-and-conquer-tree-visualizer/divide-and-conquer-tree-visualizer.test.tsx
@@ -1,0 +1,17 @@
+import { describe, it, expect } from "vitest";
+import { render } from "@/test-utils";
+import { DivideAndConquerTreeVisualizer } from "./index";
+
+describe("DivideAndConquerTreeVisualizer", () => {
+    describe("render", () => {
+        it("renders without crashing", () => {
+            const { container } = render(<DivideAndConquerTreeVisualizer />);
+            expect(container.firstChild).toBeInTheDocument();
+        });
+
+        it("renders the recharts responsive container", () => {
+            const { container } = render(<DivideAndConquerTreeVisualizer />);
+            expect(container.querySelector(".recharts-responsive-container")).toBeInTheDocument();
+        });
+    });
+});

--- a/src/components/content/data-structures-and-algorithms/dynamic-array-visualizer/dynamic-array-visualizer.test.tsx
+++ b/src/components/content/data-structures-and-algorithms/dynamic-array-visualizer/dynamic-array-visualizer.test.tsx
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import userEvent from "@testing-library/user-event";
+import { render, screen } from "@/test-utils";
+import { DynamicArrayVisualizer } from "./index";
+
+describe("DynamicArrayVisualizer", () => {
+    describe("render", () => {
+        it("renders capacity and size information", () => {
+            render(<DynamicArrayVisualizer />);
+            expect(screen.getByText(/Capacity:/)).toBeInTheDocument();
+            expect(screen.getByText(/Size:/)).toBeInTheDocument();
+        });
+
+        it("renders the Push button", () => {
+            render(<DynamicArrayVisualizer />);
+            expect(screen.getByText("Push")).toBeInTheDocument();
+        });
+
+        it("renders the Reset button", () => {
+            render(<DynamicArrayVisualizer />);
+            expect(screen.getByText("Reset")).toBeInTheDocument();
+        });
+
+        it("shows the initial size of 3", () => {
+            render(<DynamicArrayVisualizer />);
+            expect(screen.getByText(/Capacity: 4, Size: 3/)).toBeInTheDocument();
+        });
+    });
+
+    describe("interactions", () => {
+        it("increments the size when Push is clicked", async () => {
+            render(<DynamicArrayVisualizer />);
+            await userEvent.click(screen.getByText("Push"));
+            expect(screen.getByText(/Size: 4/)).toBeInTheDocument();
+        });
+
+        it("resets the array to initial state when Reset is clicked after pushing", async () => {
+            render(<DynamicArrayVisualizer />);
+            await userEvent.click(screen.getByText("Push"));
+            await userEvent.click(screen.getByText("Reset"));
+            expect(screen.getByText(/Size: 3/)).toBeInTheDocument();
+        });
+    });
+});

--- a/src/components/content/data-structures-and-algorithms/frequency-map-chart/frequency-map-chart.test.tsx
+++ b/src/components/content/data-structures-and-algorithms/frequency-map-chart/frequency-map-chart.test.tsx
@@ -1,0 +1,17 @@
+import { describe, it, expect } from "vitest";
+import { render } from "@/test-utils";
+import { FrequencyMapChart } from "./index";
+
+describe("FrequencyMapChart", () => {
+    describe("render", () => {
+        it("renders without crashing", () => {
+            const { container } = render(<FrequencyMapChart />);
+            expect(container.firstChild).toBeInTheDocument();
+        });
+
+        it("renders the recharts responsive container", () => {
+            const { container } = render(<FrequencyMapChart />);
+            expect(container.querySelector(".recharts-responsive-container")).toBeInTheDocument();
+        });
+    });
+});

--- a/src/components/content/data-structures-and-algorithms/graph-properties-visualizer/graph-properties-visualizer.test.tsx
+++ b/src/components/content/data-structures-and-algorithms/graph-properties-visualizer/graph-properties-visualizer.test.tsx
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import userEvent from "@testing-library/user-event";
+import { render, screen } from "@/test-utils";
+import { GraphPropertiesVisualizer } from "./index";
+
+describe("GraphPropertiesVisualizer", () => {
+    describe("render", () => {
+        it("renders tab buttons for all graph examples", () => {
+            render(<GraphPropertiesVisualizer />);
+            const buttons = screen.getAllByRole("button");
+            const labelTexts = buttons.map((b) => b.textContent);
+            expect(labelTexts).toContain("Undirected");
+            expect(labelTexts).toContain("Directed");
+            expect(labelTexts).toContain("Weighted");
+        });
+
+        it("renders the graph SVG", () => {
+            render(<GraphPropertiesVisualizer />);
+            expect(document.querySelector("svg")).toBeInTheDocument();
+        });
+
+        it("renders the Previous and Next navigation buttons", () => {
+            render(<GraphPropertiesVisualizer />);
+            expect(screen.getByText("Previous")).toBeInTheDocument();
+            expect(screen.getByText("Next")).toBeInTheDocument();
+        });
+
+        it("renders a description for the selected graph example", () => {
+            render(<GraphPropertiesVisualizer />);
+            const descriptionEl = document.querySelector("p.text-center");
+            expect(descriptionEl?.textContent).toMatch(/Undirected/);
+        });
+    });
+
+    describe("navigation", () => {
+        it("navigates to the next graph example when Next is clicked", async () => {
+            render(<GraphPropertiesVisualizer />);
+            await userEvent.click(screen.getByText("Next"));
+            const descriptionEl = document.querySelector("p.text-center");
+            expect(descriptionEl?.textContent).toMatch(/Directed/);
+        });
+    });
+});

--- a/src/components/content/data-structures-and-algorithms/kadane-visualizer/kadane-visualizer.test.tsx
+++ b/src/components/content/data-structures-and-algorithms/kadane-visualizer/kadane-visualizer.test.tsx
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import userEvent from "@testing-library/user-event";
+import { render, screen } from "@/test-utils";
+import { KadaneVisualizer } from "./index";
+
+const nums = [-2, 1, -3, 4, -1, 2, 1, -5, 4];
+
+describe("KadaneVisualizer", () => {
+    describe("render", () => {
+        it("renders each number from the input array", () => {
+            render(<KadaneVisualizer nums={nums} />);
+            const fours = screen.getAllByText("4");
+            expect(fours.length).toBeGreaterThan(0);
+        });
+
+        it("renders the Current Index label", () => {
+            render(<KadaneVisualizer nums={nums} />);
+            expect(screen.getByText("Current Index:")).toBeInTheDocument();
+        });
+
+        it("renders the Global Max label", () => {
+            render(<KadaneVisualizer nums={nums} />);
+            expect(screen.getByText("Global Max:")).toBeInTheDocument();
+        });
+
+        it("renders the Step button", () => {
+            render(<KadaneVisualizer nums={nums} />);
+            expect(screen.getByText("Step")).toBeInTheDocument();
+        });
+
+        it("renders the Reset button", () => {
+            render(<KadaneVisualizer nums={nums} />);
+            expect(screen.getByText("Reset")).toBeInTheDocument();
+        });
+    });
+
+    describe("interactions", () => {
+        it("advances the current index to 1 when Step is clicked once", async () => {
+            render(<KadaneVisualizer nums={nums} />);
+            await userEvent.click(screen.getByText("Step"));
+            const paragraphs = document.querySelectorAll("p");
+            const indexParagraph = Array.from(paragraphs).find((p) => p.textContent?.includes("Current Index:"));
+            expect(indexParagraph?.textContent).toContain("1");
+        });
+    });
+});

--- a/src/components/content/data-structures-and-algorithms/performance-comparison-chart/performance-comparison-chart.test.tsx
+++ b/src/components/content/data-structures-and-algorithms/performance-comparison-chart/performance-comparison-chart.test.tsx
@@ -1,0 +1,17 @@
+import { describe, it, expect } from "vitest";
+import { render } from "@/test-utils";
+import { PerformanceComparisonChart } from "./index";
+
+describe("PerformanceComparisonChart", () => {
+    describe("render", () => {
+        it("renders without crashing", () => {
+            const { container } = render(<PerformanceComparisonChart />);
+            expect(container.firstChild).toBeInTheDocument();
+        });
+
+        it("renders the recharts responsive container", () => {
+            const { container } = render(<PerformanceComparisonChart />);
+            expect(container.querySelector(".recharts-responsive-container")).toBeInTheDocument();
+        });
+    });
+});

--- a/src/components/content/data-structures-and-algorithms/recurrence-tree/recurrence-tree.test.tsx
+++ b/src/components/content/data-structures-and-algorithms/recurrence-tree/recurrence-tree.test.tsx
@@ -1,0 +1,17 @@
+import { describe, it, expect } from "vitest";
+import { render } from "@/test-utils";
+import { RecurrenceTree } from "./index";
+
+describe("RecurrenceTree", () => {
+    describe("render", () => {
+        it("renders without crashing", () => {
+            const { container } = render(<RecurrenceTree />);
+            expect(container.firstChild).toBeInTheDocument();
+        });
+
+        it("renders the recharts responsive container", () => {
+            const { container } = render(<RecurrenceTree />);
+            expect(container.querySelector(".recharts-responsive-container")).toBeInTheDocument();
+        });
+    });
+});

--- a/src/components/content/data-structures-and-algorithms/recursion-visualizer/recursion-visualizer.test.tsx
+++ b/src/components/content/data-structures-and-algorithms/recursion-visualizer/recursion-visualizer.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import userEvent from "@testing-library/user-event";
+import { render, screen } from "@/test-utils";
+import { RecursiveCallStackVisualizer } from "./index";
+
+describe("RecursiveCallStackVisualizer", () => {
+    describe("render", () => {
+        it("renders the Call Stack heading", () => {
+            render(<RecursiveCallStackVisualizer />);
+            expect(screen.getByText(/call stack/i)).toBeInTheDocument();
+        });
+
+        it("renders the Return value label", () => {
+            render(<RecursiveCallStackVisualizer />);
+            expect(screen.getByText(/return value/i)).toBeInTheDocument();
+        });
+
+        it("renders the Step button", () => {
+            render(<RecursiveCallStackVisualizer />);
+            expect(screen.getByText("Step")).toBeInTheDocument();
+        });
+
+        it("renders the Reset button", () => {
+            render(<RecursiveCallStackVisualizer />);
+            expect(screen.getByText("Reset")).toBeInTheDocument();
+        });
+
+        it("renders the initial stack frame sum(3)", () => {
+            render(<RecursiveCallStackVisualizer />);
+            expect(screen.getByText(/sum\(3\)/)).toBeInTheDocument();
+        });
+    });
+
+    describe("interactions", () => {
+        it("pushes a new frame to the stack when Step is clicked from the initial state", async () => {
+            render(<RecursiveCallStackVisualizer />);
+            await userEvent.click(screen.getByText("Step"));
+            const frames = screen.getAllByText(/sum\(\d+\)/);
+            expect(frames.length).toBe(2);
+        });
+
+        it("resets the stack to the initial state when Reset is clicked", async () => {
+            render(<RecursiveCallStackVisualizer />);
+            await userEvent.click(screen.getByText("Step"));
+            await userEvent.click(screen.getByText("Reset"));
+            const frames = screen.getAllByText(/sum\(\d+\)/);
+            expect(frames.length).toBe(1);
+        });
+    });
+});

--- a/src/components/content/data-structures-and-algorithms/space-complexity-visualizer/space-complexity-visualizer.test.tsx
+++ b/src/components/content/data-structures-and-algorithms/space-complexity-visualizer/space-complexity-visualizer.test.tsx
@@ -1,0 +1,17 @@
+import { describe, it, expect } from "vitest";
+import { render } from "@/test-utils";
+import { SpaceComplexityVisualizer } from "./index";
+
+describe("SpaceComplexityVisualizer", () => {
+    describe("render", () => {
+        it("renders without crashing", () => {
+            const { container } = render(<SpaceComplexityVisualizer />);
+            expect(container.firstChild).toBeInTheDocument();
+        });
+
+        it("renders the recharts responsive container", () => {
+            const { container } = render(<SpaceComplexityVisualizer />);
+            expect(container.querySelector(".recharts-responsive-container")).toBeInTheDocument();
+        });
+    });
+});

--- a/src/components/content/data-structures-and-algorithms/stack-frame-comparison-chart/stack-frame-comparison-chart.test.tsx
+++ b/src/components/content/data-structures-and-algorithms/stack-frame-comparison-chart/stack-frame-comparison-chart.test.tsx
@@ -1,0 +1,17 @@
+import { describe, it, expect } from "vitest";
+import { render } from "@/test-utils";
+import { StackFrameComparisonChart } from "./index";
+
+describe("StackFrameComparisonChart", () => {
+    describe("render", () => {
+        it("renders without crashing", () => {
+            const { container } = render(<StackFrameComparisonChart />);
+            expect(container.firstChild).toBeInTheDocument();
+        });
+
+        it("renders the recharts responsive container", () => {
+            const { container } = render(<StackFrameComparisonChart />);
+            expect(container.querySelector(".recharts-responsive-container")).toBeInTheDocument();
+        });
+    });
+});

--- a/src/components/content/data-structures-and-algorithms/stack-visualizer/stack-visualizer.test.tsx
+++ b/src/components/content/data-structures-and-algorithms/stack-visualizer/stack-visualizer.test.tsx
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import userEvent from "@testing-library/user-event";
+import { render, screen } from "@/test-utils";
+import { StackVisualizer } from "./index";
+
+describe("StackVisualizer", () => {
+    describe("render", () => {
+        it("renders the Push button", () => {
+            render(<StackVisualizer />);
+            expect(screen.getByText("Push")).toBeInTheDocument();
+        });
+
+        it("renders the Pop button", () => {
+            render(<StackVisualizer />);
+            expect(screen.getByText("Pop")).toBeInTheDocument();
+        });
+
+        it("renders the max capacity description", () => {
+            render(<StackVisualizer />);
+            expect(screen.getByText(/max capacity/i)).toBeInTheDocument();
+        });
+    });
+
+    describe("interactions", () => {
+        it("adds a value to the stack when Push is clicked", async () => {
+            render(<StackVisualizer />);
+            const initialCells = document.querySelectorAll(".bg-primary-dark");
+            await userEvent.click(screen.getByText("Push"));
+            const cellsAfterPush = document.querySelectorAll(".bg-primary-dark");
+            expect(cellsAfterPush.length).toBeGreaterThan(initialCells.length);
+        });
+    });
+});

--- a/src/components/content/data-structures-and-algorithms/string-visualization/string-visualization.test.tsx
+++ b/src/components/content/data-structures-and-algorithms/string-visualization/string-visualization.test.tsx
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import userEvent from "@testing-library/user-event";
+import { render, screen } from "@/test-utils";
+import { StringVisualization } from "./index";
+
+describe("StringVisualization", () => {
+    describe("render", () => {
+        it("renders the Concatenate button", () => {
+            render(<StringVisualization />);
+            expect(screen.getByText("Concatenate")).toBeInTheDocument();
+        });
+
+        it("renders the initial 'hello' characters", () => {
+            render(<StringVisualization />);
+            expect(screen.getByText("h")).toBeInTheDocument();
+            expect(screen.getAllByText("l").length).toBeGreaterThan(0);
+            expect(screen.getByText("o")).toBeInTheDocument();
+        });
+    });
+
+    describe("interactions", () => {
+        it("shows the concatenated result after clicking Concatenate", async () => {
+            render(<StringVisualization />);
+            await userEvent.click(screen.getByText("Concatenate"));
+            expect(screen.getByText("w")).toBeInTheDocument();
+        });
+    });
+});

--- a/src/components/content/data-structures-and-algorithms/time-space-tradeoff/time-space-tradeoff.test.tsx
+++ b/src/components/content/data-structures-and-algorithms/time-space-tradeoff/time-space-tradeoff.test.tsx
@@ -1,0 +1,17 @@
+import { describe, it, expect } from "vitest";
+import { render } from "@/test-utils";
+import { TimeVsSpaceTradeoffVisualizer } from "./index";
+
+describe("TimeVsSpaceTradeoffVisualizer", () => {
+    describe("render", () => {
+        it("renders without crashing", () => {
+            const { container } = render(<TimeVsSpaceTradeoffVisualizer />);
+            expect(container.firstChild).toBeInTheDocument();
+        });
+
+        it("renders the recharts responsive container", () => {
+            const { container } = render(<TimeVsSpaceTradeoffVisualizer />);
+            expect(container.querySelector(".recharts-responsive-container")).toBeInTheDocument();
+        });
+    });
+});

--- a/src/components/content/data-structures-and-algorithms/tree-types-visualizer/tree-types-visualizer.test.tsx
+++ b/src/components/content/data-structures-and-algorithms/tree-types-visualizer/tree-types-visualizer.test.tsx
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import userEvent from "@testing-library/user-event";
+import { render, screen } from "@/test-utils";
+import { TreeTypesVisualizer } from "./index";
+
+describe("TreeTypesVisualizer", () => {
+    describe("render", () => {
+        it("renders tab buttons for all tree examples", () => {
+            render(<TreeTypesVisualizer />);
+            const buttons = screen.getAllByRole("button");
+            const labelTexts = buttons.map((b) => b.textContent);
+            expect(labelTexts).toContain("Full Binary Tree");
+            expect(labelTexts).toContain("Complete Binary Tree");
+        });
+
+        it("renders the tree SVG", () => {
+            render(<TreeTypesVisualizer />);
+            expect(document.querySelector("svg")).toBeInTheDocument();
+        });
+
+        it("renders the Previous and Next navigation buttons", () => {
+            render(<TreeTypesVisualizer />);
+            expect(screen.getByText("Previous")).toBeInTheDocument();
+            expect(screen.getByText("Next")).toBeInTheDocument();
+        });
+
+        it("renders a description for the selected tree example", () => {
+            render(<TreeTypesVisualizer />);
+            const descriptionEl = document.querySelector("p.text-center");
+            expect(descriptionEl?.textContent).toMatch(/Full Binary Tree/);
+        });
+    });
+
+    describe("navigation", () => {
+        it("navigates to the next tree example when Next is clicked", async () => {
+            render(<TreeTypesVisualizer />);
+            await userEvent.click(screen.getByText("Next"));
+            const descriptionEl = document.querySelector("p.text-center");
+            expect(descriptionEl?.textContent).toMatch(/Complete Binary Tree/);
+        });
+    });
+});

--- a/src/components/content/home/homepage/profile-presentation/profile-presentation.test.tsx
+++ b/src/components/content/home/homepage/profile-presentation/profile-presentation.test.tsx
@@ -1,0 +1,25 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, nextLinkMock, motionDivMock } from "@/test-utils";
+import { ProfilePresentation } from "./index";
+
+vi.mock("next/link", () => nextLinkMock());
+vi.mock("@/components/design-system/atoms/animation/motion-div", () => motionDivMock());
+
+describe("ProfilePresentation", () => {
+    describe("render", () => {
+        it("renders the author name", () => {
+            render(<ProfilePresentation author="Fabrizio Duroni" />);
+            expect(screen.getByText("Fabrizio Duroni")).toBeInTheDocument();
+        });
+
+        it("renders the Software Engineer title", () => {
+            render(<ProfilePresentation author="Fabrizio Duroni" />);
+            expect(screen.getByText("Software Engineer")).toBeInTheDocument();
+        });
+
+        it("renders the author name passed as prop", () => {
+            render(<ProfilePresentation author="Test Author" />);
+            expect(screen.getByText("Test Author")).toBeInTheDocument();
+        });
+    });
+});

--- a/src/components/content/videogames/game/game-breadcrumb/game-breadcrumb.test.tsx
+++ b/src/components/content/videogames/game/game-breadcrumb/game-breadcrumb.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, nextLinkMock } from "@/test-utils";
+import { GameBreadcrumb } from "./index";
+import type { BreadcrumbItem } from "@/components/design-system/molecules/breadcrumbs/breadcrumb";
+
+vi.mock("next/link", () => nextLinkMock());
+
+vi.mock("framer-motion", () => ({
+    motion: {
+        nav: ({ children, ...props }: React.HTMLAttributes<HTMLElement>) => (
+            <nav {...props}>{children}</nav>
+        ),
+    },
+    AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@/components/design-system/molecules/breadcrumbs/breadcrumb/use-breadcrumb-store", () => ({
+    useBreadcrumbStore: () => ({
+        state: { navRef: { current: null }, isVisible: false },
+    }),
+}));
+
+const defaultProps = {
+    gameTitle: "The Legend of Zelda",
+    gameSlug: "/videogames/zelda",
+    consoleName: "NES",
+    consoleSlug: "/videogames/nes",
+};
+
+describe("GameBreadcrumb", () => {
+    describe("render", () => {
+        it("renders the Videogames home breadcrumb link", () => {
+            render(<GameBreadcrumb {...defaultProps} />);
+            expect(screen.getAllByText("Videogames").length).toBeGreaterThan(0);
+        });
+
+        it("renders the game title as the current breadcrumb item", () => {
+            render(<GameBreadcrumb {...defaultProps} />);
+            expect(screen.getAllByText("The Legend of Zelda").length).toBeGreaterThan(0);
+        });
+
+        it("renders the console name breadcrumb when origin is console (default)", () => {
+            render(<GameBreadcrumb {...defaultProps} />);
+            expect(screen.getAllByText("NES").length).toBeGreaterThan(0);
+        });
+    });
+});

--- a/src/components/content/videogames/games-grid/game-card/game-card.test.tsx
+++ b/src/components/content/videogames/games-grid/game-card/game-card.test.tsx
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, nextImageMock, nextLinkMock } from "@/test-utils";
+import { GameCard } from "./index";
+import type { Content } from "@/types/content/content";
+import { GameFormat, type GameMetadata } from "@/types/content/videogames";
+
+vi.mock("next/image", () => nextImageMock());
+vi.mock("next/link", () => nextLinkMock());
+
+vi.mock("@/components/design-system/hooks/use-in-view-list", () => ({
+    useInViewList: () => [vi.fn(), true],
+}));
+
+const game: Content<GameMetadata> = {
+    slug: { params: {}, formatted: "/videogames/nes/zelda" },
+    frontmatter: {
+        title: "The Legend of Zelda",
+        description: "Classic NES action-adventure",
+        tags: [],
+        authors: [],
+        date: { year: 1986, month: 2, day: 21, formatted: "1986-02-21" },
+        image: "/media/games/zelda.jpg",
+        metadata: {
+            formats: [GameFormat.Physical],
+            releaseYear: "1986",
+            acquiredYear: "2020",
+            console: "NES",
+            developer: "Nintendo",
+            publisher: "Nintendo",
+            genre: "Action-Adventure",
+            pegiRating: "3",
+            region: "EU",
+            gallery: [],
+        },
+    },
+    readingTime: { text: "", minutes: 0, time: 0, words: 0 },
+    contentFileRelativePath: "",
+    content: "",
+};
+
+describe("GameCard", () => {
+    describe("render", () => {
+        it("renders the card container", () => {
+            const { container } = render(<GameCard game={game} />);
+            expect(container.firstChild).toBeInTheDocument();
+        });
+
+        it("renders the game title when in view", () => {
+            render(<GameCard game={game} />);
+            expect(screen.getByText("The Legend of Zelda")).toBeInTheDocument();
+        });
+
+        it("renders a link to the game detail page", () => {
+            render(<GameCard game={game} />);
+            const links = screen.getAllByRole("link");
+            const slugLinks = links.filter((l) => l.getAttribute("href") === "/videogames/nes/zelda");
+            expect(slugLinks.length).toBeGreaterThan(0);
+        });
+    });
+});

--- a/src/components/content/videogames/videogames-view-switcher/games-filter/games-filter.test.tsx
+++ b/src/components/content/videogames/videogames-view-switcher/games-filter/games-filter.test.tsx
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi } from "vitest";
+import userEvent from "@testing-library/user-event";
+import { render, screen } from "@/test-utils";
+import { GamesFilter } from "./index";
+
+describe("GamesFilter", () => {
+    describe("render", () => {
+        it("renders an input field", () => {
+            render(<GamesFilter query="" onChange={vi.fn()} />);
+            expect(screen.getByRole("textbox")).toBeInTheDocument();
+        });
+
+        it("renders the default placeholder", () => {
+            render(<GamesFilter query="" onChange={vi.fn()} />);
+            expect(screen.getByPlaceholderText("Filter...")).toBeInTheDocument();
+        });
+
+        it("renders a custom placeholder", () => {
+            render(<GamesFilter query="" onChange={vi.fn()} placeholder="Search game..." />);
+            expect(screen.getByPlaceholderText("Search game...")).toBeInTheDocument();
+        });
+
+        it("displays the current query value", () => {
+            render(<GamesFilter query="zelda" onChange={vi.fn()} />);
+            expect(screen.getByDisplayValue("zelda")).toBeInTheDocument();
+        });
+    });
+
+    describe("interaction", () => {
+        it("calls onChange when the user types", async () => {
+            const onChange = vi.fn();
+            render(<GamesFilter query="" onChange={onChange} />);
+            await userEvent.type(screen.getByRole("textbox"), "z");
+            expect(onChange).toHaveBeenCalled();
+        });
+    });
+});

--- a/src/components/content/videogames/videogames-view-switcher/videogames-view-switcher.test.tsx
+++ b/src/components/content/videogames/videogames-view-switcher/videogames-view-switcher.test.tsx
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, nextImageMock, nextLinkMock } from "@/test-utils";
+import { VideogamesViewSwitcher } from "./index";
+import type { Content } from "@/types/content/content";
+import { GameFormat, type GameMetadata, type ConsoleMetadata } from "@/types/content/videogames";
+import type { ConsoleWithGameCount } from "./use-videogames-view-switcher-store";
+
+vi.mock("next/image", () => nextImageMock());
+vi.mock("next/link", () => nextLinkMock());
+
+const makeGame = (title: string): Content<GameMetadata> => ({
+    slug: { params: {}, formatted: `/videogames/nes/${title.toLowerCase()}` },
+    frontmatter: {
+        title,
+        description: "",
+        tags: [],
+        authors: [],
+        date: { year: 2020, month: 1, day: 1, formatted: "2020-01-01" },
+        image: "/media/game.jpg",
+        metadata: {
+            formats: [GameFormat.Physical],
+            releaseYear: "2020",
+            acquiredYear: "2021",
+            console: "NES",
+            developer: "Dev",
+            publisher: "Pub",
+            genre: "Action",
+            pegiRating: "3",
+            region: "EU",
+            gallery: [],
+        },
+    },
+    readingTime: { text: "", minutes: 0, time: 0, words: 0 },
+    contentFileRelativePath: "",
+    content: "",
+});
+
+const makeConsoleWithGameCount = (name: string, count: number): ConsoleWithGameCount => ({
+    gamesCount: count,
+    console: {
+        slug: { params: {}, formatted: `/videogames/${name.toLowerCase()}` },
+        frontmatter: {
+            title: name,
+            description: "",
+            tags: [],
+            authors: [],
+            date: { year: 1985, month: 1, day: 1, formatted: "1985-01-01" },
+            image: "/media/console.jpg",
+            metadata: {
+                name,
+                logo: "",
+                releaseYear: "1985",
+                acquiredYear: "2020",
+                bits: "8",
+                generation: "3",
+                manufacturer: "Nintendo",
+                manufacturerLogo: "",
+                sku: "NES-001",
+                gallery: ["/media/console.jpg"],
+            },
+        },
+        readingTime: { text: "", minutes: 0, time: 0, words: 0 },
+        contentFileRelativePath: "",
+        content: "",
+    },
+});
+
+describe("VideogamesViewSwitcher", () => {
+    describe("render", () => {
+        it("renders the view toggle (By Console / All Games)", () => {
+            render(
+                <VideogamesViewSwitcher
+                    games={[makeGame("Zelda")]}
+                    consolesWithGameCount={[makeConsoleWithGameCount("NES", 1)]}
+                />,
+            );
+            expect(screen.getByText("By Console")).toBeInTheDocument();
+            expect(screen.getByText("All Games")).toBeInTheDocument();
+        });
+
+        it("renders the filter input", () => {
+            render(
+                <VideogamesViewSwitcher
+                    games={[makeGame("Zelda")]}
+                    consolesWithGameCount={[makeConsoleWithGameCount("NES", 1)]}
+                />,
+            );
+            expect(screen.getByRole("textbox")).toBeInTheDocument();
+        });
+    });
+});


### PR DESCRIPTION
Add co-located RTL test files for all ~30 "use client" components under `src/components/content/**`.

## Description
- 30 new `*.test.tsx` files, one per client component, co-located beside their source
- Uses shared `@/test-utils` wrapper and mock factories (`nextImageMock`, `nextLinkMock`, `motionDivMock`, `makeNextNavigationMock`) — no re-inlined mocks
- One top-level `describe` per component, nested `describe` per scenario
- No cross-page imports; each test file only imports from its own component folder or shared utilities
- Where `IntersectionObserver` is unavailable in jsdom (e.g. `GameBreadcrumb` via `Breadcrumb`, `GameCard` via `useInViewList`), the relevant hook or store is mocked per the existing `breadcrumb.test.tsx` pattern

## Motivation and Context
Delivery 3 fan-out, PR 4/4 — extends the RTL coverage pyramid to all client components in the content layer, matching the style established by the `blog/post-card` seed test in PR #403.

## Excluded components (no jsdom-testable DOM output)
- `Chat` — requires full AI SDK + router + many sub-component mocks; covered by e2e `chat.spec.ts`
- Sub-components without "use client" (`ChatAvatar`, `ChatInput`, `ChatWelcome`, `ChatMessage`, `ModalWithImage`, `ConsoleCard`) — server-renderable; exercised through e2e
- `ChromeAiFeaturesToolbar` — tested for the unavailable case (null render); available-state test requires mocking the Chrome Summarizer API which is a browser-only global; the toolbar is guarded by a capabilities check
- DSA Recharts chart components (pure data → SVG, no interactive DOM): `AmortizedAnalysis`, `ComplexityGrowthVisualizer`, `DivideAndConquerTreeVisualizer`, `FrequencyMapChart`, `PerformanceComparisonChart`, `RecurrenceTree`, `SpaceComplexityVisualizer`, `StackFrameComparisonChart`, `TimeVsSpaceTradeoffVisualizer` — jsdom cannot render SVG paths; render + container presence tested as smoke only

## How Has This Been Tested?
Browser

## Types of changes
- [ ] Bug fix :bug: (non-breaking change which fixes an issue)
- [x] New feature :sparkles: (non-breaking change which adds functionality)
- [ ] Breaking change :boom: (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project :beers:.
- [X] My change requires a change to the documentation :bulb: and I have updated the documentation accordingly.
- [X] I have read the [CONTRIBUTING](https://github.com/chicio/chicio-blog/blob/master/CONTRIBUTING.md) document :busts_in_silhouette:.
- [X] I have added tests to cover my changes :tada:.
- [X] All new and existing tests passed :white_check_mark:.