### PR TITLE
chore: :robot: featured-image prompt contract + composition reference for writer agent

### DIFF
--- a/.claude/agents/fabrizioduroni-writer-engineer.md
+++ b/.claude/agents/fabrizioduroni-writer-engineer.md
@@ -160,8 +160,30 @@ Follow this workflow precisely when creating a new article. Act autonomously on 
 ### Phase 3: Featured Image
 - If the user provides a featured image, place it in the post's co-located `media/` folder (`<post-dir>/media/` — see Images section)
 - If the user wants a suggestion, search for relevant free stock images or suggest options
-- If no good candidate exists, generate a detailed prompt for an AI image generator (DALL-E, Midjourney, etc.) that matches the blog's aesthetic in terms of color/style, but without the matrix rain in the image.
+- If no good candidate exists, generate a detailed prompt for an AI image generator (DALL-E, Midjourney, etc.) following the Featured Image Prompt Contract below.
 - Once the image is available (provided or generated), ensure it's placed correctly
+
+#### Featured Image Prompt Contract
+
+The visual reference for everything below is `.claude/references/featured-image-reference.svg` — read it before writing the prompt. It exists because the post card renders the image with `object-cover` at fixed heights: the big (launch) card crops it to a ~3.1:1 horizontal band on desktop, while the small (2-in-a-row) card and phones crop it to a ~1.45:1 window. Any detail near the edges of the image gets cut in one of the two layouts.
+
+Every generated prompt MUST specify:
+
+- **Canvas**: 2:1 landscape (e.g. 1200x600 or 2000x1000).
+- **Composition**: ONE clear focal subject, centered, fully contained in the central ~55% of width and ~50% of height. The outer edges (roughly 15% on each side, 17% top and bottom) must be ambient background only — gradients, glow, texture, out-of-focus environment. Nothing that hurts when cropped away.
+- **No text**: no readable words, titles, logos, or UI chrome baked into the image (the card overlays its own title). Matrix-style falling glyph rain IS allowed — it is a great fit for the ambient edge zones and background — as long as the glyphs read as abstract texture (no real words) and the rain stays behind/around the subject, never competing with it.
+- **Color map** — quote these hex values verbatim in the prompt so the generator matches the design system:
+  - `#001100` background (dominant) and `#002200` background light
+  - `#003D10` primary dark (shadows, depth)
+  - `#00CC33` secondary and `#00FF41` primary (main greens of the subject)
+  - `#39FF14` accent (sparingly — glows, highlights, rim light)
+  - `#E8FFE8` highlight text-green (brightest points only)
+  - No hues outside this map: the image must stay dark green-on-black; never introduce blues, purples, oranges, or warm palettes.
+- **Style**: dark, moody, subtle green glow — consistent with the site's Matrix-inspired glassmorphism aesthetic.
+
+Prompt skeleton to adapt per topic:
+
+> A [subject relevant to the article topic], centered composition occupying the middle half of the frame, wide 2:1 landscape format, dark background #001100 fading to #002200, subject rendered in greens #00CC33 and #00FF41 with #39FF14 glow accents and #E8FFE8 highlights, deep shadows in #003D10, faint matrix-style rain of abstract falling glyphs in the background and along the edges, edges otherwise pure ambient dark gradient with no important detail, no readable words, no logos, digital illustration, subtle glow, high contrast, moody.
 
 ### Phase 4: Article Writing
 1. Write the complete MDX article following:

--- a/.claude/references/featured-image-reference.svg
+++ b/.claude/references/featured-image-reference.svg
@@ -1,0 +1,81 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="820" viewBox="0 0 1200 820" font-family="'Courier Prime', 'Courier New', monospace">
+    <title>Featured image composition reference — chicio-blog post cards</title>
+    <desc>
+        Composition and color reference for AI-generated featured images.
+        The post card renders the image with object-cover at fixed heights, so the visible
+        window changes with card size: the big (launch) card shows a ~3.1:1 horizontal band,
+        the small (2-in-a-row) card and phones show a ~1.45:1 vertical window.
+        The subject must sit fully inside the intersection of both windows (the safe zone).
+    </desc>
+
+    <rect width="1200" height="820" fill="#000a00"/>
+
+    <!-- The 2:1 generation canvas -->
+    <g>
+        <rect x="0" y="0" width="1200" height="600" fill="#001100" stroke="#00CC33" stroke-width="2"/>
+
+        <!-- Areas cut by the big-card crop (top and bottom bands) -->
+        <rect x="0" y="0" width="1200" height="106" fill="#ff2a2a" opacity="0.10"/>
+        <rect x="0" y="494" width="1200" height="106" fill="#ff2a2a" opacity="0.10"/>
+        <line x1="0" y1="106" x2="1200" y2="106" stroke="#00FF41" stroke-width="1.5" stroke-dasharray="10 6"/>
+        <line x1="0" y1="494" x2="1200" y2="494" stroke="#00FF41" stroke-width="1.5" stroke-dasharray="10 6"/>
+        <text x="16" y="30" fill="#E8FFE8" font-size="18">CUT on big card (desktop crop is ~3.1:1 — only the middle 65% of height survives)</text>
+        <text x="16" y="586" fill="#E8FFE8" font-size="18">CUT on big card — ambient background only, nothing important here</text>
+
+        <!-- Areas cut by the small-card / phone crop (left and right bands) -->
+        <rect x="0" y="106" width="168" height="388" fill="#ff2a2a" opacity="0.10"/>
+        <rect x="1032" y="106" width="168" height="388" fill="#ff2a2a" opacity="0.10"/>
+        <line x1="168" y1="0" x2="168" y2="600" stroke="#00FF41" stroke-width="1.5" stroke-dasharray="10 6"/>
+        <line x1="1032" y1="0" x2="1032" y2="600" stroke="#00FF41" stroke-width="1.5" stroke-dasharray="10 6"/>
+        <text x="152" y="330" fill="#E8FFE8" font-size="16" transform="rotate(-90 152 330)" text-anchor="middle">CUT on small card (~1.45:1)</text>
+        <text x="1052" y="330" fill="#E8FFE8" font-size="16" transform="rotate(90 1052 330)" text-anchor="middle">CUT on small card (~1.45:1)</text>
+
+        <!-- Safe zone: intersection of both crops -->
+        <rect x="168" y="106" width="864" height="388" fill="#39FF14" opacity="0.06" stroke="#39FF14" stroke-width="2"/>
+        <text x="600" y="132" fill="#39FF14" font-size="18" text-anchor="middle">SAFE ZONE — everything meaningful must fit inside (central 72% x 65%)</text>
+
+        <!-- Ideal subject bounding box -->
+        <rect x="270" y="150" width="660" height="300" fill="none" stroke="#00FF41" stroke-width="3"/>
+        <text x="600" y="290" fill="#00FF41" font-size="26" text-anchor="middle" font-weight="bold">SINGLE CENTERED SUBJECT</text>
+        <text x="600" y="322" fill="#E8FFE8" font-size="18" text-anchor="middle">one clear focal element, fully inside this box (~55% x 50% of frame)</text>
+        <text x="600" y="348" fill="#E8FFE8" font-size="18" text-anchor="middle">no readable words, no logos — matrix glyph rain OK as background</text>
+        <text x="600" y="430" fill="#00CC33" font-size="16" text-anchor="middle">generate at 2:1 — e.g. 1200x600 or 2000x1000</text>
+    </g>
+
+    <!-- Color map -->
+    <g>
+        <text x="16" y="646" fill="#E8FFE8" font-size="20">COLOR MAP — quote these hex values verbatim in the generation prompt</text>
+
+        <rect x="16" y="666" width="120" height="64" fill="#001100" stroke="#00CC33"/>
+        <text x="16" y="754" fill="#E8FFE8" font-size="15">#001100</text>
+        <text x="16" y="774" fill="#00CC33" font-size="13">background</text>
+
+        <rect x="156" y="666" width="120" height="64" fill="#002200" stroke="#00CC33"/>
+        <text x="156" y="754" fill="#E8FFE8" font-size="15">#002200</text>
+        <text x="156" y="774" fill="#00CC33" font-size="13">background light</text>
+
+        <rect x="296" y="666" width="120" height="64" fill="#003D10" stroke="#00CC33"/>
+        <text x="296" y="754" fill="#E8FFE8" font-size="15">#003D10</text>
+        <text x="296" y="774" fill="#00CC33" font-size="13">primary dark</text>
+
+        <rect x="436" y="666" width="120" height="64" fill="#00CC33"/>
+        <text x="436" y="754" fill="#E8FFE8" font-size="15">#00CC33</text>
+        <text x="436" y="774" fill="#00CC33" font-size="13">secondary</text>
+
+        <rect x="576" y="666" width="120" height="64" fill="#00FF41"/>
+        <text x="576" y="754" fill="#E8FFE8" font-size="15">#00FF41</text>
+        <text x="576" y="774" fill="#00CC33" font-size="13">primary</text>
+
+        <rect x="716" y="666" width="120" height="64" fill="#39FF14"/>
+        <text x="716" y="754" fill="#E8FFE8" font-size="15">#39FF14</text>
+        <text x="716" y="774" fill="#00CC33" font-size="13">accent</text>
+
+        <rect x="856" y="666" width="120" height="64" fill="#E8FFE8"/>
+        <text x="856" y="754" fill="#E8FFE8" font-size="15">#E8FFE8</text>
+        <text x="856" y="774" fill="#00CC33" font-size="13">highlight text-green</text>
+
+        <text x="990" y="700" fill="#E8FFE8" font-size="13">dominant: #001100/#002200</text>
+        <text x="990" y="722" fill="#E8FFE8" font-size="13">accents: greens, sparingly</text>
+        <text x="990" y="744" fill="#E8FFE8" font-size="13">no hues outside this map</text>
+    </g>
+</svg>


### PR DESCRIPTION
## What

- Adds a **Featured Image Prompt Contract** to `fabrizioduroni-writer-engineer` (Phase 3), replacing the vague "match the blog's aesthetic" instruction.
- Adds `.claude/references/featured-image-reference.svg` — a visual composition reference the agent reads before writing an image-generation prompt.

## Why

The post card renders the featured image with `object-cover` at fixed heights, so the visible window changes per layout:

| Context | Window | Survives from a 2:1 image |
|---|---|---|
| Big (launch) card, desktop | ~3.1:1 | central 65% of height |
| Small card (2-in-a-row) | ~1.48:1 | central 74% of width |
| Small phones | ~1.44:1 | central ~72% of width |

Any subject near the edges gets cut in one of the two card sizes. The intersection of the crops is a stable safe zone (central ~72% × 65% of a 2:1 canvas), so the fix is a composition contract rather than a card-code change.

## The contract

- 2:1 canvas (1200x600 / 2000x1000)
- one centered subject inside the middle ~55% × 50% of the frame; edges ambient-only
- full design-system color map quoted by hex (`#001100`/`#002200` dominant, greens `#00CC33`/`#00FF41`, `#39FF14` accent glow, `#E8FFE8` highlights, `#003D10` shadows — no foreign hues)
- no readable words/logos; matrix glyph rain allowed as background/edge texture
- ready-to-adapt prompt skeleton

The SVG shows both crop windows, the cut bands, the safe zone, the ideal subject box, and the palette strip — and being SVG, the agent can read its geometry and labels as text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated featured image generation guidelines with clearer composition, canvas, and color requirements.
  * Added a reusable prompt structure to improve consistency across generated images.
  * Clarified restrictions around readable text and interface elements while permitting abstract ambient glyph effects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->