### PR TITLE
fix(capabilities): :robot: pipeline tuning — e2e-sentinel QA agent + default isolation

### DIFF
--- a/.claude/agents/fabrizioduroni-e2e-sentinel.md
+++ b/.claude/agents/fabrizioduroni-e2e-sentinel.md
@@ -1,0 +1,85 @@
+---
+name: "fabrizioduroni-e2e-sentinel"
+summary: "The live-QA arm of the fabrizioduroni-blog-sdlc review stage: drives the running app with agent-browser to smoke-test a UI/route/flow change, then returns a severity-classified QA report that folds into the code reviewer's verdict. Read-only; starts the dev server the correct way (Bash run_in_background, never '&') and tears it down."
+description: "Use this agent to perform live, in-browser QA of a UI / route / user-flow change in chicio-blog — dispatched by the fabrizioduroni-blog-sdlc orchestrator as the REVIEW stage's QA arm, only when the diff touches rendered UI, routing, or flows. It boots the dev server (correctly, via the Bash tool's background mode), drives the changed flow with agent-browser (open / snapshot / click / fill), verifies the change actually renders and behaves, then tears the server down and returns a severity-classified QA report. It does NOT fix code and does NOT run for pure lib/config/content diffs.\\n\\nExamples:\\n\\n- Example 1 (review-stage QA arm):\\n  context: The reviewer is checking a diff that changed the blog post 'Read next' UI.\\n  assistant: \"Dispatching fabrizioduroni-e2e-sentinel to smoke-test the Read next section live before finalizing the review verdict.\"\\n  <commentary>UI changed, so the orchestrator runs the sentinel; its findings merge into the review verdict.</commentary>\\n\\n- Example 2 (skipped):\\n  context: The diff only touches a pure lib function and its unit test.\\n  assistant: \"No rendered UI changed — the sentinel is skipped; Playwright + unit tests cover this.\"\\n  <commentary>The sentinel is conditional on UI/route/flow changes.</commentary>"
+model: sonnet
+color: green
+effort: medium
+tools:
+  - Read
+  - Grep
+  - Glob
+  - Bash
+allowedTools: Bash(npm run dev), Bash(npm run build), Bash(npm start), Bash(npx agent-browser:*), Bash(curl:*), Bash(kill:*)
+---
+
+You are the **live-QA sentinel** for chicio-blog — the agent-browser QA arm of the `fabrizioduroni-blog-sdlc` review
+stage. When a change touches rendered UI, routing, or a user flow, you drive the running app in a real browser to
+confirm it actually works, then return findings that fold into the code reviewer's verdict. You are the "does it
+*look and behave* right" check that Playwright's assertions and the linter cannot make.
+
+## Hard constraints
+
+- **Read-only. You do not fix code.** You have no Write/Edit tool. You report findings; the implementer fixes them.
+- **No Agent tool.** You run the QA yourself.
+- **You are conditional.** You are dispatched only when the diff touches `src/app/**` routes,
+  `src/components/features/**`, `src/components/design-system/**` rendered output, or anything altering
+  navigation/forms/streaming. For pure lib/config/content diffs you should not have been called — if you were, say so
+  and return a "skipped — no UI surface" verdict.
+
+## Server lifecycle — do this EXACTLY (this is where it usually goes wrong)
+
+1. **Start the dev server with the Bash tool's background mode** — set `run_in_background: true` on the Bash call
+   running `npm run dev`. **NEVER** use the `&` shell operator (`npm run dev &`) and **never** chain commands with
+   `&&`/`;` — `&` trips a safety prompt and orphans the process, and chaining defeats per-command approval. One
+   command per Bash call.
+2. **Wait for readiness WITHOUT a foreground `sleep`** (foreground sleep is blocked). Poll with curl until the server
+   answers: `curl --retry-connrefused --retry 60 --retry-delay 1 -sf http://localhost:3000` — this blocks until the
+   dev server is up (default port 3000) and fails fast if it never comes up.
+3. **Drive the change with agent-browser** (a local devDependency — invoke as `npx agent-browser`, not global):
+   - `npx agent-browser open <url>` for each page the change affects.
+   - `npx agent-browser snapshot -i` to read the interactive accessibility tree; confirm expected landmark roles
+     (`navigation`, `main`, `form` where relevant) and that the changed element is present and correct.
+   - `npx agent-browser click`/`fill` to exercise interactions the change introduces.
+   - `npx agent-browser close` when done.
+   - If agent-browser is unavailable (binaries not installed: `npx agent-browser install` was never run), say so
+     **explicitly** and fall back to Playwright headed mode (`npm run test:e2e:ui`) — NEVER silently skip QA.
+4. **Tear down before returning.** Stop the background dev server (kill the background task) so you never leave an
+   orphan server holding the port. Do this even if the QA failed.
+
+(In an isolated pipeline run — the chicio **default** — you execute inside the pipeline's worktree; assume project
+dependencies and agent-browser binaries are available there. If `npm run dev` fails because deps are missing, report
+that as a setup issue rather than a QA failure.)
+
+## What to QA
+
+You are given the changed flow and the URL(s) to check (from the orchestrator/explorer). Smoke-test the **specific
+change**, not the whole site: open the affected page(s), confirm the change renders, behaves, and didn't visibly break
+the surrounding UI or navigation. Be concrete about what you observed in the a11y tree.
+
+## Output contract (folds into the review verdict)
+
+Return ONLY this:
+
+```
+# Live QA: <short title>  —  agent-browser
+
+## Outcome: PASS | ISSUES_FOUND | SKIPPED
+(SKIPPED only if no UI surface, or agent-browser unavailable and you fell back — state which.)
+
+## Flow tested
+<URLs opened and the interactions performed.>
+
+## Observations
+<What the a11y tree showed; whether the changed element/behavior is present and correct; landmark roles seen.>
+
+## Findings
+- [blocking]  <what is visibly broken / missing / wrong> — <page/element>.
+- [non-blocking] <cosmetic / polish observation>.
+(blocking = the feature does not work or the page is visibly broken; these become blocking review findings.)
+
+## Server
+<Confirm you started the dev server via background mode and stopped it. Note any setup issue.>
+```
+
+Keep it factual. Your value is an honest live look at the change, classified so the reviewer can act on it.

--- a/.claude/agents/fabrizioduroni-implementer.md
+++ b/.claude/agents/fabrizioduroni-implementer.md
@@ -106,7 +106,7 @@ reviewer will RE-RUN to verify, so they must genuinely pass before you hand off:
 5. `npm run test:run` — Vitest unit + component tests green. **Every change adds tests for the behavior it changes** (see Loop Discipline below).
 6. `npm run test:e2e` — Playwright e2e green (prod build, externals mocked) when the change affects a user-facing flow.
 7. `npm run build` — must succeed.
-8. **agent-browser live-QA** — MANDATORY whenever the diff touches rendered UI or user-facing behavior. Boot the dev server, drive the changed feature in a real browser via `npx agent-browser` (`open` → `snapshot -i` → `click`/`fill` → verify it actually works; it's a local devDependency, not global), and report what you observed. If agent-browser is unavailable in this environment, say so explicitly and fall back to Playwright headed mode (`npm run test:e2e:ui`) — NEVER silently skip. Pure lib/config/content-only diffs may skip this step.
+8. **UI verification discipline.** UI/behavior changes are verified by check 6 (Playwright `npm run test:e2e`), which builds prod and runs its own server. **Do NOT background-spawn a server (`npm start &`, `next dev &`, etc.)** — the `&` operator trips a safety prompt and orphans processes; let the `test:e2e` harness own the server lifecycle. **Do NOT run agent-browser from inside the pipeline** — live agent-browser QA is `fabrizioduroni-e2e-sentinel`'s job (the orchestrator dispatches it as the review stage's QA arm). If a changed behavior has no Playwright coverage, **add or extend a spec** rather than reaching for a manual browser. Pure lib/config/content-only diffs may skip e2e. (agent-browser remains available for direct, human-present escape-hatch use — never with a backgrounded server.)
 9. New components compose from existing design system atoms/molecules. Tracking events added for new UI interactions. Search index regeneration verified if content changed.
 
 **Gate**: All applicable checks pass. If any check fails, fix the issue and re-run. Only after all checks pass, hand the diff to review (next section).
@@ -142,9 +142,9 @@ Tests are not paperwork — they are the deterministic grader that closes your w
 
 - **Every PR adds tests for the behavior it changes.** No exceptions for "small" changes.
 - **Bug fixes are strict red-green**: failing regression test FIRST, then fix (see Debugging Tasks above).
-- **Features**: tests are a required Verify deliverable and your iteration grader. TDD is encouraged but not enforced line-by-line — visual/exploratory iteration via agent-browser is often the real feedback signal for UI work.
+- **Features**: tests are a required Verify deliverable and your iteration grader. TDD is encouraged but not enforced line-by-line. Live visual QA is `fabrizioduroni-e2e-sentinel`'s job, not yours — you prove UI behavior with Playwright specs.
 - **What to test where**: pure logic in `src/lib/**` and store hooks (`use-*-store.ts`) are unit-tested directly; thin components are exercised through full RTL render (a render test naturally drives the component's store); reach for isolated `renderHook` only when the UI can't trigger the logic. Component (RTL) coverage starts in the self-contained `design-system/` and climbs outward.
-- **agent-browser is your eyes, Playwright is your safety net**: use agent-browser for live exploratory QA during the loop (never committed, never CI); Playwright specs are the committed, deterministic regression gate. Don't conflate them.
+- **Playwright is your UI gate in the pipeline**: as a dispatched agent you verify UI with `npm run test:e2e` (committed, deterministic) and never background-spawn a server. Live agent-browser exploratory QA belongs to `fabrizioduroni-e2e-sentinel` (dispatched by the orchestrator during review when UI changed).
 - Run the fast grader (`npm run test:run`) constantly during iteration; run the full pyramid before opening the PR.
 
 ## Proactive Feature Suggestions

--- a/.claude/skills/fabrizioduroni-blog-sdlc/SKILL.md
+++ b/.claude/skills/fabrizioduroni-blog-sdlc/SKILL.md
@@ -17,12 +17,12 @@ Intake.
 ## Invocation
 
 ```
-/fabrizioduroni-blog-sdlc [description] [--fix] [--isolated]
+/fabrizioduroni-blog-sdlc [description] [--fix] [--in-place]
 ```
 
 - `[description]` — what to build or fix (free text).
 - `--fix` — select **fix mode**. Also implied if the user pastes a stack trace / error / failing-test output.
-- `--isolated` — run the whole pipeline in one shared git worktree (§ Isolation).
+- `--in-place` — run in the **current** working tree instead of an isolated worktree. The pipeline is **isolated by default** (§ Isolation); pass this only when you deliberately want the live-tree, micro-commit-visible flow.
 
 Create a todo list with one item per stage of the selected mode, and work them in order. Do not skip a gate.
 
@@ -40,9 +40,13 @@ separation is what makes Phase 2 a flag flip rather than a rewrite.
 2. **Content firewall.** If the task is purely content — adding/editing MDX blog posts, DSA articles, or prose — STOP
    and redirect: blog prose → `fabrizioduroni-writer-engineer`; DSA articles → `fabrizioduroni-writer-dsa-engineer`.
    This pipeline is for code. (A change that is *both* code and content stays here for the code part.)
-3. **Branch guard.** Run `git status`. If on `main`, do NOT proceed on it — create and switch to a feature branch
-   `feat/<slug>` (slug from the ticket-less description, or refine after brainstorm). Never commit to `main`.
-4. **Isolation.** If `--isolated`, `EnterWorktree` now so the whole pipeline runs in one shared worktree (§ Isolation).
+3. **Isolation (default ON).** Unless `--in-place` was passed, `EnterWorktree` now — the whole pipeline runs in its
+   own isolated worktree on its own `feat/<slug>` branch. This is the chicio default (diverging from mobile's in-place
+   default) because this is a solo, often multi-session setup: running in the live working tree can collide with
+   another session or sweep in stray uncommitted changes. Pipeline-level only — never per-agent (§ Isolation).
+4. **Branch guard.** In `--in-place` mode, run `git status`; if on `main`, create and switch to `feat/<slug>` (never
+   commit to `main`). In isolated mode the worktree already carries its own `feat/<slug>` branch. Slug from the
+   description, refined after brainstorm.
 
 ## Feature mode
 
@@ -63,11 +67,19 @@ Dispatch **`fabrizioduroni-implementer`** (sonnet) with the **approved plan** + 
 code + tests, **micro-commits per logical step**, and runs ALL mechanical gates (below) before handing off. It does
 not open the PR. Capture its handoff summary (what it built, gate results, tests added, uncertainties).
 
-### Stage 4 — Review
+### Stage 4 — Review (+ live-QA arm)
 Dispatch **`fabrizioduroni-code-reviewer`** (opus) with the diff (`git diff main...HEAD`) + the approved plan. It
 **re-runs the gates to verify** (never trusts), reviews against `CLAUDE.md` + `.claude/rules/*` + the plan, runs the
-E2E suite when UI/route/flow files changed, and returns a verdict: `PASS` or `CHANGES_REQUIRED` with
+Playwright E2E suite when UI/route/flow files changed, and returns a verdict: `PASS` or `CHANGES_REQUIRED` with
 severity-classified findings.
+
+**Live-QA arm (conditional).** When the diff touches rendered UI / routing / flows (`src/app/**` routes,
+`src/components/features/**`, `src/components/design-system/**` rendered output, navigation/forms/streaming), **also
+dispatch `fabrizioduroni-e2e-sentinel`** — the reviewer has no Agent tool and can't nest-dispatch, so the orchestrator
+runs it — passing the changed flow + the URL(s) to check. It drives agent-browser against the running app and returns
+a QA report. **Merge its findings into the review verdict:** a `blocking` sentinel finding (feature visibly
+broken/missing) forces the overall verdict to `CHANGES_REQUIRED`; non-blocking ones are reported. This keeps live QA
+inside the single Stage-5 loop — no separate loop path.
 
 ### Stage 5 — Loop 3⇄4 (the bounded self-correction loop)
 - If verdict is **PASS** (zero blocking findings) → go to Stage 6.
@@ -85,7 +97,7 @@ Show the human the final diff + a review summary (verdict, findings resolved, an
 1. Push the feature branch.
 2. Open the PR with `gh pr create` to `main`, conventional-commit + Gitmoji title, using the PR template below.
 3. Start a **non-blocking** CI watch (don't block the human on it).
-4. If `--isolated`: leave the branch for review / `ExitWorktree`.
+4. Unless `--in-place`: `ExitWorktree` (the pushed branch remains for review).
 Return the PR URL.
 
 ## Fix mode (delta)
@@ -125,9 +137,13 @@ Present the root-cause report. The human decides:
 
 Pipeline-level only — **never** per-agent. Per-agent worktrees would give the reviewer a different worktree and break
 the loop.
-- **Default:** run in the current worktree; the diff appears live via the implementer's micro-commits.
-- **`--isolated`:** `EnterWorktree` at Intake, run the whole pipeline there, `ExitWorktree` at the end. Parallel
-  stories = multiple isolated pipelines.
+- **Default (isolated):** `EnterWorktree` at Intake, run the whole pipeline (including the e2e-sentinel) in that one
+  shared worktree, `ExitWorktree` at the end. This is the chicio default — it prevents collisions with other sessions
+  and stray uncommitted changes in the live tree. The isolated worktree must have project dependencies available
+  (the `EnterWorktree` harness provides them); the sentinel reports a setup issue if `npm run dev` can't start.
+  Parallel stories = multiple isolated pipelines.
+- **`--in-place`:** run in the current working tree; the diff appears live via the implementer's micro-commits. Use
+  only when you're not running another session against the same clone.
 
 ## PR template (Gate 2)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,9 +95,10 @@ AI agents and tools that send `Accept: text/markdown` receive a Markdown represe
 Non-trivial **code** changes can be run through an orchestrated, multi-agent SDLC. It is **manual** and main-thread —
 invoke the orchestrator skill explicitly; it never auto-triggers.
 
-- **Orchestrator**: `/fabrizioduroni-blog-sdlc [description] [--fix] [--isolated]` — sequences the agents, hosts two
+- **Orchestrator**: `/fabrizioduroni-blog-sdlc [description] [--fix] [--in-place]` — sequences the agents, hosts two
   human gates (plan approval, PR approval), and runs a bounded implement⇄review loop (max 3 rounds). Code only — it
-  refuses content tasks and points at the writer agents.
+  refuses content tasks and points at the writer agents. **Runs in an isolated worktree by default** (pass `--in-place`
+  to run in the current tree); isolation is pipeline-level, never per-agent.
 - **Feature mode**: explore → brainstorm (grill-me) 🚪 → implement ⇄ review → PR 🚪.
 - **Fix mode** (`--fix` or a pasted stack trace): investigate → confirm-root-cause 🚪 → implement ⇄ review → PR 🚪.
 
@@ -109,6 +110,7 @@ Agent roster:
 | `fabrizioduroni-implementer` | sonnet | writes code + tests, micro-commits, runs the mechanical gates (repurposed from the former senior-engineer) |
 | `fabrizioduroni-code-reviewer` | opus | re-runs the gates to verify + reviews the diff against rules/plan; severity-classified findings |
 | `fabrizioduroni-bug-investigator` | opus | fix-mode root-cause report from the codebase + git history (no Sentry/Jira) |
+| `fabrizioduroni-e2e-sentinel` | sonnet | review-stage live-QA arm: drives agent-browser against the running app when UI/route/flow changed; findings fold into the review verdict |
 
 Content agents are **separate** and unchanged: `fabrizioduroni-writer-engineer` (blog prose),
 `fabrizioduroni-writer-dsa-engineer` (DSA articles).

--- a/docs/agentic-sdlc/2026-06-29-fabrizioduroni-blog-sdlc-pipeline.md
+++ b/docs/agentic-sdlc/2026-06-29-fabrizioduroni-blog-sdlc-pipeline.md
@@ -47,11 +47,11 @@ fix mode:      investigate ──→ confirm-root-cause ──┘         (share
 ### 3.1 Invocation
 
 ```
-/fabrizioduroni-blog-sdlc [description] [--fix] [--isolated]
+/fabrizioduroni-blog-sdlc [description] [--fix] [--in-place]
 ```
 
 - `--fix` selects fix mode. May also be triggered by pasting a stack trace / error description.
-- `--isolated` runs the whole pipeline in one shared git worktree (see §7).
+- `--in-place` runs in the current working tree instead of an isolated worktree (isolated is the **default**; see §7).
 - **Dropped from the mobile spec:** `JIRA-KEY` and `figma-url` — this project has no Jira and no Figma.
 
 ### 3.2 Dependency constraint (hard rule)
@@ -70,13 +70,13 @@ setup self-contained and is the exercise's whole point.
 
 | # | Stage | Executor | Behavior |
 |---|-------|----------|----------|
-| 0 | **Intake** | orchestrator | Parse args. **Branch guard**: if on `main`, refuse and create `feat/<slug>` (slug from the description or brainstorm output). If `--isolated`, `EnterWorktree`. **Content firewall**: if the task is MDX/DSA/prose-only, refuse and point at the writer agents. |
+| 0 | **Intake** | orchestrator | Parse args. **Isolation (default)**: unless `--in-place`, `EnterWorktree` (own worktree + `feat/<slug>` branch). **Branch guard** (in-place mode): if on `main`, create `feat/<slug>`. **Content firewall**: if the task is MDX/DSA/prose-only, refuse and point at the writer agents. |
 | 1 | **Explore** | `fabrizioduroni-explorer` (haiku) | Read-only. Produces a structured exploration report (see §4.1). Reads `CLAUDE.md`, `.claude/rules/*` (7 files), `.dependency-cruiser.js`, and the target area. |
 | 2 | **Brainstorm** 🚪 | **grill-me** skill (main thread) | Fed by the explorer report. Interviews the user to nail the approach. Output: an approved plan. **HUMAN GATE 1.** |
 | 3 | **Implement** | `fabrizioduroni-implementer` (sonnet) | Writes code + tests. **Micro-commits per logical step** (reviewable PR trail). Matches existing patterns unless the plan says otherwise. Runs all mechanical gates (§5) **before** handing to review. |
-| 4 | **Review** | `fabrizioduroni-code-reviewer` (opus) | Re-runs the gates to **verify** (don't trust). Reviews diff against `CLAUDE.md` + `.claude/rules/*` + the approved plan. Severity-classified findings (§6). **Conditionally runs the E2E check** (Playwright `test:e2e`, optionally `agent-browser`) when UI / route / flow files changed. |
+| 4 | **Review** | `fabrizioduroni-code-reviewer` (opus) | Re-runs the gates to **verify** (don't trust). Reviews diff against `CLAUDE.md` + `.claude/rules/*` + the approved plan. Severity-classified findings (§6). Runs Playwright `test:e2e` when UI/flow changed. **The orchestrator also dispatches `fabrizioduroni-e2e-sentinel`** (the reviewer can't nest-dispatch) for live agent-browser QA when UI/route/flow changed; its blocking findings fold into the review verdict. |
 | 5 | **Loop 3⇄4** | orchestrator | **Max 3 rounds.** Only **blocking** findings force another round. Implementer either fixes or **rebuts once** with written justification; if the reviewer re-asserts, **escalate to human** (no further looping). After 3 rounds, stop and surface open findings. |
-| 6 | **PR** 🚪 | orchestrator | Show diff + review summary. **HUMAN GATE 2.** On approval: push; `gh pr create` to `main` using the existing PR template (conventional commit + Gitmoji). Start a **non-blocking** CI watch. If `--isolated`, leave the branch for review / `ExitWorktree`. |
+| 6 | **PR** 🚪 | orchestrator | Show diff + review summary. **HUMAN GATE 2.** On approval: push; `gh pr create` to `main` using the existing PR template (conventional commit + Gitmoji). Start a **non-blocking** CI watch. Unless `--in-place`, `ExitWorktree` (the pushed branch remains for review). |
 
 ### 4.1 Explorer report shape (remapped to this codebase)
 
@@ -128,9 +128,13 @@ test meaningfulness, and (for UI) rendered behavior.
 Pipeline-level, **never** per-agent frontmatter (per-agent worktrees would give the reviewer a *different* worktree
 and break the loop — this is why the implementer's current `isolation: worktree` must be removed; see §9).
 
-- **Main mode (default):** runs in the current worktree; the diff appears live via micro-commits.
-- **Worktree mode (`--isolated`):** orchestrator moves the whole pipeline into one shared worktree using the native
-  `EnterWorktree` / `ExitWorktree` harness tools. Parallel stories = multiple isolated pipelines.
+- **Isolated mode (DEFAULT):** orchestrator `EnterWorktree` at Intake and runs the whole pipeline (incl. the
+  e2e-sentinel) in that one shared worktree, `ExitWorktree` at the end. **This is the chicio default — diverging from
+  mobile's in-place default** — because chicio is a solo, often multi-session setup: an in-place run can collide with
+  another session or sweep in stray uncommitted changes (this actually happened during Phase-1 validation). The
+  isolated worktree must carry project dependencies (the `EnterWorktree` harness provides them) so the sentinel's
+  `npm run dev` works. Parallel stories = multiple isolated pipelines.
+- **In-place mode (`--in-place`):** runs in the current worktree; diff appears live via micro-commits. Opt-in only.
 
 ## 8. Agent roster
 
@@ -140,6 +144,7 @@ and break the loop — this is why the implementer's current `isolation: worktre
 | `fabrizioduroni-implementer` | **repurposed** from `fabrizioduroni-senior-engineer` | sonnet | pink | **project** (kept) | Read, Write, Edit, Grep, Glob, LSP, Bash(+git) · MCP: context7 |
 | `fabrizioduroni-code-reviewer` | **NEW** | opus | orange | **project** | Read, Grep, Glob, LSP, Bash(verify-only: `lint`/`validate-architecture`/`knip`/`typecheck`/`test:run`/`test:e2e`/`build`, `git diff`/`log`/`show`/`status`), **Write (memory dir ONLY)**; no Edit, no Agent |
 | `fabrizioduroni-bug-investigator` | **NEW** | opus | red | project | Read, Grep, Glob, LSP, Bash(`git log`/`git blame`); no Write/Edit |
+| `fabrizioduroni-e2e-sentinel` | **NEW** | sonnet | green | — | Read, Grep, Glob, Bash(`npm run dev` via background mode, `npx agent-browser`, `curl`, `kill`); no Write/Edit, no Agent |
 | `fabrizioduroni-writer-dsa-engineer` | **renamed** from `fabrizioduroni-dsa-senior-engineer` | unchanged | unchanged | unchanged (dir renamed) | unchanged |
 | `fabrizioduroni-writer-engineer` | untouched | unchanged | unchanged | unchanged | unchanged |
 
@@ -216,6 +221,13 @@ Miss any one and the agent silently starts with **empty memory**.
 11. Phase 2 runner → **GitHub Action** is the target; local `/loop` is the proof-of-concept first step.
 12. Loop is **PR-only, never auto-merge**; concurrency cap = 1; per-run budget cap.
 13. This spec is **temporary** — delete only after both phases ship.
+14. (Phase-1 tuning) Live agent-browser QA → **dedicated `fabrizioduroni-e2e-sentinel`** (sonnet), dispatched by the
+    orchestrator as the **review stage's QA arm** when UI/route/flow changed; findings fold into the review verdict
+    (one unified loop). The implementer no longer runs agent-browser or background servers — its UI gate is Playwright.
+15. (Phase-1 tuning) Isolation → **isolated worktree is the DEFAULT** for chicio (opt out with `--in-place`),
+    diverging from mobile's in-place default; prompted by a real same-clone multi-session collision during validation.
+16. (Phase-1 tuning) Servers are started via the **Bash `run_in_background` mode, never `&`**; readiness via
+    `curl --retry-connrefused`, never foreground `sleep`.
 
 ## 12. Build order — Phase 1 (interactive pipeline; each step independently revertible)
 


### PR DESCRIPTION
Tuning from the first end-to-end pipeline run (the merged read-next feature, #415). Two findings.

## 1. Live QA moved out of the implementer into a dedicated agent
The implementer hit a permission prompt running `npm start &` + agent-browser for live QA. Root cause: `&` backgrounding trips a safety check, and live-QA doesn't belong in a dispatched implementer anyway.

- **Implementer**: no longer runs agent-browser or backgrounded servers. Its UI gate is **Playwright** (`npm run test:e2e`); it adds/extends specs for uncovered behavior.
- **NEW `fabrizioduroni-e2e-sentinel` (sonnet)**: does live agent-browser QA as the **review stage's QA arm** — the orchestrator dispatches it when UI/route/flow files changed (the reviewer has no Agent tool, so it can't nest-dispatch). Its findings **fold into the review verdict**, so QA lives inside the single implement⇄review loop. Starts the server via the Bash **`run_in_background`** mode (never `&`), waits with `curl --retry-connrefused` (never foreground `sleep`), and tears it down on exit.

## 2. Isolation is now the default
The Phase-1 run executed in the live working tree and collided with a second session in the same clone (branch got switched mid-run). The pipeline now runs in an **isolated worktree by default**; the `--isolated` flag is replaced by **`--in-place`** (opt-out). This diverges from mobile's in-place default to fit a solo, multi-session setup.

## Files
- `.claude/agents/fabrizioduroni-implementer.md` — UI verification discipline (Playwright, no `&`, no in-pipeline agent-browser)
- `.claude/agents/fabrizioduroni-e2e-sentinel.md` — **new**
- `.claude/skills/fabrizioduroni-blog-sdlc/SKILL.md` — default isolation, `--in-place`, sentinel wired into Stage 4
- `CLAUDE.md` — roster + default-isolation note
- `docs/agentic-sdlc/…` — spec updated (§4, §7, §8, §11)

## How Has This Been Tested?
Config/agent-prompt changes only — no `src/` touched, so CI (lint/knip/validate-architecture/typecheck/test/build) has nothing of these to fail on. The pre-push husky hook was bypassed because a `git worktree` lacks `node_modules` (the hook's binaries) — and its checks target source, not agent config.

## Types of changes
- [x] Bug fix :bug: (pipeline tooling)
- [x] New feature :sparkles: (e2e-sentinel agent)
- [ ] Breaking change :boom:

🤖 Generated with [Claude Code](https://claude.com/claude-code)