### PR TITLE
test(capabilities): :white_check_mark: cover matrix-settings read/write/settingsToProps

### DIFF
--- a/src/components/design-system/state/matrix-rain/matrix-settings.test.ts
+++ b/src/components/design-system/state/matrix-rain/matrix-settings.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+    readMatrixSettings,
+    writeMatrixSettings,
+    settingsToProps,
+    matrixSettingsChangeEvent,
+    MATRIX_RAIN_DEFAULTS,
+    MatrixRainSettings,
+} from "./matrix-settings";
+
+const STORAGE_KEY = "fabrizioduroni_matrix-rain-settings";
+
+describe("matrix-settings", () => {
+    beforeEach(() => {
+        localStorage.clear();
+    });
+
+    describe("readMatrixSettings", () => {
+        it("returns the defaults when nothing is stored", () => {
+            expect(readMatrixSettings()).toEqual(MATRIX_RAIN_DEFAULTS);
+        });
+
+        it("returns the SAME object reference across consecutive calls with identical raw storage", () => {
+            localStorage.setItem(STORAGE_KEY, JSON.stringify(MATRIX_RAIN_DEFAULTS));
+            expect(readMatrixSettings()).toBe(readMatrixSettings());
+        });
+
+        it("returns the defaults when the stored version does not match the current version", () => {
+            const stale: MatrixRainSettings = {
+                ...MATRIX_RAIN_DEFAULTS,
+                version: 999,
+            };
+            localStorage.setItem(STORAGE_KEY, JSON.stringify(stale));
+            expect(readMatrixSettings()).toEqual(MATRIX_RAIN_DEFAULTS);
+        });
+
+        it("returns the defaults without throwing when the stored value is malformed JSON", () => {
+            localStorage.setItem(STORAGE_KEY, "{not-valid-json");
+            expect(() => readMatrixSettings()).not.toThrow();
+            expect(readMatrixSettings()).toEqual(MATRIX_RAIN_DEFAULTS);
+        });
+
+        it("reflects a fresh value after the stored raw changes", () => {
+            const custom: MatrixRainSettings = {
+                version: MATRIX_RAIN_DEFAULTS.version,
+                rain: { density: 0.5, stepRate: 5, fontSize: 10 },
+                bloom: { enabled: false, intensity: 0, threshold: 0, emission: 0 },
+                crt: { enabled: false, scanlineStrength: 0, aberration: 0 },
+            };
+            localStorage.setItem(STORAGE_KEY, JSON.stringify(custom));
+            expect(readMatrixSettings()).toEqual(custom);
+        });
+    });
+
+    describe("writeMatrixSettings", () => {
+        it("persists the settings stamped with the current version", () => {
+            const custom: MatrixRainSettings = {
+                version: MATRIX_RAIN_DEFAULTS.version,
+                rain: { density: 0.7, stepRate: 12, fontSize: 18 },
+                bloom: { enabled: false, intensity: 1, threshold: 1, emission: 1 },
+                crt: { enabled: true, scanlineStrength: 0.5, aberration: 0.5 },
+            };
+            writeMatrixSettings(custom);
+            const stored = JSON.parse(localStorage.getItem(STORAGE_KEY) as string) as MatrixRainSettings;
+            expect(stored).toEqual(custom);
+        });
+
+        it("dispatches the matrix settings change event", () => {
+            const listener = vi.fn();
+            window.addEventListener(matrixSettingsChangeEvent, listener);
+            writeMatrixSettings(MATRIX_RAIN_DEFAULTS);
+            window.removeEventListener(matrixSettingsChangeEvent, listener);
+            expect(listener).toHaveBeenCalledOnce();
+        });
+
+        it("round-trips: a written value is reflected by a subsequent read", () => {
+            const custom: MatrixRainSettings = {
+                version: MATRIX_RAIN_DEFAULTS.version,
+                rain: { density: 0.6, stepRate: 20, fontSize: 14 },
+                bloom: { enabled: true, intensity: 2, threshold: 0.4, emission: 0.9 },
+                crt: { enabled: false, scanlineStrength: 0.1, aberration: 0.2 },
+            };
+            writeMatrixSettings(custom);
+            expect(readMatrixSettings()).toEqual(custom);
+        });
+    });
+
+    describe("settingsToProps", () => {
+        it("maps bloom and crt to their options objects when both are enabled", () => {
+            const settings: MatrixRainSettings = {
+                version: MATRIX_RAIN_DEFAULTS.version,
+                rain: { density: 0.95, stepRate: 10, fontSize: 20 },
+                bloom: { enabled: true, intensity: 1.5, threshold: 0.8, emission: 1.1 },
+                crt: { enabled: true, scanlineStrength: 0.3, aberration: 1.0 },
+            };
+            expect(settingsToProps(settings)).toEqual({
+                rain: { density: 0.95, stepRate: 10, fontSize: 20 },
+                bloom: { intensity: 1.5, threshold: 0.8, emission: 1.1 },
+                crt: { scanlineStrength: 0.3, aberration: 1.0 },
+            });
+        });
+
+        it("maps bloom and crt to false when both are disabled", () => {
+            const settings: MatrixRainSettings = {
+                version: MATRIX_RAIN_DEFAULTS.version,
+                rain: { density: 0.5, stepRate: 8, fontSize: 16 },
+                bloom: { enabled: false, intensity: 1.5, threshold: 0.8, emission: 1.1 },
+                crt: { enabled: false, scanlineStrength: 0.3, aberration: 1.0 },
+            };
+            expect(settingsToProps(settings)).toEqual({
+                rain: { density: 0.5, stepRate: 8, fontSize: 16 },
+                bloom: false,
+                crt: false,
+            });
+        });
+    });
+});


### PR DESCRIPTION
Add behavioral unit tests for `src/components/design-system/state/matrix-rain/matrix-settings.ts`, raising it from 62.85% lines / 40% functions to **94.28% lines / 100% functions**.

## Description
New co-located test file `matrix-settings.test.ts` (jsdom project, 10 tests, single top-level `describe` with a nested `describe` per function). No production code changed. Scenarios:
- **readMatrixSettings** — default when nothing stored; **cached-snapshot identity** on identical raw (`toBe` object-reference, the `useSyncExternalStore` getSnapshot stability contract); version-mismatch → defaults; malformed-JSON → defaults without throwing; fresh value after the raw changes.
- **writeMatrixSettings** — persists version-stamped JSON, dispatches the change event, round-trips through `readMatrixSettings`.
- **settingsToProps** — bloom/crt enabled → options object; disabled → `false`.

The two remaining uncovered lines are unreachable defensive `catch` branches (the inner `readLocalStorage` already swallows its own throw), so coverage sits at 94% lines without contriving dead-code tests.

## Motivation and Context
`matrix-settings.ts` is pure logic in the coverage-gated surface (`design-system/**`) and was under-tested. Closes #427.

## How Has This Been Tested?
Automated (lint, validate-architecture, knip, typecheck, Vitest 885 tests, build, coverage). Global floor unchanged and not lowered. Playwright e2e not required — pure-logic unit tests, no UI/route/flow change.

Closes #427

## Types of changes
- [ ] Bug fix :bug: (non-breaking change which fixes an issue)
- [ ] New feature :sparkles: (non-breaking change which adds functionality)
- [ ] Breaking change :boom: (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project :beers:.
- [X] My change requires a change to the documentation :bulb: and I have updated the documentation accordingly.
- [X] I have read the [CONTRIBUTING](https://github.com/chicio/chicio.github.io/blob/master/CONTRIBUTING.md) document :busts_in_silhouette:.
- [X] I have added tests to cover my changes :tada:.
- [X] All new and existing tests passed :white_check_mark:.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated coverage for settings behavior, including fallback to default values when saved data is missing or invalid.
  * Verified that saved settings are read consistently, updated changes are reflected, and changes are properly persisted.
  * Added checks for display-related option mapping to ensure enabled and disabled states are handled correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->