### PR TITLE
test(capabilities): :white_check_mark: gate CI on a coverage ratchet floor

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -13,7 +13,7 @@ always: true
 | E2E | Playwright | Full-page flows with real production build + mocked external APIs |
 | Live QA | agent-browser (local only) | Agent-driven a11y tree + click-through smoke walks |
 
-Coverage: v8 provider, text + json-summary reporters. No threshold gate yet — add a ratchet in `vitest.config.ts` once the baseline is established.
+Coverage: v8 provider, text + json-summary reporters. **Threshold ratchet is active** — thresholds are set in `vitest.config.ts` and the CI `test` job gates on them. The floor is the measured baseline over `src/lib/**` + `src/components/design-system/**` (Matrix CG effects excluded — they are canvas-only and cannot run in jsdom). Floor values (set 2026-06-28): statements 64%, branches 59%, functions 61%, lines 65%. Raise the floor whenever tests improve coverage; never lower it.
 
 ## File Layout
 
@@ -109,7 +109,7 @@ validate-arch  -+- typecheck -+- test -> build -> e2e
 ```
 
 - **typecheck** job: `npm run typecheck` — covers `src/**`, `**/*.test.*`, `e2e/**`, and config files. Zero errors required.
-- **test** job: `npm run test:coverage` — prints coverage summary, no gate
+- **test** job: `npm run test:coverage` — prints coverage summary and **gates on thresholds** (statements 64%, branches 59%, functions 61%, lines 65% over `src/lib/**` + `src/components/design-system/**`). Coverage below the floor fails CI.
 - **e2e** job: runs after build, Playwright browsers cached, report uploaded as artifact; no third-party secrets needed (externals are mocked)
 
 ## Pre-Push Hook (.husky/pre-push)

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -17,8 +17,12 @@ export default defineConfig({
         coverage: {
             provider: "v8",
             reporter: ["text", "json-summary"],
-            // No threshold gate yet — codebase starts near-zero.
-            // A ratchet can be added here once baseline coverage is established.
+            thresholds: {
+                statements: 64,
+                branches: 59,
+                functions: 61,
+                lines: 65,
+            },
             include: ["src/lib/**", "src/components/design-system/**"],
             // Matrix CG/canvas effects cannot run in jsdom, so they are excluded from
             // coverage rather than carried by meaningless smoke tests.


### PR DESCRIPTION
Gate CI on a non-decreasing coverage floor for the deliberately near-fully-covered surface (`src/lib/**` + `src/components/design-system/**`, Matrix CG effects excluded).

## Description

- Adds a `coverage.thresholds` block to `vitest.config.ts` with floors measured from the current baseline: **statements 64%, branches 59%, functions 61%, lines 65%**
- The CI `test` job already runs `npm run test:coverage`, so thresholds gate it automatically — no CI YAML change needed
- Updates `.claude/rules/testing.md` to document the ratchet as active, record the floor values and measured scope, and state the rule: raise over time, never lower
- Intentionally does NOT expand `coverage.include` to `features/` / `content/` / `app/` — those are tested but would drag in untested server components and produce a fragile low floor; that is a possible future tuning step

## Gate verification

Temporarily set `statements: 99` and confirmed `npm run test:coverage` exits non-zero with:
```
ERROR: Coverage for statements (64.79%) does not meet global threshold (99%)
```
Then restored the real floor; run passes cleanly.

## How Has This Been Tested?

- `npm run typecheck` — clean from fresh state (removed next-env.d.ts + .next)
- `npm run test:run` — 155 files, 751 tests, all green
- `npm run test:coverage` — passes at the real floor, confirmed gate fails when threshold is artificially raised
- `npm run lint` — zero errors
- `npm run validate-architecture` — zero violations
- `npm run knip` — pre-existing violations, none introduced by this PR

## Types of changes
- [x] New feature :sparkles: (non-breaking change which adds functionality)

## Checklist:
- [X] My code follows the code style of this project :beers:.
- [X] My change requires a change to the documentation :bulb: and I have updated the documentation accordingly.
- [X] I have read the [CONTRIBUTING](https://github.com/chicio/chicio-blog/blob/master/CONTRIBUTING.md) document :busts_in_silhouette:.
- [X] I have added tests to cover my changes :tada:.
- [X] All new and existing tests passed :white_check_mark:.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added enforced test coverage minimums for key app areas, so builds now fail if coverage drops below the required floor.
  * Coverage reporting now includes clear thresholds for statements, branches, functions, and lines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->