### PR TITLE
fix(ux): :wheelchair: exclude the contact honeypot from the accessibility tree

### DIFF
--- a/src/components/content/contact/contact/contact-form/contact-form.test.tsx
+++ b/src/components/content/contact/contact/contact-form/contact-form.test.tsx
@@ -20,9 +20,11 @@ describe("ContactForm", () => {
             expect(screen.getByLabelText(/message/i)).toBeInTheDocument();
         });
 
-        it("renders the honeypot field with a programmatic label", () => {
-            render(<ContactForm trackingCategory="test" />);
-            expect(screen.getByLabelText(/additional information/i)).toBeInTheDocument();
+        it("keeps the honeypot field in the DOM but out of the accessibility tree", () => {
+            const { container } = render(<ContactForm trackingCategory="test" />);
+            const honeypot = container.querySelector('input[name="website"]');
+            expect(honeypot).toBeInTheDocument();
+            expect(honeypot?.closest('[aria-hidden="true"]')).not.toBeNull();
         });
 
         it("renders the Send Message button", () => {

--- a/src/components/content/contact/contact/contact-form/contact-form.test.tsx
+++ b/src/components/content/contact/contact/contact-form/contact-form.test.tsx
@@ -20,6 +20,11 @@ describe("ContactForm", () => {
             expect(screen.getByLabelText(/message/i)).toBeInTheDocument();
         });
 
+        it("renders the honeypot field with a programmatic label", () => {
+            render(<ContactForm trackingCategory="test" />);
+            expect(screen.getByLabelText(/additional information/i)).toBeInTheDocument();
+        });
+
         it("renders the Send Message button", () => {
             render(<ContactForm trackingCategory="test" />);
             expect(screen.getByText("Send Message")).toBeInTheDocument();

--- a/src/components/content/contact/contact/contact-form/contact-form.tsx
+++ b/src/components/content/contact/contact/contact-form/contact-form.tsx
@@ -91,6 +91,7 @@ export const ContactForm: FC<ContactFormProps> = ({ trackingCategory }) => {
                         label="Additional Information"
                         icon={<BiMessageDetail size={20} />}
                         type="text"
+                        id="website"
                         name="website"
                         value={honeypot}
                         onChange={onHoneypotChange}

--- a/src/components/content/contact/contact/contact-form/contact-form.tsx
+++ b/src/components/content/contact/contact/contact-form/contact-form.tsx
@@ -86,12 +86,11 @@ export const ContactForm: FC<ContactFormProps> = ({ trackingCategory }) => {
                     disabled={isSubmitting}
                     hasError={!!errors.message}
                 />
-                <div className="absolute -left-2499.75 -top-2499.75 opacity-0">
+                <div aria-hidden="true" className="absolute -left-2499.75 -top-2499.75 opacity-0">
                     <FormField
                         label="Additional Information"
                         icon={<BiMessageDetail size={20} />}
                         type="text"
-                        id="website"
                         name="website"
                         value={honeypot}
                         onChange={onHoneypotChange}


### PR DESCRIPTION
Fix the axe `label` (critical) violation on `/contact` by excluding the anti-spam honeypot input from the accessibility tree — the correct treatment for a bot trap.

## Description
The offending `input[autocomplete="off"]` is a honeypot (`name="website"`, off-screen, `tabIndex={-1}`) used to detect bots. Rather than giving it a programmatic label — which would make a screen-reader user who fills it look like a bot — the honeypot's off-screen wrapper is marked `aria-hidden="true"`, removing the whole subtree from the accessibility tree.

- axe's `label` rule no longer fires (elements inside an `aria-hidden` subtree are not checked).
- No `aria-hidden-focus` violation is introduced: the input keeps `tabIndex={-1}`, so it is not in the tab order.
- The field stays in the DOM and functional, so bots still fill it and the honeypot logic (`onHoneypotChange`) is unchanged.

The test asserts the honeypot is present in the DOM but inside an `aria-hidden` subtree (i.e. excluded from assistive tech).

## Motivation and Context
A honeypot should be invisible to assistive technology, not merely off-screen. Excluding it from the a11y tree both resolves the axe `label` violation and is the semantically correct behavior. Closes #431.

## How Has This Been Tested?
Automated (lint, validate-architecture, knip, typecheck, Vitest, build) + `npm run a11y-scan` — **zero `label` violations on `/contact`, and no new `aria-hidden-focus` violation** (verified in the report). Playwright e2e not required — the honeypot is non-interactive and off-screen; no user-visible flow change.

Closes #431

## Types of changes
- [X] Bug fix :bug: (non-breaking change which fixes an issue)
- [ ] New feature :sparkles: (non-breaking change which adds functionality)
- [ ] Breaking change :boom: (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project :beers:.
- [X] My change requires a change to the documentation :bulb: and I have updated the documentation accordingly.
- [X] I have read the [CONTRIBUTING](https://github.com/chicio/chicio.github.io/blob/master/CONTRIBUTING.md) document :busts_in_silhouette:.
- [X] I have added tests to cover my changes :tada:.
- [X] All new and existing tests passed :white_check_mark:.