### PR TITLE
fix(capabilities): :bug: loop drainer reads-and-follows the orchestrator

### DIFF
--- a/.claude/skills/fabrizioduroni-loop/SKILL.md
+++ b/.claude/skills/fabrizioduroni-loop/SKILL.md
@@ -57,15 +57,21 @@ gh issue list --label "loop:ready" --state open --json number,title,createdAt,la
 - Otherwise pick the issue with the **oldest `createdAt`** (FIFO). **One issue per tick — never more.**
 
 ### 4. Hand off to the orchestrator
-Invoke the orchestrator's autonomous mode on the selected issue:
+The orchestrator skill is `disable-model-invocation: true`, so you **cannot invoke it via the Skill tool** from here
+(you are running as the model). Instead, **read and follow** its autonomous procedure directly:
 
-```
-/fabrizioduroni-blog-sdlc --autonomous --from-issue <N>
-```
+1. `Read` `.claude/skills/fabrizioduroni-blog-sdlc/SKILL.md`.
+2. Execute its **§ Autonomous mode (Phase 2)** end-to-end for the selected issue `<N>` — that is, as if invoked with
+   `--autonomous --from-issue <N>`.
 
-It does everything from here: claims the issue (`loop:ready` → `loop:working`), runs the contract check, and either
-lands a PR (`loop:review`) or blocks the issue (`loop:blocked`) — see its **§ Autonomous mode**. Do **not** duplicate
-any of that logic here; just invoke it and wait for it to return.
+It does everything from there: claims the issue (`loop:ready` → `loop:working`), runs the contract check, and either
+lands a PR (`loop:review`) or blocks the issue (`loop:blocked`). Do **not** duplicate or paraphrase that logic here —
+follow the orchestrator's own steps as the single source of truth, then return to step 5.
+
+> Why read-and-follow instead of invoke: the orchestrator stays `disable-model-invocation: true` on purpose so it
+> never auto-fires on a casual request (its interactive Phase 1 modes are manual-only). Reading its file and following
+> § Autonomous mode is functionally identical to a skill invocation — it injects the same instructions — without
+> widening the orchestrator's auto-trigger surface.
 
 ### 5. Report the outcome
 Summarize the tick in one short block, then let `/loop` sleep:


### PR DESCRIPTION
Follow-up to #418. The `fabrizioduroni-loop` drainer's step 4 told the model to invoke `/fabrizioduroni-blog-sdlc --autonomous` — but the orchestrator is `disable-model-invocation: true`, so the model (which is what the drainer runs as) can't invoke it via the Skill tool. Same class of bug as the grill-me → grilling fix in #418.

## Description
Change the drainer's hand-off to **read and follow** the orchestrator's `§ Autonomous mode` from its `SKILL.md`, rather than invoking it as a skill. Functionally identical (it injects the same instructions) but it keeps the orchestrator `disable-model-invocation: true`.

## Motivation and Context
Keeping the flag preserves the deliberate "the orchestrator never auto-triggers" property documented in `CLAUDE.md` (the escape hatch exists precisely so trivial changes don't get auto-routed through the full pipeline). Dropping the flag would have unblocked the drainer but also let the orchestrator auto-fire on casual requests — so read-and-follow is the fix that unblocks the hand-off without widening the auto-trigger surface.

## How Has This Been Tested?
Skill-doc-only change (no source). This is also the exact mechanism used to drive the first live autonomous run manually, so it is validated in practice.

## Types of changes
- [X] Bug fix :bug: (non-breaking change which fixes an issue)

## Checklist:
- [X] My code follows the code style of this project :beers:.
- [X] My change requires a change to the documentation :bulb: and I have updated the documentation accordingly.
- [X] I have read the [CONTRIBUTING](https://github.com/chicio/chicio.github.io/blob/master/CONTRIBUTING.md) document :busts_in_silhouette:.
- [ ] I have added tests to cover my changes :tada:.
- [X] All new and existing tests passed :white_check_mark:.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the handoff flow for orchestrated tasks, with updated guidance to follow the orchestrator’s autonomous steps directly and keep the trigger surface limited.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->