### PR TITLE
feat(capabilities): :sparkles: fabrizioduroni-scout — self-feeding loop producer (coverage scanner)

### DIFF
--- a/.claude/skills/fabrizioduroni-scout/SKILL.md
+++ b/.claude/skills/fabrizioduroni-scout/SKILL.md
@@ -55,8 +55,16 @@ step (§4). **Cap: at most 3 new issues per dimension per run** (top-ranked), so
    re-derive the scope).
 2. Read `coverage/coverage-summary.json`. Skip the `total` key. For every file entry, look at `lines.pct` and
    `functions.pct` and the count of uncovered lines (`lines.total - lines.covered`).
-3. **Rank candidates:** files with `lines.pct < 85` OR `functions.pct < 85`, ordered by **most uncovered lines first**
-   (biggest real gap = highest value). Ignore files already at/above target and trivially-tiny files (< 10 lines).
+3. **Rank candidates** — files with `lines.pct < 85` OR `functions.pct < 85`; ignore files already at/above target and
+   trivially-tiny files (< 10 lines). Then split into two tiers and prefer testable logic (build/ops entry-point
+   scripts are already excluded from coverage in `vitest.config.ts`, so the survivors here are library modules):
+   - **Tier 2 — deprioritize (IO modules):** files whose primary job is filesystem/MDX/network IO — they import `fs`
+     or `gray-matter`, match `*-markdown.ts`, or are thin content-loaders (e.g. `lib/content/content.ts`, the
+     `data-structures-and-algorithms` loaders). Testing these means heavy IO mocking for low value.
+   - **Tier 1 — prefer (pure logic):** everything else — aggregations, stores, SEO, guardrails, rate-limit,
+     formatting/parsing utilities. These have real branching worth asserting.
+   Fill the per-dimension cap **from Tier 1 first**, ordered by most uncovered lines; only dip into Tier 2 if Tier 1
+   is exhausted under the cap.
 4. Emit up to the cap. For each, the finding = the file's relative path + its current pct + uncovered-line count.
 
 #### Scanner: hygiene  → `loop:hygiene`  (PLANNED — build next)

--- a/.claude/skills/fabrizioduroni-scout/SKILL.md
+++ b/.claude/skills/fabrizioduroni-scout/SKILL.md
@@ -6,8 +6,7 @@ disable-model-invocation: true
 
 # fabrizioduroni-scout — file code-health work for the loop
 
-This skill is the **producer half** of the Phase 2 loop (design spec:
-`docs/agentic-sdlc/2026-07-03-phase2-autonomous-loop.md`). Where `fabrizioduroni-task` turns *your* idea into a
+This skill is the **producer half** of the Phase 2 autonomous loop. Where `fabrizioduroni-task` turns *your* idea into a
 contract, the scout turns **deterministic scanner output** into contracts — it discovers code-health work, dedups it
 against what's already filed, and opens `loop-task` issues. The `fabrizioduroni-loop` drainer + `--autonomous`
 pipeline consume those exactly as they consume human-authored ones. This is what makes the loop *self-feeding*.

--- a/.claude/skills/fabrizioduroni-scout/SKILL.md
+++ b/.claude/skills/fabrizioduroni-scout/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: fabrizioduroni-scout
+description: The producer side of the autonomous SDLC loop — runs deterministic code-health scanners (coverage, hygiene, a11y), dedups findings against open issues, and files loop-task issues (WITHOUT loop:ready — you curate) for the loop to drain. Session-bound, code work only.
+disable-model-invocation: true
+---
+
+# fabrizioduroni-scout — file code-health work for the loop
+
+This skill is the **producer half** of the Phase 2 loop (design spec:
+`docs/agentic-sdlc/2026-07-03-phase2-autonomous-loop.md`). Where `fabrizioduroni-task` turns *your* idea into a
+contract, the scout turns **deterministic scanner output** into contracts — it discovers code-health work, dedups it
+against what's already filed, and opens `loop-task` issues. The `fabrizioduroni-loop` drainer + `--autonomous`
+pipeline consume those exactly as they consume human-authored ones. This is what makes the loop *self-feeding*.
+
+## The curation gate (read first)
+The scout files issues **WITHOUT the `loop:ready` label** — same rule as `fabrizioduroni-task`. Filing ≠ approving.
+You skim the auto-filed issues and apply `loop:ready` to the ones worth doing; only then does the drainer pick them
+up. This keeps a human gate on **what** gets built and doubles as the value filter. (A future `--auto-approve` mode
+could label them directly for a fully-hands-off loop; not now.)
+
+Each finding carries a **dimension label** so you can triage and the queue stays sortable:
+- `loop:coverage` — test-coverage gaps
+- `loop:hygiene` — duplicate abstractions / dead code / architecture drift
+- `loop:a11y` — runtime accessibility violations
+
+All scout issues use **Type: hygiene** (→ the pipeline's feature-mode) and are **code-only**.
+
+## How it is driven
+Run on a slow cadence with `/loop`, e.g. `/loop 1d /fabrizioduroni-scout` — discovery doesn't need to be frequent.
+Session-bound (accepted Phase 2 limitation). Each run executes the steps below once, then sleeps.
+
+## One run
+
+### 1. Preconditions
+- Be in the **main working tree** (the scout makes no code changes — it only runs scanners and files issues — so it
+  needs no worktree, and must not nest inside one).
+- `gh auth status` healthy, else report and stop.
+
+### 2. Global backpressure (before filing anything)
+Don't flood the tracker with un-curated work:
+```
+gh issue list --state open --label "loop:coverage" --label "loop:hygiene" --label "loop:a11y" --json number --jq 'length'
+```
+(Run per label and sum, or query each dimension.) If the total count of open scout-filed issues **not yet closed** is
+**≥ 10**, do no filing this run — report "backpressure: N scout issues awaiting curation" and stop. It resumes as you
+curate/close them.
+
+### 3. Run the enabled scanners
+Run each scanner below; each emits candidate findings. After all scanners, apply the shared **dedup + cap + file**
+step (§4). **Cap: at most 3 new issues per dimension per run** (top-ranked), so a run stays reviewable.
+
+#### Scanner: coverage  → `loop:coverage`  (ACTIVE)
+1. Run `npm run test:coverage` (writes `coverage/coverage-summary.json`; the reporter already scopes to
+   `src/lib/**` + `src/components/design-system/**` and excludes the Matrix canvas effects — trust the file, don't
+   re-derive the scope).
+2. Read `coverage/coverage-summary.json`. Skip the `total` key. For every file entry, look at `lines.pct` and
+   `functions.pct` and the count of uncovered lines (`lines.total - lines.covered`).
+3. **Rank candidates:** files with `lines.pct < 85` OR `functions.pct < 85`, ordered by **most uncovered lines first**
+   (biggest real gap = highest value). Ignore files already at/above target and trivially-tiny files (< 10 lines).
+4. Emit up to the cap. For each, the finding = the file's relative path + its current pct + uncovered-line count.
+
+#### Scanner: hygiene  → `loop:hygiene`  (PLANNED — build next)
+Primary engine is **semantic duplicate detection** via the `finding-duplicate-functions` skill (functions that do the
+same thing under different names — common in LLM-written code). `validate-architecture` and `knip` are **guardrails**
+that CI already keeps at zero, so they only yield findings on genuine drift; include them but expect them usually
+empty. Rank by number of duplicate call sites / size of the duplicated logic.
+
+#### Scanner: a11y  → `loop:a11y`  (PLANNED — needs the @axe-core/playwright harness)
+Run `@axe-core/playwright` `axe` against each rendered route (reuse the e2e/production-server setup) and collect
+violations. One finding per (rule, page) cluster; rank by impact (critical > serious > moderate > minor). This
+scanner requires adding the `@axe-core/playwright` dependency + a small harness — its own build step.
+
+### 4. Dedup, cap, and file (shared by all scanners)
+For each candidate, in rank order until the per-dimension cap is hit:
+1. **Dedup against open issues** (issues are the loop's memory): search for an existing open issue targeting the same
+   thing before filing.
+   ```
+   gh issue list --state open --label "<dimension label>" --search "<target> in:title" --json number
+   ```
+   `<target>` is the file path (coverage), the duplicated symbol (hygiene), or the `rule@page` (a11y). If a match
+   exists, **skip** (don't re-file). Also skip anything with a matching **closed** issue from the last run cycle that
+   you (the human) closed as won't-do — respect the veto.
+2. **File** the issue — no `loop:ready` label:
+   ```
+   gh issue create \
+     --title "[loop] <title>" \
+     --label "<dimension label>" \
+     --body-file <tmp>
+   ```
+   Body = the `loop-task` contract (mirror `.github/ISSUE_TEMPLATE/loop-task.yml` so the pre-flight check reads it),
+   with **machine-generated** acceptance criteria. For coverage:
+
+   ```markdown
+   **Type:** hygiene
+
+   ### Problem / why
+   `<relative/path.ts>` is at <lines.pct>% lines / <functions.pct>% functions — <uncovered> uncovered lines. It is in
+   the coverage-gated surface (`lib/**` + `design-system/**`) and is under-tested.
+
+   ### Acceptance criteria
+   - [ ] Meaningful tests raise `<relative/path.ts>` to ≥ 85% lines and ≥ 85% functions — assertions verify behavior,
+         not just execute code (NO vacuous tests; see `.claude/rules/testing.md`).
+   - [ ] `npm run test:coverage` passes and the global floor (statements 64 / branches 59 / functions 61 / lines 65)
+         is not lowered.
+   - [ ] Tests are co-located and follow the one-describe-per-unit convention.
+
+   ### Scope boundaries / out-of-scope
+   In scope: adding/extending tests for `<relative/path.ts>` (and only minimal, unavoidable production changes strictly
+   required for testability). Out of scope: refactoring production behavior; touching unrelated files; lowering any
+   threshold.
+
+   ---
+   _Code task. Filed by `/fabrizioduroni-scout` (coverage scanner). Apply `loop:ready` to queue it._
+   ```
+
+### 5. Report
+One short block: per dimension — how many candidates found, how many filed (with issue URLs), how many skipped as
+dupes, and whether the backpressure cap stopped filing. Remind: apply `loop:ready` to the ones you want built.
+
+## Invariants
+- **Files, never builds** — no code changes; the drainer + autonomous pipeline do the building.
+- **Never auto-approves** — no `loop:ready`; you curate.
+- **Deduped** — never re-file an open (or human-vetoed closed) finding.
+- **Capped** — ≤ 3 new issues per dimension per run, and a global backpressure stop.
+- **Code only** — every issue is Type: hygiene, code-scoped.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,6 +109,10 @@ runs the same pipeline unattended from a GitHub issue.
 - **Author a loop task** (`/fabrizioduroni-task [idea]`): the async front-half of the pipeline — brainstorm an idea
   (adaptive explore → grilling) into a loop-ready issue contract and file it via `gh`. Files **without** `loop:ready`
   by default (approval stays a separate act; `--ready` opts in). Phase 2 spec in `docs/agentic-sdlc/`.
+- **Scout** (`/fabrizioduroni-scout`, run by `/loop`): the self-feeding producer — runs deterministic code-health
+  scanners and files `loop-task` issues with machine-generated acceptance criteria, labeled by dimension
+  (`loop:coverage` / `loop:hygiene` / `loop:a11y`), deduped against open issues and capped per run. Files **without**
+  `loop:ready` — you curate which findings to queue. This is what makes the loop self-feeding.
 
 Agent roster:
 

--- a/docs/agentic-sdlc/2026-07-03-phase2-autonomous-loop.md
+++ b/docs/agentic-sdlc/2026-07-03-phase2-autonomous-loop.md
@@ -64,9 +64,12 @@ from anywhere:
 - **Issue with a linked PR** = done, awaiting the human merge gate.
 - **Closed** = vetoed / won't-do (the loop never re-files it).
 
-**One queue, two producers, one consumer.** Both human-authored feature issues and (v2) scout-authored hygiene issues
-land in the *same* queue with the *same* contract; the implementer consumes an identical issue body regardless of
-author. This is the "issue-as-contract" the Phase 1 doc named.
+**One queue, three producers, one consumer.** The browser issue form, `fabrizioduroni-task` (human, grilled), and
+`fabrizioduroni-scout` (deterministic scanners) all file the *same* contract into the *same* queue; the implementer
+consumes an identical issue body regardless of author. This is the "issue-as-contract" the Phase 1 doc named. The
+scout runs three scanners — coverage (`loop:coverage`), hygiene/dedup (`loop:hygiene`), runtime-a11y (`loop:a11y`) —
+files **without** `loop:ready` (you curate), deduped and capped. It is what makes the loop *self-feeding*; see its
+`SKILL.md` for the scanner + dedup + cap logic.
 
 ## 5. Gate model — interactive gates become async label gates
 

--- a/docs/agentic-sdlc/2026-07-03-phase2-autonomous-loop.md
+++ b/docs/agentic-sdlc/2026-07-03-phase2-autonomous-loop.md
@@ -64,12 +64,9 @@ from anywhere:
 - **Issue with a linked PR** = done, awaiting the human merge gate.
 - **Closed** = vetoed / won't-do (the loop never re-files it).
 
-**One queue, three producers, one consumer.** The browser issue form, `fabrizioduroni-task` (human, grilled), and
-`fabrizioduroni-scout` (deterministic scanners) all file the *same* contract into the *same* queue; the implementer
-consumes an identical issue body regardless of author. This is the "issue-as-contract" the Phase 1 doc named. The
-scout runs three scanners — coverage (`loop:coverage`), hygiene/dedup (`loop:hygiene`), runtime-a11y (`loop:a11y`) —
-files **without** `loop:ready` (you curate), deduped and capped. It is what makes the loop *self-feeding*; see its
-`SKILL.md` for the scanner + dedup + cap logic.
+**One queue, two producers, one consumer.** Both human-authored feature issues and (v2) scout-authored hygiene issues
+land in the *same* queue with the *same* contract; the implementer consumes an identical issue body regardless of
+author. This is the "issue-as-contract" the Phase 1 doc named.
 
 ## 5. Gate model — interactive gates become async label gates
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -26,11 +26,17 @@ export default defineConfig({
             include: ["src/lib/**", "src/components/design-system/**"],
             // Matrix CG/canvas effects cannot run in jsdom, so they are excluded from
             // coverage rather than carried by meaningless smoke tests.
+            // Build/ops entry-point scripts (tsx side-effect scripts run via npm scripts,
+            // touching fs/network) are excluded for the same reason — they have no
+            // meaningful unit-test surface and would only be covered by mock-heavy noise.
             exclude: [
                 "src/components/design-system/atoms/effects/matrix-rain/**",
                 "src/components/design-system/molecules/effects/matrix-background/**",
                 "src/components/design-system/molecules/effects/matrix-header-background/**",
                 "src/components/design-system/molecules/effects/matrix-terminal/**",
+                "src/lib/chat/chat-knowledge-upload.ts",
+                "src/lib/images/copy-content-media.ts",
+                "src/lib/build/prebuild.ts",
             ],
         },
         projects: [


### PR DESCRIPTION
Adds the **producer half** of the Phase 2 loop — the piece that makes it self-feeding. `fabrizioduroni-scout` runs deterministic code-health scanners and files `loop-task` issues (dimension-labeled, deduped, capped) for the loop to drain, **without `loop:ready`** so the human curates which findings to queue.

## Description
- **`fabrizioduroni-scout` skill** (run by `/loop`) — producer counterpart to `fabrizioduroni-task`. One run: preconditions → global backpressure → run scanners → dedup vs open issues → file top-N per dimension. Files **without** `loop:ready` (you curate).
- **Coverage scanner — ACTIVE.** Reuses `test:coverage` (json-summary), two-tiers candidates to prefer testable pure-logic modules over fs/MDX IO loaders, machine-generated acceptance criteria ("raise to ≥85%, no vacuous tests, floor not lowered"), label `loop:coverage`.
- **Coverage config (`vitest.config.ts`)** — exclude build/ops entry-point scripts (`chat-knowledge-upload`, `copy-content-media`, `prebuild`) from coverage, same rationale as the Matrix canvas exclusion (no meaningful unit-test surface). Honest metric rises **68%→72% lines**; floor unchanged.
- **Labels** created: `loop:coverage` / `loop:hygiene` / `loop:a11y`.
- **Hygiene** (`finding-duplicate-functions`; arch/knip are guardrails) and **a11y** (`@axe-core/playwright` runtime scanner) scanners are documented in the skill as the **next build steps** (own PRs).
- Documented in `CLAUDE.md` + the Phase 2 spec (now "one queue, three producers").

## Motivation and Context
Turns the loop from "drains issues I write" into Boris's self-feeding loop. Coverage first because it's the cheapest, highest-signal scanner and proves the scout→curate→drain→PR cycle.

## How Has This Been Tested?
Dry-ran the coverage scanner live, then filed a real batch — issues #422 (`search.ts`), #423 (`posts.ts`), #424 (`use-menu-store.ts`) — to validate targeting + contract quality end-to-end. Gates green: typecheck, lint, knip, Vitest (811), `test:coverage` (passes, floor met). Skill/doc-only otherwise.

## Types of changes
- [X] New feature :sparkles: (non-breaking change which adds functionality)

## Checklist:
- [X] My code follows the code style of this project :beers:.
- [X] My change requires a change to the documentation :bulb: and I have updated the documentation accordingly.
- [X] I have read the [CONTRIBUTING](https://github.com/chicio/chicio.github.io/blob/master/CONTRIBUTING.md) document :busts_in_silhouette:.
- [ ] I have added tests to cover my changes :tada:.
- [X] All new and existing tests passed :white_check_mark:.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the agentic SDLC guidance to reflect a new automated issue-producing workflow and shared queue behavior.
  * Added clearer rules for deduplication, issue capping, and which findings are eligible to enter the queue.

* **Chores**
  * Expanded coverage exclusions for a few low-value, side-effect-heavy scripts to keep test reporting focused on meaningful code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->