### PR TITLE
test(capabilities): :white_check_mark: cover use-search min-char gate, results mapping, easter egg, reset

### DIFF
--- a/src/components/design-system/hooks/use-search.test.ts
+++ b/src/components/design-system/hooks/use-search.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { renderHook, act } from "@testing-library/react";
+import { renderHook, act, RenderHookResult } from "@testing-library/react";
 import { ChangeEvent } from "react";
 import type { SearchResult, EasterEggSearchResult } from "@/types/search/search";
 
@@ -33,6 +33,19 @@ function getResultsFromSearchResult(result: SearchResult) {
     }
     return [];
 }
+
+type UseSearchReturn = ReturnType<typeof useSearch>;
+
+const renderLoadedSearch = async (
+    easterEgg: (query: string) => SearchResult | null = noEasterEgg,
+    searchIndexFileName = "search-index.json",
+): Promise<RenderHookResult<UseSearchReturn, unknown>> => {
+    let rendered!: RenderHookResult<UseSearchReturn, unknown>;
+    await act(async () => {
+        rendered = renderHook(() => useSearch(true, easterEgg, searchIndexFileName));
+    });
+    return rendered;
+};
 
 describe("useSearch", () => {
     beforeEach(() => {
@@ -84,23 +97,56 @@ describe("useSearch", () => {
             expect(getResultsFromSearchResult(result.current.search)).toHaveLength(0);
         });
 
-        it("returns easter egg result when easterEgg returns non-null", async () => {
+        it("returns easter egg result and short-circuits the index search when easterEgg returns non-null", async () => {
             const easterEggResult: EasterEggSearchResult = {
                 type: "easterEgg",
                 terminalLines: [{ text: "Wake up, Neo..." }],
             };
             const easterEgg = vi.fn((): SearchResult | null => easterEggResult);
 
-            const { result } = renderHook(() =>
-                useSearch(true, easterEgg, "search-index.json"),
-            );
+            const { result } = await renderLoadedSearch(easterEgg);
 
             const event = { target: { value: "matrix" } } as ChangeEvent<HTMLInputElement>;
             await act(async () => {
                 result.current.handleSearch(event);
             });
 
-            expect(result.current.search.type).toBe("easterEgg");
+            expect(result.current.search).toEqual(easterEggResult);
+            expect(mockSearch).not.toHaveBeenCalled();
+        });
+
+        it("returns empty results when the query is below the 3-char minimum", async () => {
+            const { result } = await renderLoadedSearch();
+
+            const event = { target: { value: "ab" } } as ChangeEvent<HTMLInputElement>;
+            await act(async () => {
+                result.current.handleSearch(event);
+            });
+
+            expect(mockSearch).not.toHaveBeenCalled();
+            expect(result.current.search.type).toBe("search");
+            expect(getResultsFromSearchResult(result.current.search)).toHaveLength(0);
+        });
+
+        it("returns docs mapped from the search index when the query meets the minimum length", async () => {
+            const { result } = await renderLoadedSearch();
+
+            const event = { target: { value: "matrix" } } as ChangeEvent<HTMLInputElement>;
+            await act(async () => {
+                result.current.handleSearch(event);
+            });
+
+            expect(mockSearch).toHaveBeenCalledWith("matrix", { expand: true });
+            expect(mockGetDoc).toHaveBeenCalledWith("post-1");
+            expect(getResultsFromSearchResult(result.current.search)).toEqual([
+                {
+                    title: "Test Post",
+                    slug: "post-1",
+                    description: "desc",
+                    tags: [],
+                    authors: [],
+                },
+            ]);
         });
     });
 
@@ -112,6 +158,23 @@ describe("useSearch", () => {
             await act(async () => {
                 result.current.resetSearch();
             });
+            expect(result.current.search.type).toBe("search");
+            expect(getResultsFromSearchResult(result.current.search)).toHaveLength(0);
+        });
+
+        it("clears previously found results", async () => {
+            const { result } = await renderLoadedSearch();
+
+            const event = { target: { value: "matrix" } } as ChangeEvent<HTMLInputElement>;
+            await act(async () => {
+                result.current.handleSearch(event);
+            });
+            expect(getResultsFromSearchResult(result.current.search)).toHaveLength(1);
+
+            await act(async () => {
+                result.current.resetSearch();
+            });
+
             expect(result.current.search.type).toBe("search");
             expect(getResultsFromSearchResult(result.current.search)).toHaveLength(0);
         });


### PR DESCRIPTION
Add behavioral tests for the shared `use-search.ts` hook, raising it from 75% lines / 66.66% functions to **96.87% lines / 100% functions**.

## Description
Extended the co-located `use-search.test.ts` (the only file changed — no production code), reusing its existing `elasticlunr` + `fetch` mocks. A `renderLoadedSearch()` helper awaits the fetch→`Index.load`→`startTransition` chain via `act(async …)`. Scenarios (all behavioral — the hook itself is never mocked):
- **Min-char gate** — a <3-char query asserts the index search (`mockSearch`) is **not** called and results stay empty.
- **Matching query → mapped docs** — asserts `mockSearch("matrix", { expand: true })`, `getDoc("post-1")`, and the results equal the mapped doc shape (not merely non-empty).
- **Easter-egg short-circuit** — with an easter-egg match, asserts the result is the easter egg **and** the index search is never invoked.
- **resetSearch** — after populating real results, asserts they clear back to `{ type: "search", results: [] }`.

## Motivation and Context
`use-search.ts` is a shared hook in the coverage-gated surface (`design-system/**`) and was under-tested. Closes #429.

## How Has This Been Tested?
Automated (lint, validate-architecture, knip, typecheck, Vitest 878 tests, build, coverage). Global floor unchanged and not lowered. Playwright e2e not required — test-only diff, no rendered/route/flow change.

Closes #429

## Types of changes
- [ ] Bug fix :bug: (non-breaking change which fixes an issue)
- [ ] New feature :sparkles: (non-breaking change which adds functionality)
- [ ] Breaking change :boom: (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project :beers:.
- [X] My change requires a change to the documentation :bulb: and I have updated the documentation accordingly.
- [X] I have read the [CONTRIBUTING](https://github.com/chicio/chicio.github.io/blob/master/CONTRIBUTING.md) document :busts_in_silhouette:.
- [X] I have added tests to cover my changes :tada:.
- [X] All new and existing tests passed :white_check_mark:.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded search hook test coverage for search handling.
  * Added checks for shortcut behavior when a special result is returned.
  * Verified short queries do not trigger search and return no results.
  * Confirmed valid queries fetch and map results correctly.
  * Added coverage to ensure resetting search clears prior results and returns to an empty state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->