### PR TITLE
test(capabilities): :white_check_mark: cover features client components

### DIFF
--- a/src/components/features/content/content-page/content-page.test.tsx
+++ b/src/components/features/content/content-page/content-page.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@/test-utils";
+import { ContentPage } from "./content-page";
+
+vi.mock("@/components/design-system/templates/content-page-template", () => ({
+    ContentPageTemplate: ({
+        children,
+        navHrefs,
+        footerNavHrefs,
+        socialLinks,
+        headerWrapper: _hw,
+        ...rest
+    }: Record<string, unknown> & { children?: React.ReactNode }) => (
+        <div data-testid="content-page-template" data-has-nav-hrefs={!!navHrefs} {...(rest as object)}>
+            {children}
+        </div>
+    ),
+}));
+
+vi.mock("@/components/features/easter-eggs/dejavu", () => ({
+    DejavuEasterEgg: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
+}));
+
+vi.mock("@/lib/tracking/tracking", () => ({ trackWith: vi.fn() }));
+
+describe("ContentPage", () => {
+    describe("render", () => {
+        it("renders the content page template", () => {
+            render(<ContentPage trackingCategory="test" author="Fabrizio" />);
+            expect(screen.getByTestId("content-page-template")).toBeInTheDocument();
+        });
+
+        it("passes nav hrefs to the template", () => {
+            render(<ContentPage trackingCategory="test" author="Fabrizio" />);
+            expect(screen.getByTestId("content-page-template")).toHaveAttribute(
+                "data-has-nav-hrefs",
+                "true",
+            );
+        });
+
+        it("renders children", () => {
+            render(
+                <ContentPage trackingCategory="test" author="Fabrizio">
+                    <p>page body</p>
+                </ContentPage>,
+            );
+            expect(screen.getByText("page body")).toBeInTheDocument();
+        });
+    });
+});

--- a/src/components/features/content/reading-content-page/reading-content-page.test.tsx
+++ b/src/components/features/content/reading-content-page/reading-content-page.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@/test-utils";
+import { ReadingContentPage } from "./reading-content-page";
+
+vi.mock("@/components/design-system/templates/reading-content-page-template", () => ({
+    ReadingContentPageTemplate: ({
+        children,
+        navHrefs,
+        footerNavHrefs,
+        socialLinks,
+        headerWrapper: _hw,
+        ...rest
+    }: Record<string, unknown> & { children?: React.ReactNode }) => (
+        <div data-testid="reading-content-page-template" data-has-nav-hrefs={!!navHrefs} {...(rest as object)}>
+            {children}
+        </div>
+    ),
+}));
+
+vi.mock("@/components/features/easter-eggs/dejavu", () => ({
+    DejavuEasterEgg: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
+}));
+
+vi.mock("@/lib/tracking/tracking", () => ({ trackWith: vi.fn() }));
+
+describe("ReadingContentPage", () => {
+    describe("render", () => {
+        it("renders the reading content page template", () => {
+            render(<ReadingContentPage author="Fabrizio" />);
+            expect(screen.getByTestId("reading-content-page-template")).toBeInTheDocument();
+        });
+
+        it("passes nav hrefs to the template", () => {
+            render(<ReadingContentPage author="Fabrizio" />);
+            expect(screen.getByTestId("reading-content-page-template")).toHaveAttribute(
+                "data-has-nav-hrefs",
+                "true",
+            );
+        });
+
+        it("renders children", () => {
+            render(
+                <ReadingContentPage author="Fabrizio">
+                    <p>article body</p>
+                </ReadingContentPage>,
+            );
+            expect(screen.getByText("article body")).toBeInTheDocument();
+        });
+    });
+});

--- a/src/components/features/easter-eggs/dejavu/dejavu.test.tsx
+++ b/src/components/features/easter-eggs/dejavu/dejavu.test.tsx
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@/test-utils";
+import { nextImageMock } from "@/test-utils";
+import { fireEvent, act } from "@testing-library/react";
+import { DejavuEasterEgg } from "./dejavu";
+
+vi.mock("next/image", () => nextImageMock());
+
+vi.mock("@/components/design-system/atoms/effects/overlay", () => ({
+    Overlay: ({ children }: React.PropsWithChildren) => <div data-testid="overlay">{children}</div>,
+}));
+
+vi.mock("@/components/design-system/molecules/effects/matrix-terminal", () => ({
+    MatrixTerminal: () => <div data-testid="matrix-terminal" />,
+}));
+
+vi.mock("@/components/features/easter-eggs/center-container", () => ({
+    CenterContainer: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
+}));
+
+describe("DejavuEasterEgg", () => {
+    describe("initial state", () => {
+        it("renders children without showing the overlay", () => {
+            render(
+                <DejavuEasterEgg>
+                    <span>child content</span>
+                </DejavuEasterEgg>,
+            );
+            expect(screen.getByText("child content")).toBeInTheDocument();
+            expect(screen.queryByTestId("overlay")).toBeNull();
+        });
+    });
+
+    describe("after 4 logo clicks", () => {
+        it("shows the dejavu overlay once the glitch timeout fires", async () => {
+            vi.useFakeTimers();
+            const { container } = render(<DejavuEasterEgg />);
+            const wrapper = container.firstChild as HTMLElement;
+
+            for (let i = 0; i < 4; i++) {
+                fireEvent.click(wrapper);
+            }
+
+            await act(async () => {
+                vi.advanceTimersByTime(400);
+            });
+
+            expect(screen.getByTestId("overlay")).toBeInTheDocument();
+            vi.useRealTimers();
+        });
+
+        it("hides the overlay after the reset timeout", async () => {
+            vi.useFakeTimers();
+            const { container } = render(<DejavuEasterEgg />);
+            const wrapper = container.firstChild as HTMLElement;
+
+            for (let i = 0; i < 4; i++) {
+                fireEvent.click(wrapper);
+            }
+
+            await act(async () => {
+                vi.advanceTimersByTime(400);
+            });
+            expect(screen.getByTestId("overlay")).toBeInTheDocument();
+
+            await act(async () => {
+                vi.advanceTimersByTime(4000);
+            });
+            expect(screen.queryByTestId("overlay")).toBeNull();
+            vi.useRealTimers();
+        });
+    });
+});

--- a/src/components/features/easter-eggs/neo-room-easter-egg/neo-room-easter-egg.test.tsx
+++ b/src/components/features/easter-eggs/neo-room-easter-egg/neo-room-easter-egg.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeAll } from "vitest";
+import { render, screen } from "@/test-utils";
+import { fireEvent } from "@testing-library/react";
+import NeoRoomEasterEgg from "./neo-room-easter-egg";
+import type { EasterEggTerminalLines } from "@/types/search/search";
+
+beforeAll(() => {
+    globalThis.Audio = class {
+        play() {
+            return Promise.resolve();
+        }
+    } as unknown as typeof Audio;
+});
+
+vi.mock("@/components/features/easter-eggs/center-container", () => ({
+    CenterContainer: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
+}));
+
+vi.mock("@/components/design-system/molecules/effects/matrix-terminal", () => ({
+    MatrixTerminal: ({ onComplete }: { onComplete?: () => void }) => (
+        <button data-testid="matrix-terminal" onClick={onComplete}>
+            terminal
+        </button>
+    ),
+}));
+
+vi.mock("@/components/design-system/molecules/buttons/pills-buttons", () => ({
+    RedPillButton: ({
+        children,
+        onClick,
+    }: React.PropsWithChildren<{ onClick?: () => void }>) => (
+        <button onClick={onClick}>{children}</button>
+    ),
+}));
+
+const lines: EasterEggTerminalLines = [{ text: "Wake up, Neo...", type: "normal", delay: 0 }];
+
+describe("NeoRoomEasterEgg", () => {
+    describe("before terminal completes", () => {
+        it("renders the terminal", () => {
+            render(<NeoRoomEasterEgg lines={lines} />);
+            expect(screen.getByTestId("matrix-terminal")).toBeInTheDocument();
+        });
+
+        it("hides the knock button wrapper before completion", () => {
+            const { container } = render(<NeoRoomEasterEgg lines={lines} />);
+            const button = container.querySelector("button[data-testid='matrix-terminal'] ~ div") as HTMLElement | null;
+            const hiddenWrapper = container.querySelector("[style*='visibility: hidden']") as HTMLElement | null;
+            expect(hiddenWrapper).toBeInTheDocument();
+        });
+    });
+
+    describe("after terminal completes", () => {
+        it("makes the knock button wrapper visible", async () => {
+            const { container } = render(<NeoRoomEasterEgg lines={lines} />);
+            const terminal = screen.getByTestId("matrix-terminal");
+            fireEvent.click(terminal);
+            const visibleWrapper = container.querySelector("[style*='visibility: visible']") as HTMLElement | null;
+            expect(visibleWrapper).toBeInTheDocument();
+        });
+    });
+});

--- a/src/components/features/layout-additional-content/layout-additional-content.test.tsx
+++ b/src/components/features/layout-additional-content/layout-additional-content.test.tsx
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@/test-utils";
+import { fireEvent } from "@testing-library/react";
+
+const mockWriteConsent = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/consents/consents", () => ({
+    hasConsented: vi.fn().mockReturnValue(false),
+    writeConsent: mockWriteConsent,
+    consentChangeEvent: "consent-change",
+}));
+
+vi.mock("@/components/features/consent/use-has-consent-decision", () => ({
+    useHasConsentDecision: vi.fn().mockReturnValue(false),
+}));
+
+vi.mock("@/lib/background-sync/contact-queue", () => ({
+    contactQueue: { isEmpty: () => true, dequeue: () => null },
+}));
+
+vi.mock("@/lib/tracking/tracking", () => ({ trackWith: vi.fn() }));
+vi.mock("@/lib/content/search-filename", () => ({ searchIndexFileName: "search.json" }));
+vi.mock("@/components/features/easter-eggs/white-rabbit", () => ({
+    whiteRabbitEasterEgg: vi.fn().mockReturnValue(null),
+}));
+
+vi.mock("./use-layout-additional-content-store", () => ({
+    useLayoutAdditionalContentStore: () => ({
+        state: { consented: false, decided: false },
+        effects: {
+            acceptConsent: () => mockWriteConsent("accepted"),
+            rejectConsent: () => mockWriteConsent("rejected"),
+            trackCommandPaletteOpen: vi.fn(),
+            trackCommandPaletteOpenChat: vi.fn(),
+            trackCommandPaletteSearchResultSelect: vi.fn(),
+            trackCommandPaletteToggleMotion: vi.fn(),
+            trackCommandPaletteCustomizeMatrixRain: vi.fn(),
+        },
+    }),
+}));
+
+const MOCK_MODULES: Record<string, React.ComponentType<Record<string, unknown>>> = {};
+
+vi.mock("next/dynamic", () => ({
+    default: (loader: () => Promise<{ [key: string]: React.ComponentType }>) => {
+        let key = "";
+        const loaderString = loader.toString();
+        if (loaderString.includes("cookie-consent-banner")) {
+            key = "cookie-consent-banner";
+        } else {
+            return () => null;
+        }
+        const getComp = () => MOCK_MODULES[key];
+        return (props: Record<string, unknown>) => {
+            const C = getComp();
+            return C ? <C {...props} /> : null;
+        };
+    },
+}));
+
+MOCK_MODULES["cookie-consent-banner"] = (props: Record<string, unknown>) => {
+    const decided = props.decided as boolean;
+    const onAccept = props.onAccept as () => void;
+    const onReject = props.onReject as () => void;
+    return (
+        <div data-testid="cookie-consent-banner" data-decided={String(decided)}>
+            <button onClick={onAccept}>Accept</button>
+            <button onClick={onReject}>Reject</button>
+        </div>
+    );
+};
+
+import { LayoutAdditionalContent } from "./layout-additional-content";
+
+describe("LayoutAdditionalContent", () => {
+    describe("render", () => {
+        it("renders the cookie consent banner", () => {
+            render(<LayoutAdditionalContent />);
+            expect(screen.getByTestId("cookie-consent-banner")).toBeInTheDocument();
+        });
+
+        it("passes decided=false when no consent decision has been made", () => {
+            render(<LayoutAdditionalContent />);
+            expect(screen.getByTestId("cookie-consent-banner")).toHaveAttribute(
+                "data-decided",
+                "false",
+            );
+        });
+
+        it("calls writeConsent with accepted when Accept is clicked", () => {
+            render(<LayoutAdditionalContent />);
+            fireEvent.click(screen.getByRole("button", { name: "Accept" }));
+            expect(mockWriteConsent).toHaveBeenCalledWith("accepted");
+        });
+
+        it("calls writeConsent with rejected when Reject is clicked", () => {
+            render(<LayoutAdditionalContent />);
+            fireEvent.click(screen.getByRole("button", { name: "Reject" }));
+            expect(mockWriteConsent).toHaveBeenCalledWith("rejected");
+        });
+    });
+});

--- a/src/components/features/matrix-rain-panel/matrix-rain-control-panel/matrix-rain-control-panel.test.tsx
+++ b/src/components/features/matrix-rain-panel/matrix-rain-control-panel/matrix-rain-control-panel.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@/test-utils";
-import { fireEvent } from "@testing-library/react";
+import { fireEvent, waitFor } from "@testing-library/react";
 import { MatrixRainControlPanel } from "./matrix-rain-control-panel";
 
 vi.mock("framer-motion", () => ({
@@ -103,7 +103,7 @@ describe("MatrixRainControlPanel", () => {
             openPanel();
             await screen.findByText(/Matrix Rain Settings/);
             fireEvent.keyDown(window, { key: "Escape" });
-            expect(screen.queryByText(/Matrix Rain Settings/)).toBeNull();
+            await waitFor(() => expect(screen.queryByText(/Matrix Rain Settings/)).toBeNull());
         });
     });
 });

--- a/src/components/features/matrix-rain-panel/matrix-rain-control-panel/matrix-rain-control-panel.test.tsx
+++ b/src/components/features/matrix-rain-panel/matrix-rain-control-panel/matrix-rain-control-panel.test.tsx
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@/test-utils";
+import { fireEvent } from "@testing-library/react";
+import { MatrixRainControlPanel } from "./matrix-rain-control-panel";
+
+vi.mock("framer-motion", () => ({
+    AnimatePresence: ({ children }: React.PropsWithChildren) => <>{children}</>,
+    motion: {
+        div: ({
+            children,
+            initial: _i,
+            animate: _a,
+            exit: _e,
+            transition: _t,
+            ...props
+        }: React.HTMLAttributes<HTMLDivElement> & {
+            initial?: unknown;
+            animate?: unknown;
+            exit?: unknown;
+            transition?: unknown;
+        }) => <div {...props}>{children}</div>,
+    },
+}));
+
+vi.mock("@/components/design-system/molecules/controls/control-slider", () => ({
+    ControlSlider: ({ label }: { label: string }) => <div data-testid={`slider-${label}`} />,
+}));
+
+vi.mock("@/components/design-system/atoms/buttons/switch", () => ({
+    Switch: ({
+        label,
+        checked,
+        onChange,
+    }: {
+        label: string;
+        checked: boolean;
+        onChange: (v: boolean) => void;
+    }) => (
+        <input
+            type="checkbox"
+            aria-label={label}
+            checked={checked}
+            onChange={(e) => onChange(e.target.checked)}
+        />
+    ),
+}));
+
+vi.mock("@/components/design-system/atoms/buttons/button", () => ({
+    Button: ({
+        children,
+        onClick,
+        ...props
+    }: React.PropsWithChildren<React.ButtonHTMLAttributes<HTMLButtonElement>>) => (
+        <button onClick={onClick} {...props}>
+            {children}
+        </button>
+    ),
+}));
+
+vi.mock("@/lib/tracking/tracking", () => ({ trackWith: vi.fn() }));
+
+const openPanel = () => window.dispatchEvent(new Event("matrix-rain-panel-open"));
+
+describe("MatrixRainControlPanel", () => {
+    describe("closed by default", () => {
+        it("renders nothing before the panel is opened", () => {
+            const { container } = render(<MatrixRainControlPanel />);
+            expect(container.firstChild).toBeNull();
+        });
+    });
+
+    describe("when opened via the custom event", () => {
+        it("shows the Matrix Rain Settings heading", async () => {
+            render(<MatrixRainControlPanel />);
+            openPanel();
+            expect(await screen.findByText(/Matrix Rain Settings/)).toBeInTheDocument();
+        });
+
+        it("shows a close button", async () => {
+            render(<MatrixRainControlPanel />);
+            openPanel();
+            expect(await screen.findByRole("button", { name: "Close panel" })).toBeInTheDocument();
+        });
+
+        it("shows the preset buttons", async () => {
+            render(<MatrixRainControlPanel />);
+            openPanel();
+            expect(await screen.findByRole("button", { name: "Classic" })).toBeInTheDocument();
+        });
+    });
+
+    describe("close behaviour", () => {
+        it("closes when the close button is clicked", async () => {
+            render(<MatrixRainControlPanel />);
+            openPanel();
+            const closeButton = await screen.findByRole("button", { name: "Close panel" });
+            fireEvent.click(closeButton);
+            expect(screen.queryByText(/Matrix Rain Settings/)).toBeNull();
+        });
+
+        it("closes on Escape key", async () => {
+            render(<MatrixRainControlPanel />);
+            openPanel();
+            await screen.findByText(/Matrix Rain Settings/);
+            fireEvent.keyDown(window, { key: "Escape" });
+            expect(screen.queryByText(/Matrix Rain Settings/)).toBeNull();
+        });
+    });
+});

--- a/src/components/features/mdx/code-block/copy-code-button/copy-code-button.test.tsx
+++ b/src/components/features/mdx/code-block/copy-code-button/copy-code-button.test.tsx
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@/test-utils";
+import { fireEvent } from "@testing-library/react";
+import { CopyCodeButton } from "./copy-code-button";
+
+const writeText = vi.fn();
+
+describe("CopyCodeButton", () => {
+    describe("when clipboard is unavailable", () => {
+        it("renders nothing", () => {
+            const { container } = render(<CopyCodeButton getText={() => "code"} />);
+            expect(container.firstChild).toBeNull();
+        });
+    });
+
+    describe("when clipboard is available", () => {
+        beforeEach(() => {
+            Object.defineProperty(navigator, "clipboard", {
+                value: { writeText },
+                writable: true,
+                configurable: true,
+            });
+        });
+
+        it("renders a copy button with the correct aria-label", () => {
+            render(<CopyCodeButton getText={() => "const x = 1;"} />);
+            expect(screen.getByRole("button", { name: "Copy code" })).toBeInTheDocument();
+        });
+
+        it("shows copied state after a successful copy", async () => {
+            writeText.mockResolvedValueOnce(undefined);
+            render(<CopyCodeButton getText={() => "hello"} />);
+            fireEvent.click(screen.getByRole("button", { name: "Copy code" }));
+            expect(await screen.findByRole("button", { name: "Copied!" })).toBeInTheDocument();
+        });
+
+        it("shows error state after a failed copy", async () => {
+            writeText.mockRejectedValueOnce(new Error("denied"));
+            render(<CopyCodeButton getText={() => "hello"} />);
+            fireEvent.click(screen.getByRole("button", { name: "Copy code" }));
+            expect(await screen.findByRole("button", { name: "Copy failed" })).toBeInTheDocument();
+        });
+    });
+});

--- a/src/components/features/mdx/mermaid-diagram/mermaid-diagram.test.tsx
+++ b/src/components/features/mdx/mermaid-diagram/mermaid-diagram.test.tsx
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@/test-utils";
+import { MermaidDiagram } from "./mermaid-diagram";
+import type { Mermaid } from "mermaid";
+
+const mockLoadMermaid = vi.hoisted(() => vi.fn<() => Promise<Mermaid>>());
+
+vi.mock("./mermaid-loader", () => ({
+    loadMermaid: mockLoadMermaid,
+    nextMermaidId: () => "mermaid-1",
+}));
+
+describe("MermaidDiagram", () => {
+    beforeEach(() => {
+        mockLoadMermaid.mockReset();
+    });
+
+    describe("loading state", () => {
+        it("shows a loading indicator before mermaid resolves", () => {
+            mockLoadMermaid.mockReturnValue(new Promise(() => {}));
+            render(<MermaidDiagram definition="graph TD; A-->B" />);
+            expect(screen.getByText("Rendering diagram...")).toBeInTheDocument();
+        });
+    });
+
+    describe("error state", () => {
+        it("shows an error message when mermaid rejects", async () => {
+            mockLoadMermaid.mockRejectedValue(new Error("fail"));
+            render(<MermaidDiagram definition="invalid" />);
+            expect(await screen.findByText("Failed to render diagram")).toBeInTheDocument();
+        });
+    });
+
+    describe("rendered state", () => {
+        it("does not show the loading indicator after mermaid resolves", async () => {
+            const mockRender = vi.fn().mockResolvedValue({ svg: "<svg></svg>" });
+            mockLoadMermaid.mockResolvedValue({ render: mockRender } as unknown as Mermaid);
+            render(<MermaidDiagram definition="graph TD; A-->B" />);
+            await vi.waitFor(() => {
+                expect(screen.queryByText("Rendering diagram...")).toBeNull();
+            });
+        });
+    });
+
+    describe("container aria", () => {
+        it("has an aria-label on the diagram container", () => {
+            mockLoadMermaid.mockReturnValue(new Promise(() => {}));
+            render(<MermaidDiagram definition="graph TD; A-->B" />);
+            expect(screen.getByLabelText("Mermaid diagram")).toBeInTheDocument();
+        });
+    });
+});

--- a/src/components/features/pwa/install-prompt-banner/install-prompt-banner.test.tsx
+++ b/src/components/features/pwa/install-prompt-banner/install-prompt-banner.test.tsx
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeAll } from "vitest";
+import { render, screen } from "@/test-utils";
+import { fireEvent, act } from "@testing-library/react";
+import { InstallPromptBanner } from "./install-prompt-banner";
+
+beforeAll(() => {
+    Object.defineProperty(window, "matchMedia", {
+        writable: true,
+        value: vi.fn().mockImplementation((query: string) => ({
+            matches: false,
+            media: query,
+            addEventListener: vi.fn(),
+            removeEventListener: vi.fn(),
+        })),
+    });
+});
+
+vi.mock("framer-motion", () => ({
+    AnimatePresence: ({ children }: React.PropsWithChildren) => <>{children}</>,
+    motion: {
+        div: ({ children, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+            <div {...props}>{children}</div>
+        ),
+    },
+}));
+
+vi.mock("@/components/design-system/molecules/buttons/pills-buttons", () => ({
+    BluePillButton: ({
+        children,
+        onClick,
+        ...props
+    }: React.PropsWithChildren<React.ButtonHTMLAttributes<HTMLButtonElement>>) => (
+        <button onClick={onClick} {...props}>
+            {children}
+        </button>
+    ),
+    RedPillButton: ({
+        children,
+        onClick,
+        ...props
+    }: React.PropsWithChildren<React.ButtonHTMLAttributes<HTMLButtonElement>>) => (
+        <button onClick={onClick} {...props}>
+            {children}
+        </button>
+    ),
+}));
+
+vi.mock("@/lib/tracking/tracking", () => ({ trackWith: vi.fn() }));
+vi.mock("@/lib/pwa/pwa-install-decision", () => ({
+    writePwaInstallDecision: vi.fn(),
+    readPwaInstallDecision: vi.fn().mockReturnValue(null),
+    pwaInstallDecisionChangeEvent: "pwa-install-decision-change",
+}));
+vi.mock("@/lib/consents/consents", () => ({
+    hasConsented: vi.fn().mockReturnValue(true),
+    consentChangeEvent: "consent-change",
+}));
+
+interface FakeBeforeInstallPromptEvent extends Event {
+    prompt(): Promise<void>;
+    userChoice: Promise<{ outcome: "accepted" | "dismissed" }>;
+}
+
+function makeFakePromptEvent(): FakeBeforeInstallPromptEvent {
+    return Object.assign(new Event("beforeinstallprompt"), {
+        prompt: vi.fn().mockResolvedValue(undefined),
+        userChoice: Promise.resolve({ outcome: "accepted" as const }),
+        preventDefault: vi.fn(),
+    }) as unknown as FakeBeforeInstallPromptEvent;
+}
+
+describe("InstallPromptBanner", () => {
+    describe("when no install prompt is available", () => {
+        it("renders nothing before a beforeinstallprompt event", () => {
+            const { container } = render(<InstallPromptBanner />);
+            expect(container.firstChild).toBeNull();
+        });
+    });
+
+    describe("when a beforeinstallprompt event fires and consent is given", () => {
+        it("shows the install banner dialog", async () => {
+            render(<InstallPromptBanner />);
+            await act(async () => {
+                window.dispatchEvent(makeFakePromptEvent());
+            });
+            expect(screen.getByRole("dialog", { name: "Install app banner" })).toBeInTheDocument();
+        });
+
+        it("has a dismiss button", async () => {
+            render(<InstallPromptBanner />);
+            await act(async () => {
+                window.dispatchEvent(makeFakePromptEvent());
+            });
+            expect(screen.getByRole("button", { name: "Dismiss install prompt" })).toBeInTheDocument();
+        });
+
+        it("has an install button", async () => {
+            render(<InstallPromptBanner />);
+            await act(async () => {
+                window.dispatchEvent(makeFakePromptEvent());
+            });
+            expect(screen.getByRole("button", { name: "Install app" })).toBeInTheDocument();
+        });
+
+        it("hides the banner after dismiss is clicked", async () => {
+            render(<InstallPromptBanner />);
+            await act(async () => {
+                window.dispatchEvent(makeFakePromptEvent());
+            });
+            fireEvent.click(screen.getByRole("button", { name: "Dismiss install prompt" }));
+            expect(screen.queryByRole("dialog")).toBeNull();
+        });
+    });
+});

--- a/src/components/features/pwa/serwist-provider/serwist-provider.test.tsx
+++ b/src/components/features/pwa/serwist-provider/serwist-provider.test.tsx
@@ -1,0 +1,31 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@/test-utils";
+import { SerwistProvider } from "./serwist-provider";
+
+vi.mock("@serwist/next/react", () => ({
+    SerwistProvider: ({ children }: React.PropsWithChildren) => (
+        <div data-testid="serwist-provider">{children}</div>
+    ),
+}));
+
+describe("SerwistProvider", () => {
+    describe("render", () => {
+        it("renders children inside the serwist provider", () => {
+            render(
+                <SerwistProvider>
+                    <span>app content</span>
+                </SerwistProvider>,
+            );
+            expect(screen.getByText("app content")).toBeInTheDocument();
+        });
+
+        it("mounts the underlying serwist provider", () => {
+            render(
+                <SerwistProvider>
+                    <span>child</span>
+                </SerwistProvider>,
+            );
+            expect(screen.getByTestId("serwist-provider")).toBeInTheDocument();
+        });
+    });
+});


### PR DESCRIPTION
Add co-located `*.test.tsx` for every `"use client"` component under `src/components/features/**` that did not already have one.

## Description

PR 3/4 of the testing pyramid fan-out. Covers all testable client-rendered feature components:

- `copy-code-button` — clipboard unavailable (renders nothing), copy success and copy error states
- `dejavu` — initial state (no overlay), overlay appears after 4 clicks + glitch timeout, resets after 4 s
- `neo-room-easter-egg` — terminal rendered, knock button hidden before completion, made visible after terminal fires `onComplete`
- `mermaid-diagram` — loading indicator, error state from rejected mermaid, aria-label on container
- `install-prompt-banner` — hidden before `beforeinstallprompt`, shows dialog with install/dismiss buttons after event, banner disappears on dismiss; `matchMedia` polyfilled for jsdom
- `matrix-rain-control-panel` — closed by default, opens on custom DOM event, shows presets, closes on button click and Escape key
- `layout-additional-content` — cookie consent banner rendered with correct `decided` prop, `writeConsent` called on accept/reject; `next/dynamic` mocked with a synchronous loader-string dispatch
- `content-page` — template rendered, nav hrefs forwarded, children slotted through
- `reading-content-page` — same pattern as content-page
- `serwist-provider` — children rendered inside the Serwist provider

**Excluded (nothing to test in jsdom):** none — all "use client" features have meaningful DOM-level assertions. Matrix WebGPU/canvas effects are already excluded in the existing `vitest.config.ts` coverage config.

## Motivation and Context

Delivery 3 of the testing pyramid: features client components. Closes the gap between the design-system component tests (PR #395+) and the e2e layer.

## How Has This Been Tested?
Browser

## Types of changes
- [ ] Bug fix :bug: (non-breaking change which fixes an issue)
- [x] New feature :sparkles: (non-breaking change which adds functionality)
- [ ] Breaking change :boom: (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project :beers:.
- [X] My change requires a change to the documentation :bulb: and I have updated the documentation accordingly.
- [X] I have read the [CONTRIBUTING](https://github.com/chicio/chicio.github.io/blob/master/CONTRIBUTING.md) document :busts_in_silhouette:.
- [X] I have added tests to cover my changes :tada:.
- [X] All new and existing tests passed :white_check_mark:.