### PR TITLE
chore(deps): :arrow_up: bump matrix-rain-webgpu to 2.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,8 +18,6 @@
         "@next/third-parties": "16.2.7",
         "@react-email/components": "^1.0.12",
         "@tailwindcss/postcss": "^4.2.2",
-        "@typegpu/noise": "^0.11.0",
-        "@typegpu/react": "^0.11.2",
         "@types/mdx": "^2.0.13",
         "@upstash/redis": "^1.38.0",
         "@upstash/vector": "^1.2.3",
@@ -33,7 +31,7 @@
         "gray-matter": "^4.0.3",
         "katex": "^0.16.45",
         "marked": "^17.0.5",
-        "matrix-rain-webgpu": "^1.0.0",
+        "matrix-rain-webgpu": "^2.0.0",
         "mermaid": "^11.15.0",
         "next": "16.2.9",
         "postcss": "^8.5.15",
@@ -56,7 +54,6 @@
         "serwist": "^9.5.11",
         "tailwindcss": "^4.3.1",
         "tsx": "^4.22.4",
-        "typegpu": "^0.11.8",
         "zod": "^4.4.3"
       },
       "devDependencies": {
@@ -14376,16 +14373,18 @@
       }
     },
     "node_modules/matrix-rain-webgpu": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/matrix-rain-webgpu/-/matrix-rain-webgpu-1.0.0.tgz",
-      "integrity": "sha512-/I1glAn4t7cQG1fG+Ou9Cm7CLJ/C2aXTQe2ZzK3U2J1UP+iNQTMi4RoKqYC+glkkDiA0ddgJyCg2nXe4DmWdHA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/matrix-rain-webgpu/-/matrix-rain-webgpu-2.0.0.tgz",
+      "integrity": "sha512-1xddRCWdWQjNF2VRqADHW1OGQDkMpPQroMc2dR7VZpswjcJoKSxjU2ZeTbvQ0BmAEqAckYTyPifCshBZCvvzng==",
       "license": "MIT",
+      "dependencies": {
+        "@typegpu/noise": "0.11.0",
+        "@typegpu/react": "0.11.2",
+        "typegpu": "0.11.9"
+      },
       "peerDependencies": {
-        "@typegpu/noise": "^0.11.0",
-        "@typegpu/react": "^0.11.0",
         "react": "^19.0.0",
-        "react-dom": "^19.0.0",
-        "typegpu": "^0.11.0"
+        "react-dom": "^19.0.0"
       }
     },
     "node_modules/mdast-util-find-and-replace": {
@@ -19704,9 +19703,9 @@
       "license": "MIT"
     },
     "node_modules/typegpu": {
-      "version": "0.11.8",
-      "resolved": "https://registry.npmjs.org/typegpu/-/typegpu-0.11.8.tgz",
-      "integrity": "sha512-aEVdtGDTWrXB5yVCwriM84iyfnw8dHWiXVTA2Hr9hnJN2F4IXKainTVKd3HP2/lPHqDg5iYjt7yL//p2sJAWBg==",
+      "version": "0.11.9",
+      "resolved": "https://registry.npmjs.org/typegpu/-/typegpu-0.11.9.tgz",
+      "integrity": "sha512-AqBV6P9lW2jA7pEVDeiMD7Qoza9doPgueQbwyUyf09u4ndb9jOttHwpZ18c+BEzwLHaPlV50jw0hx5QsmVJGNg==",
       "license": "MIT",
       "dependencies": {
         "tinyest": "~0.3.2",

--- a/package.json
+++ b/package.json
@@ -32,8 +32,6 @@
     "@next/third-parties": "16.2.7",
     "@react-email/components": "^1.0.12",
     "@tailwindcss/postcss": "^4.2.2",
-    "@typegpu/noise": "^0.11.0",
-    "@typegpu/react": "^0.11.2",
     "@types/mdx": "^2.0.13",
     "@upstash/redis": "^1.38.0",
     "@upstash/vector": "^1.2.3",
@@ -47,7 +45,7 @@
     "gray-matter": "^4.0.3",
     "katex": "^0.16.45",
     "marked": "^17.0.5",
-    "matrix-rain-webgpu": "^1.0.0",
+    "matrix-rain-webgpu": "^2.0.0",
     "mermaid": "^11.15.0",
     "next": "16.2.9",
     "postcss": "^8.5.15",
@@ -70,7 +68,6 @@
     "serwist": "^9.5.11",
     "tailwindcss": "^4.3.1",
     "tsx": "^4.22.4",
-    "typegpu": "^0.11.8",
     "zod": "^4.4.3"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

Updates `matrix-rain-webgpu` `^1.0.0` → `^2.0.0` following the [2.0.0 release](https://github.com/chicio/matrix-rain-webgpu/releases/tag/2.0.0).

The 2.0.0 release is a dependency-management release — **no runtime API changes**. It moves the TypeGPU packages from `peerDependencies` to **exact-pinned regular dependencies** and requires `@typegpu/react ^0.11.2`.

Following that intent:
- Bumped `matrix-rain-webgpu` to `^2.0.0`.
- **Removed** `typegpu`, `@typegpu/react`, and `@typegpu/noise` from the blog's direct dependencies. They only existed to satisfy 1.0.0's peer requirements; the blog never imports them directly (only through `matrix-rain-webgpu`). 2.0.0 now supplies them transitively at pinned versions: `typegpu@0.11.9`, `@typegpu/react@0.11.2`, `@typegpu/noise@0.11.0`.

## Supersedes

This **supersedes `chore/bump-typegpu-0.11.9`** — that branch manually bumped `typegpu` to 0.11.9 to satisfy the `@typegpu/react` peer. The 2.0.0 library now pins `typegpu@0.11.9` itself, so the manual bump is no longer needed. That branch/PR can be closed.

## Verification

All gates green locally:
- ✅ knip
- ✅ typecheck
- ✅ lint
- ✅ 760 tests
- ✅ validate-architecture (656 modules, no violations)
- ✅ production build

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a bundled graphics-related dependency to a newer major version.
  * Removed a few unused package dependencies to keep the project leaner.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->