### PR TITLE
feat(ux): :sparkles: align DSA chart visualizers with blog-stats chart style

### DIFF
--- a/.claude/agent-memory/fabrizioduroni-code-reviewer/MEMORY.md
+++ b/.claude/agent-memory/fabrizioduroni-code-reviewer/MEMORY.md
@@ -4,3 +4,4 @@ Compounding review heuristics (recurring violation patterns worth catching faste
 No per-PR facts — those go stale.
 
 - [e2e-launch-timeout-flake.md](e2e-launch-timeout-flake.md) — scattered e2e failures with "browserType.launch Timeout" are parallel-load flakes; re-run failing specs --workers=1 before calling a regression
+- [recharts-legend-text-color.md](recharts-legend-text-color.md) — recharts Legend text color must use labelStyle (or per-item formatter), not wrapperStyle; entry.color overrides inherited color

--- a/.claude/agent-memory/fabrizioduroni-code-reviewer/recharts-legend-text-color.md
+++ b/.claude/agent-memory/fabrizioduroni-code-reviewer/recharts-legend-text-color.md
@@ -1,0 +1,22 @@
+---
+name: recharts-legend-text-color
+description: recharts Legend text color must be set via labelStyle (or a per-item formatter), never wrapperStyle
+metadata:
+  type: feedback
+---
+
+When reviewing a chart that themes its recharts `<Legend>` text color, the correct prop is
+`labelStyle={{ color }}` (or a per-item `formatter` returning a styled span) — NOT `wrapperStyle={{ color }}`.
+
+**Why:** In recharts 3.x `DefaultLegendContent` renders each item text as
+`<span className="recharts-legend-item-text" style={finalLabelStyle}>` where
+`finalLabelStyle.color = labelStyle.color || entry.color`. So an explicit per-series `entry.color`
+(the series stroke/fill) is applied inline to each label span and overrides any inherited color from
+`wrapperStyle`'s outer div. `labelStyle.color`, when set, wins over `entry.color`. `<Legend>` forwards
+`labelStyle` through `LegendContent` to `DefaultLegendContent`, so `<Legend labelStyle={{ color }} />`
+does reach the text spans.
+
+**How to apply:** If a diff themes legend text via `wrapperStyle`, the text will still render in the
+series color, not the theme color — flag it. `labelStyle` is the correct approach and is verified working.
+Related: chart-theme lives in `src/types/configuration/chart-theme.ts` and must never be value-imported by
+`src/components/design-system/**` (design-system may only type-import from types/).

--- a/.claude/agent-memory/fabrizioduroni-implementer/MEMORY.md
+++ b/.claude/agent-memory/fabrizioduroni-implementer/MEMORY.md
@@ -42,6 +42,9 @@
 ## Features (continued 4)
 - [Testing Pyramid](feature_testing_pyramid.md) — Vitest+RTL+Playwright introduced PR #395; vi.hoisted() gotcha, react-dom pin, reactCompilerPreset v6 API, node/jsdom split, mock-per-test discipline
 
+## Features (continued 5)
+- [Chart Theme](feature_chart_theme.md) — shared chartTheme module in types/configuration; fixed-slot palette; recharts Legend labelStyle vs wrapperStyle gotcha
+
 ## Feedback
 - [PWA & State Patterns](feedback_pwa_patterns.md) — useSyncExternalStore for localStorage state, consent-gated UI, banner/error page alignment rules
 - [Worktree git stash hazard](feedback_worktree_git_stash_hazard.md) — never `git stash` inside a pipeline worktree, refs/stash is shared across all worktrees

--- a/.claude/agent-memory/fabrizioduroni-implementer/feature_chart_theme.md
+++ b/.claude/agent-memory/fabrizioduroni-implementer/feature_chart_theme.md
@@ -1,0 +1,42 @@
+---
+name: feature_chart_theme
+description: Shared chart-theme module unifying blog-stats and DSA recharts/SVG visualizer styling
+type: project
+---
+
+`src/types/configuration/chart-theme.ts` (added 2026-07) is the single source of truth for chart styling shared
+by `content/blog/blog-stats/**` and `content/data-structures-and-algorithms/**` — the only legal placement, since
+content-page-isolation forbids the two page folders importing each other, and design-system may only type-import
+from `types/`. Shape (flat, `as const`, constants only, no functions):
+
+```ts
+export const chartTheme = {
+    axis: { tickColor: "#9fbf9f", tickFontSize: 12, lineColor: "#1f5a2e" },
+    cursorFill: "#39FF141a",     // bar-chart Tooltip cursor
+    cursorStroke: "#39FF1466",   // line/scatter-chart Tooltip cursor (pair with strokeWidth: 1 inline)
+    gridStroke: "#1f5a2e",       // CartesianGrid stroke (time-space-tradeoff scatter only; no other chart has a grid)
+    legendTextColor: "#9fbf9f",
+    series: ["#00FF41", "#36c5f0", "#ffb703", "#ff6ec7", "#b18cff", "#ff8c42", "#ff5c5c"],
+} as const;
+```
+
+Palette is fixed-order (never re-sorted); series map to `chartTheme.series[i]` in JSX **declaration order** of the
+`<Line>`/`<Bar>`/`<Scatter>` elements, not by any "hot=worse" semantic remapping — the plan's slot-order rule wins
+even when it inverts a chart's original color intuition (e.g. performance-comparison-chart's Bubble Sort — the
+worst performer — now gets green slot 1 because it's declared first).
+
+**recharts Legend text color gotcha**: `<Legend wrapperStyle={{ color }}>` does NOT reliably theme item text —
+`DefaultLegendContent` always sets an explicit inline `color` on each `<span>` (`labelStyle.color || entry.color`,
+i.e. falls back to the series color when `labelStyle` has no `.color`), which overrides any CSS inherited from the
+wrapper. The only prop that reliably wins is `labelStyle={{ color: chartTheme.legendTextColor }}` passed directly —
+it's a plain object literal (not a function), so it's fully compatible with `react/jsx-no-bind`. Use `labelStyle`,
+not `wrapperStyle`, whenever DSA/blog-stats work needs to theme Legend text independent of series color.
+
+Every one of the 9 DSA recharts components and the 2 SVG visualizers (graph-properties-visualizer,
+tree-types-visualizer) got wrapped in `ChartPanel` (design-system molecule, no title) with axis/tooltip/legend
+themed via `chartTheme`. Existing co-located tests only asserted `.recharts-responsive-container` presence and
+stayed green unchanged; added one extra assertion per file: `container.querySelector("section.glow-container")`
+to lock in the new wrap.
+
+See [[arch_design_system_purity]] for why `chart-theme.ts` had to live in `types/configuration/` rather than a
+design-system barrel constant.

--- a/src/components/content/blog/blog-stats/analytics-section/views-over-time-chart/views-over-time-chart.tsx
+++ b/src/components/content/blog/blog-stats/analytics-section/views-over-time-chart/views-over-time-chart.tsx
@@ -4,14 +4,12 @@ import { FC, ReactNode } from "react";
 import { Legend, Line, LineChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
 import { ChartTooltip } from "@/components/design-system/molecules/chart/chart-tooltip";
 import { formatShortAnalyticsMonth } from "@/lib/blog-stats/format-month";
+import { chartTheme } from "@/types/configuration/chart-theme";
 import type { ViewsPoint } from "@/types/content/analytics-stats";
 
 interface ViewsOverTimeChartProps {
     data: ViewsPoint[];
 }
-
-const AXIS_TICK_COLOR = "#9fbf9f";
-const AXIS_LINE_COLOR = "#1f5a2e";
 
 const formatTooltipMonth = (label: ReactNode): string =>
     typeof label === "string" ? formatShortAnalyticsMonth(label) : String(label ?? "");
@@ -28,20 +26,20 @@ export const ViewsOverTimeChart: FC<ViewsOverTimeChartProps> = ({ data }) => (
                     dataKey="month"
                     tickFormatter={formatShortAnalyticsMonth}
                     minTickGap={28}
-                    tick={{ fill: AXIS_TICK_COLOR, fontSize: 12 }}
+                    tick={{ fill: chartTheme.axis.tickColor, fontSize: chartTheme.axis.tickFontSize }}
                     tickLine={false}
-                    axisLine={{ stroke: AXIS_LINE_COLOR }}
+                    axisLine={{ stroke: chartTheme.axis.lineColor }}
                 />
                 <YAxis
                     allowDecimals={false}
-                    tick={{ fill: AXIS_TICK_COLOR, fontSize: 12 }}
+                    tick={{ fill: chartTheme.axis.tickColor, fontSize: chartTheme.axis.tickFontSize }}
                     tickLine={false}
-                    axisLine={{ stroke: AXIS_LINE_COLOR }}
+                    axisLine={{ stroke: chartTheme.axis.lineColor }}
                 />
                 <Tooltip
                     content={<ChartTooltip labelPrefix="" />}
                     labelFormatter={formatTooltipMonth}
-                    cursor={{ stroke: "#39FF1466", strokeWidth: 1 }}
+                    cursor={{ stroke: chartTheme.cursorStroke, strokeWidth: 1 }}
                 />
                 <Legend />
                 <Line

--- a/src/components/content/blog/blog-stats/authors-chart/authors-chart.tsx
+++ b/src/components/content/blog/blog-stats/authors-chart/authors-chart.tsx
@@ -3,6 +3,7 @@
 import { FC } from "react";
 import { Bar, BarChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
 import { ChartTooltip } from "@/components/design-system/molecules/chart/chart-tooltip";
+import { chartTheme } from "@/types/configuration/chart-theme";
 import type { AuthorCount } from "@/types/content/blog-stats";
 import { LinkedAxisTick } from "../linked-axis-tick";
 
@@ -13,8 +14,6 @@ interface AuthorsChartProps {
 const MIN_CHART_HEIGHT = 300;
 const ROW_HEIGHT = 40;
 const CATEGORY_AXIS_WIDTH = 160;
-const AXIS_TICK_COLOR = "#9fbf9f";
-const AXIS_LINE_COLOR = "#1f5a2e";
 
 export const AuthorsChart: FC<AuthorsChartProps> = ({ data }) => {
     const chartHeight = Math.max(MIN_CHART_HEIGHT, data.length * ROW_HEIGHT);
@@ -37,21 +36,21 @@ export const AuthorsChart: FC<AuthorsChartProps> = ({ data }) => {
                     <XAxis
                         type="number"
                         allowDecimals={false}
-                        tick={{ fill: AXIS_TICK_COLOR, fontSize: 12 }}
+                        tick={{ fill: chartTheme.axis.tickColor, fontSize: chartTheme.axis.tickFontSize }}
                         tickLine={false}
-                        axisLine={{ stroke: AXIS_LINE_COLOR }}
+                        axisLine={{ stroke: chartTheme.axis.lineColor }}
                     />
                     <YAxis
                         dataKey="author"
                         type="category"
                         width={CATEGORY_AXIS_WIDTH}
                         tickLine={false}
-                        axisLine={{ stroke: AXIS_LINE_COLOR }}
+                        axisLine={{ stroke: chartTheme.axis.lineColor }}
                         tick={<LinkedAxisTick hrefByValue={hrefByValue} />}
                     />
                     <Tooltip
                         content={<ChartTooltip labelPrefix="Author: " />}
-                        cursor={{ fill: "#39FF141a" }}
+                        cursor={{ fill: chartTheme.cursorFill }}
                     />
                     <Bar
                         dataKey="count"

--- a/src/components/content/blog/blog-stats/posts-per-year-chart/posts-per-year-chart.tsx
+++ b/src/components/content/blog/blog-stats/posts-per-year-chart/posts-per-year-chart.tsx
@@ -3,14 +3,12 @@
 import { FC } from "react";
 import { Bar, BarChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
 import { ChartTooltip } from "@/components/design-system/molecules/chart/chart-tooltip";
+import { chartTheme } from "@/types/configuration/chart-theme";
 import type { PostsPerYear } from "@/types/content/blog-stats";
 
 interface PostsPerYearChartProps {
     data: PostsPerYear[];
 }
-
-const AXIS_TICK_COLOR = "#9fbf9f";
-const AXIS_LINE_COLOR = "#1f5a2e";
 
 export const PostsPerYearChart: FC<PostsPerYearChartProps> = ({ data }) => (
     <div className="h-100 w-full">
@@ -18,19 +16,19 @@ export const PostsPerYearChart: FC<PostsPerYearChartProps> = ({ data }) => (
             <BarChart data={data}>
                 <XAxis
                     dataKey="year"
-                    tick={{ fill: AXIS_TICK_COLOR, fontSize: 12 }}
+                    tick={{ fill: chartTheme.axis.tickColor, fontSize: chartTheme.axis.tickFontSize }}
                     tickLine={false}
-                    axisLine={{ stroke: AXIS_LINE_COLOR }}
+                    axisLine={{ stroke: chartTheme.axis.lineColor }}
                 />
                 <YAxis
                     allowDecimals={false}
-                    tick={{ fill: AXIS_TICK_COLOR, fontSize: 12 }}
+                    tick={{ fill: chartTheme.axis.tickColor, fontSize: chartTheme.axis.tickFontSize }}
                     tickLine={false}
-                    axisLine={{ stroke: AXIS_LINE_COLOR }}
+                    axisLine={{ stroke: chartTheme.axis.lineColor }}
                 />
                 <Tooltip
                     content={<ChartTooltip labelPrefix="Year: " />}
-                    cursor={{ fill: "#39FF141a" }}
+                    cursor={{ fill: chartTheme.cursorFill }}
                 />
                 <Bar dataKey="count" name="Posts" fill="#00FF41" radius={[6, 6, 0, 0]} />
             </BarChart>

--- a/src/components/content/blog/blog-stats/tag-distribution-chart/tag-distribution-chart.tsx
+++ b/src/components/content/blog/blog-stats/tag-distribution-chart/tag-distribution-chart.tsx
@@ -3,6 +3,7 @@
 import { FC } from "react";
 import { Bar, BarChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
 import { ChartTooltip } from "@/components/design-system/molecules/chart/chart-tooltip";
+import { chartTheme } from "@/types/configuration/chart-theme";
 import type { TagCount } from "@/types/content/blog-stats";
 import { LinkedAxisTick } from "../linked-axis-tick";
 
@@ -13,8 +14,6 @@ interface TagDistributionChartProps {
 const MIN_CHART_HEIGHT = 300;
 const ROW_HEIGHT = 40;
 const CATEGORY_AXIS_WIDTH = 200;
-const AXIS_TICK_COLOR = "#9fbf9f";
-const AXIS_LINE_COLOR = "#1f5a2e";
 
 export const TagDistributionChart: FC<TagDistributionChartProps> = ({ data }) => {
     const chartHeight = Math.max(MIN_CHART_HEIGHT, data.length * ROW_HEIGHT);
@@ -37,21 +36,21 @@ export const TagDistributionChart: FC<TagDistributionChartProps> = ({ data }) =>
                     <XAxis
                         type="number"
                         allowDecimals={false}
-                        tick={{ fill: AXIS_TICK_COLOR, fontSize: 12 }}
+                        tick={{ fill: chartTheme.axis.tickColor, fontSize: chartTheme.axis.tickFontSize }}
                         tickLine={false}
-                        axisLine={{ stroke: AXIS_LINE_COLOR }}
+                        axisLine={{ stroke: chartTheme.axis.lineColor }}
                     />
                     <YAxis
                         dataKey="tag"
                         type="category"
                         width={CATEGORY_AXIS_WIDTH}
                         tickLine={false}
-                        axisLine={{ stroke: AXIS_LINE_COLOR }}
+                        axisLine={{ stroke: chartTheme.axis.lineColor }}
                         tick={<LinkedAxisTick hrefByValue={hrefByValue} />}
                     />
                     <Tooltip
                         content={<ChartTooltip labelPrefix="Tag: " />}
-                        cursor={{ fill: "#39FF141a" }}
+                        cursor={{ fill: chartTheme.cursorFill }}
                     />
                     <Bar
                         dataKey="count"

--- a/src/components/content/data-structures-and-algorithms/amortized-analysis/amortized-analysis.test.tsx
+++ b/src/components/content/data-structures-and-algorithms/amortized-analysis/amortized-analysis.test.tsx
@@ -13,5 +13,10 @@ describe("AmortizedAnalysis", () => {
             const { container } = render(<AmortizedAnalysis />);
             expect(container.querySelector(".recharts-responsive-container")).toBeInTheDocument();
         });
+
+        it("wraps the chart in a ChartPanel", () => {
+            const { container } = render(<AmortizedAnalysis />);
+            expect(container.querySelector("section.glow-container")).toBeInTheDocument();
+        });
     });
 });

--- a/src/components/content/data-structures-and-algorithms/amortized-analysis/amortized-analysis.tsx
+++ b/src/components/content/data-structures-and-algorithms/amortized-analysis/amortized-analysis.tsx
@@ -11,7 +11,9 @@ import {
     XAxis,
     YAxis,
 } from "recharts";
+import { ChartPanel } from "@/components/design-system/molecules/chart/chart-panel";
 import { ChartTooltip } from "@/components/design-system/molecules/chart/chart-tooltip";
+import { chartTheme } from "@/types/configuration/chart-theme";
 import { useAmortizedAnalysisStore } from "./use-amortized-analysis-store";
 
 export const AmortizedAnalysis: FC = () => {
@@ -19,48 +21,62 @@ export const AmortizedAnalysis: FC = () => {
     const { data } = state;
 
     return (
-        <div className="glow-container h-100 w-full p-5">
-            <ResponsiveContainer width={"100%"} height={"100%"} initialDimension={{ width: 320, height: 300 }}>
-                <LineChart data={data}>
-                    <XAxis
-                        dataKey="operation"
-                        height={50}
-                        label={{
-                            value: "Insertion number",
-                            position: "insideBottom",
-                            style: { textAnchor: "middle" },
-                        }}
-                    />
-                    <YAxis
-                        label={{
-                            value: "Operation cost",
-                            angle: -90,
-                            offset: 10,
-                            position: "insideLeft",
-                            style: { textAnchor: "middle" },
-                        }}
-                    />
-                    <Tooltip content={ChartTooltip} />
-                    <ReferenceLine y={1} stroke="#4ade80" strokeDasharray="4 4" />
-                    <Line
-                        type="stepAfter"
-                        dataKey="cost"
-                        stroke="#ef4444"
-                        strokeWidth={2.5}
-                        dot={false}
-                        name="Actual cost"
-                    />
-                    <Line
-                        type="monotone"
-                        dataKey="amortized"
-                        stroke="#3b82f6"
-                        strokeWidth={2.5}
-                        dot={false}
-                        name="Amortized average"
-                    />
-                    <Legend verticalAlign="top" />
-                </LineChart>
-            </ResponsiveContainer>
-        </div>
+        <ChartPanel>
+            <div className="h-100 w-full">
+                <ResponsiveContainer width={"100%"} height={"100%"} initialDimension={{ width: 320, height: 300 }}>
+                    <LineChart data={data}>
+                        <XAxis
+                            dataKey="operation"
+                            height={50}
+                            tick={{ fill: chartTheme.axis.tickColor, fontSize: chartTheme.axis.tickFontSize }}
+                            tickLine={false}
+                            axisLine={{ stroke: chartTheme.axis.lineColor }}
+                            label={{
+                                value: "Insertion number",
+                                position: "insideBottom",
+                                style: { textAnchor: "middle", fill: chartTheme.axis.tickColor },
+                            }}
+                        />
+                        <YAxis
+                            tick={{ fill: chartTheme.axis.tickColor, fontSize: chartTheme.axis.tickFontSize }}
+                            tickLine={false}
+                            axisLine={{ stroke: chartTheme.axis.lineColor }}
+                            label={{
+                                value: "Operation cost",
+                                angle: -90,
+                                offset: 10,
+                                position: "insideLeft",
+                                style: { textAnchor: "middle", fill: chartTheme.axis.tickColor },
+                            }}
+                        />
+                        <Tooltip
+                            content={<ChartTooltip />}
+                            cursor={{ stroke: chartTheme.cursorStroke, strokeWidth: 1 }}
+                        />
+                        <ReferenceLine y={1} stroke="#4ade80" strokeDasharray="4 4" />
+                        <Line
+                            type="stepAfter"
+                            dataKey="cost"
+                            stroke={chartTheme.series[0]}
+                            strokeWidth={2.5}
+                            dot={false}
+                            name="Actual cost"
+                        />
+                        <Line
+                            type="monotone"
+                            dataKey="amortized"
+                            stroke={chartTheme.series[1]}
+                            strokeWidth={2.5}
+                            dot={false}
+                            name="Amortized average"
+                        />
+                        <Legend
+                            verticalAlign="top"
+                            labelStyle={{ color: chartTheme.legendTextColor }}
+                        />
+                    </LineChart>
+                </ResponsiveContainer>
+            </div>
+        </ChartPanel>
     );
 };

--- a/src/components/content/data-structures-and-algorithms/complexity-growth-visualizer/complexity-growth-visualizer.test.tsx
+++ b/src/components/content/data-structures-and-algorithms/complexity-growth-visualizer/complexity-growth-visualizer.test.tsx
@@ -13,5 +13,10 @@ describe("ComplexityGrowthVisualizer", () => {
             const { container } = render(<ComplexityGrowthVisualizer />);
             expect(container.querySelector(".recharts-responsive-container")).toBeInTheDocument();
         });
+
+        it("wraps the chart in a ChartPanel", () => {
+            const { container } = render(<ComplexityGrowthVisualizer />);
+            expect(container.querySelector("section.glow-container")).toBeInTheDocument();
+        });
     });
 });

--- a/src/components/content/data-structures-and-algorithms/complexity-growth-visualizer/complexity-growth-visualizer.tsx
+++ b/src/components/content/data-structures-and-algorithms/complexity-growth-visualizer/complexity-growth-visualizer.tsx
@@ -10,7 +10,9 @@ import {
     Legend,
     ResponsiveContainer,
 } from "recharts";
+import { ChartPanel } from "@/components/design-system/molecules/chart/chart-panel";
 import { ChartTooltip } from "@/components/design-system/molecules/chart/chart-tooltip";
+import { chartTheme } from "@/types/configuration/chart-theme";
 
 type ComplexityData = {
     n: number;
@@ -48,36 +50,93 @@ const generateData = (maxN = 8): ComplexityData[] => {
 };
 
 export const ComplexityGrowthVisualizer: React.FC = () => (
-    <div className="glow-container h-[400px] w-full p-5">
-        <ResponsiveContainer width={"100%"} height={"100%"} initialDimension={{ width: 320, height: 300 }}>
-            <LineChart data={generateData(8)}>
-                <XAxis
-                    dataKey="n"
-                    height={50}
-                    label={{
-                        value: "Input size (n)",
-                        position: "insideBottom",
-                    }}
-                />
-                <YAxis
-                    label={{
-                        value: "Operations (arbitrary units)",
-                        angle: -90,
-                        offset: 10,
-                        position: "insideLeft",
-                        style: { textAnchor: "middle" },
-                    }}
-                />
-                <Tooltip content={ChartTooltip} />
-                <Legend verticalAlign="top" />
-                <Line type="monotone" dataKey="o1" stroke="#4ade80" dot={false} name="O(1)" />
-                <Line type="monotone" dataKey="ologn" stroke="#60a5fa" dot={false} name="O(log n)" />
-                <Line type="monotone" dataKey="on" stroke="#facc15" dot={false} name="O(n)" />
-                <Line type="monotone" dataKey="onlogn" stroke="#fb923c" dot={false} name="O(n log n)" />
-                <Line type="monotone" dataKey="on2" stroke="#ef4444" dot={false} name="O(n²)" />
-                <Line type="monotone" dataKey="o2n" stroke="#c084fc" dot={false} name="O(2ⁿ)" />
-                <Line type="monotone" dataKey="onfact" stroke="#ec4899" dot={false} name="O(n!)" />
-            </LineChart>
-        </ResponsiveContainer>
-    </div>
+    <ChartPanel>
+        <div className="h-[400px] w-full">
+            <ResponsiveContainer width={"100%"} height={"100%"} initialDimension={{ width: 320, height: 300 }}>
+                <LineChart data={generateData(8)}>
+                    <XAxis
+                        dataKey="n"
+                        height={50}
+                        tick={{ fill: chartTheme.axis.tickColor, fontSize: chartTheme.axis.tickFontSize }}
+                        tickLine={false}
+                        axisLine={{ stroke: chartTheme.axis.lineColor }}
+                        label={{
+                            value: "Input size (n)",
+                            position: "insideBottom",
+                            style: { fill: chartTheme.axis.tickColor },
+                        }}
+                    />
+                    <YAxis
+                        tick={{ fill: chartTheme.axis.tickColor, fontSize: chartTheme.axis.tickFontSize }}
+                        tickLine={false}
+                        axisLine={{ stroke: chartTheme.axis.lineColor }}
+                        label={{
+                            value: "Operations (arbitrary units)",
+                            angle: -90,
+                            offset: 10,
+                            position: "insideLeft",
+                            style: { textAnchor: "middle", fill: chartTheme.axis.tickColor },
+                        }}
+                    />
+                    <Tooltip
+                        content={<ChartTooltip />}
+                        cursor={{ stroke: chartTheme.cursorStroke, strokeWidth: 1 }}
+                    />
+                    <Legend
+                        verticalAlign="top"
+                        labelStyle={{ color: chartTheme.legendTextColor }}
+                    />
+                    <Line
+                        type="monotone"
+                        dataKey="o1"
+                        stroke={chartTheme.series[0]}
+                        dot={false}
+                        name="O(1)"
+                    />
+                    <Line
+                        type="monotone"
+                        dataKey="ologn"
+                        stroke={chartTheme.series[1]}
+                        dot={false}
+                        name="O(log n)"
+                    />
+                    <Line
+                        type="monotone"
+                        dataKey="on"
+                        stroke={chartTheme.series[2]}
+                        dot={false}
+                        name="O(n)"
+                    />
+                    <Line
+                        type="monotone"
+                        dataKey="onlogn"
+                        stroke={chartTheme.series[3]}
+                        dot={false}
+                        name="O(n log n)"
+                    />
+                    <Line
+                        type="monotone"
+                        dataKey="on2"
+                        stroke={chartTheme.series[4]}
+                        dot={false}
+                        name="O(n²)"
+                    />
+                    <Line
+                        type="monotone"
+                        dataKey="o2n"
+                        stroke={chartTheme.series[5]}
+                        dot={false}
+                        name="O(2ⁿ)"
+                    />
+                    <Line
+                        type="monotone"
+                        dataKey="onfact"
+                        stroke={chartTheme.series[6]}
+                        dot={false}
+                        name="O(n!)"
+                    />
+                </LineChart>
+            </ResponsiveContainer>
+        </div>
+    </ChartPanel>
 );

--- a/src/components/content/data-structures-and-algorithms/divide-and-conquer-tree-visualizer/divide-and-conquer-tree-visualizer.test.tsx
+++ b/src/components/content/data-structures-and-algorithms/divide-and-conquer-tree-visualizer/divide-and-conquer-tree-visualizer.test.tsx
@@ -13,5 +13,10 @@ describe("DivideAndConquerTreeVisualizer", () => {
             const { container } = render(<DivideAndConquerTreeVisualizer />);
             expect(container.querySelector(".recharts-responsive-container")).toBeInTheDocument();
         });
+
+        it("wraps the chart in a ChartPanel", () => {
+            const { container } = render(<DivideAndConquerTreeVisualizer />);
+            expect(container.querySelector("section.glow-container")).toBeInTheDocument();
+        });
     });
 });

--- a/src/components/content/data-structures-and-algorithms/divide-and-conquer-tree-visualizer/divide-and-conquer-tree-visualizer.tsx
+++ b/src/components/content/data-structures-and-algorithms/divide-and-conquer-tree-visualizer/divide-and-conquer-tree-visualizer.tsx
@@ -5,9 +5,13 @@ import {
     ResponsiveContainer,
     LineChart,
     Line,
+    Tooltip,
     XAxis,
     YAxis,
 } from "recharts";
+import { ChartPanel } from "@/components/design-system/molecules/chart/chart-panel";
+import { ChartTooltip } from "@/components/design-system/molecules/chart/chart-tooltip";
+import { chartTheme } from "@/types/configuration/chart-theme";
 
 type Node = {
     level: number;
@@ -29,31 +33,46 @@ export const DivideAndConquerTreeVisualizer: FC = () => {
     const data = generateData(6);
 
     return (
-        <div className="glow-container h-[350px] w-full p-5">
-            <ResponsiveContainer width={"100%"} height={"100%"} initialDimension={{ width: 320, height: 300 }}>
-                <LineChart data={data}>
-                    <XAxis
-                        dataKey="level"
-                        label={{
-                            value: "Recursion depth",
-                            position: "insideBottom",
-                        }}
-                    />
-                    <YAxis
-                        label={{
-                            value: "Number of subproblems",
-                            angle: -90,
-                            position: "insideLeft",
-                        }}
-                    />
-                    <Line
-                        type="monotone"
-                        dataKey="nodes"
-                        dot={false}
-                        name="Subproblems"
-                    />
-                </LineChart>
-            </ResponsiveContainer>
-        </div>
+        <ChartPanel>
+            <div className="h-[350px] w-full">
+                <ResponsiveContainer width={"100%"} height={"100%"} initialDimension={{ width: 320, height: 300 }}>
+                    <LineChart data={data}>
+                        <XAxis
+                            dataKey="level"
+                            tick={{ fill: chartTheme.axis.tickColor, fontSize: chartTheme.axis.tickFontSize }}
+                            tickLine={false}
+                            axisLine={{ stroke: chartTheme.axis.lineColor }}
+                            label={{
+                                value: "Recursion depth",
+                                position: "insideBottom",
+                                style: { fill: chartTheme.axis.tickColor },
+                            }}
+                        />
+                        <YAxis
+                            tick={{ fill: chartTheme.axis.tickColor, fontSize: chartTheme.axis.tickFontSize }}
+                            tickLine={false}
+                            axisLine={{ stroke: chartTheme.axis.lineColor }}
+                            label={{
+                                value: "Number of subproblems",
+                                angle: -90,
+                                position: "insideLeft",
+                                style: { fill: chartTheme.axis.tickColor },
+                            }}
+                        />
+                        <Tooltip
+                            content={<ChartTooltip />}
+                            cursor={{ stroke: chartTheme.cursorStroke, strokeWidth: 1 }}
+                        />
+                        <Line
+                            type="monotone"
+                            dataKey="nodes"
+                            stroke={chartTheme.series[0]}
+                            dot={false}
+                            name="Subproblems"
+                        />
+                    </LineChart>
+                </ResponsiveContainer>
+            </div>
+        </ChartPanel>
     );
 };

--- a/src/components/content/data-structures-and-algorithms/frequency-map-chart/frequency-map-chart.test.tsx
+++ b/src/components/content/data-structures-and-algorithms/frequency-map-chart/frequency-map-chart.test.tsx
@@ -13,5 +13,10 @@ describe("FrequencyMapChart", () => {
             const { container } = render(<FrequencyMapChart />);
             expect(container.querySelector(".recharts-responsive-container")).toBeInTheDocument();
         });
+
+        it("wraps the chart in a ChartPanel", () => {
+            const { container } = render(<FrequencyMapChart />);
+            expect(container.querySelector("section.glow-container")).toBeInTheDocument();
+        });
     });
 });

--- a/src/components/content/data-structures-and-algorithms/frequency-map-chart/frequency-map-chart.tsx
+++ b/src/components/content/data-structures-and-algorithms/frequency-map-chart/frequency-map-chart.tsx
@@ -2,6 +2,9 @@
 
 import React from "react";
 import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer } from "recharts";
+import { ChartPanel } from "@/components/design-system/molecules/chart/chart-panel";
+import { ChartTooltip } from "@/components/design-system/molecules/chart/chart-tooltip";
+import { chartTheme } from "@/types/configuration/chart-theme";
 
 const data = [
     { char: "a", count: 3 },
@@ -11,15 +14,34 @@ const data = [
 
 export const FrequencyMapChart: React.FC = () => {
     return (
-        <div className="h-64 w-full p-4 bg-purple-50 rounded-xl">
-            <ResponsiveContainer width={"100%"} height={"100%"} initialDimension={{ width: 320, height: 300 }}>
-                <BarChart data={data}>
-                    <XAxis dataKey="char" />
-                    <YAxis />
-                    <Tooltip />
-                    <Bar dataKey="count" fill="#7c3aed" />
-                </BarChart>
-            </ResponsiveContainer>
-        </div>
+        <ChartPanel>
+            <div className="h-64 w-full">
+                <ResponsiveContainer width={"100%"} height={"100%"} initialDimension={{ width: 320, height: 300 }}>
+                    <BarChart data={data}>
+                        <XAxis
+                            dataKey="char"
+                            tick={{ fill: chartTheme.axis.tickColor, fontSize: chartTheme.axis.tickFontSize }}
+                            tickLine={false}
+                            axisLine={{ stroke: chartTheme.axis.lineColor }}
+                        />
+                        <YAxis
+                            tick={{ fill: chartTheme.axis.tickColor, fontSize: chartTheme.axis.tickFontSize }}
+                            tickLine={false}
+                            axisLine={{ stroke: chartTheme.axis.lineColor }}
+                        />
+                        <Tooltip
+                            content={<ChartTooltip labelPrefix="Char: " />}
+                            cursor={{ fill: chartTheme.cursorFill }}
+                        />
+                        <Bar
+                            dataKey="count"
+                            name="Count"
+                            fill={chartTheme.series[0]}
+                            radius={[6, 6, 0, 0]}
+                        />
+                    </BarChart>
+                </ResponsiveContainer>
+            </div>
+        </ChartPanel>
     );
 };

--- a/src/components/content/data-structures-and-algorithms/graph-properties-visualizer/graph-properties-visualizer.test.tsx
+++ b/src/components/content/data-structures-and-algorithms/graph-properties-visualizer/graph-properties-visualizer.test.tsx
@@ -30,6 +30,11 @@ describe("GraphPropertiesVisualizer", () => {
             const descriptionEl = document.querySelector("p.text-center");
             expect(descriptionEl?.textContent).toMatch(/Undirected/);
         });
+
+        it("wraps the visualizer in a ChartPanel", () => {
+            const { container } = render(<GraphPropertiesVisualizer />);
+            expect(container.querySelector("section.glow-container")).toBeInTheDocument();
+        });
     });
 
     describe("navigation", () => {

--- a/src/components/content/data-structures-and-algorithms/graph-properties-visualizer/graph-properties-visualizer.tsx
+++ b/src/components/content/data-structures-and-algorithms/graph-properties-visualizer/graph-properties-visualizer.tsx
@@ -5,6 +5,7 @@ import {
     RedPillButton,
     BluePillButton,
 } from "@/components/design-system/molecules/buttons/pills-buttons";
+import { ChartPanel } from "@/components/design-system/molecules/chart/chart-panel";
 import { useGraphPropertiesVisualizerStore } from "./use-graph-properties-visualizer-store";
 
 interface GraphNode {
@@ -231,55 +232,57 @@ export const GraphPropertiesVisualizer: FC = () => {
     const example = graphExamples[selectedIndex];
 
     return (
-        <div className="w-full">
-            <div className="mb-4 flex flex-wrap items-center justify-center gap-2">
-                {graphExamples.map((ex, i) => (
-                    <button
-                        key={ex.label}
-                        onClick={selectIndex(i)}
-                        className={`rounded-lg border px-3 py-1 text-sm font-mono transition-colors ${
-                            i === selectedIndex
-                                ? "border-accent bg-primary-dark text-accent"
-                                : "border-gray-600 bg-transparent text-gray-400 hover:border-accent hover:text-accent"
-                        }`}
+        <ChartPanel>
+            <div className="w-full">
+                <div className="mb-4 flex flex-wrap items-center justify-center gap-2">
+                    {graphExamples.map((ex, i) => (
+                        <button
+                            key={ex.label}
+                            onClick={selectIndex(i)}
+                            className={`rounded-lg border px-3 py-1 text-sm font-mono transition-colors ${
+                                i === selectedIndex
+                                    ? "border-accent bg-primary-dark text-accent"
+                                    : "border-gray-600 bg-transparent text-gray-400 hover:border-accent hover:text-accent"
+                            }`}
+                        >
+                            {ex.label}
+                        </button>
+                    ))}
+                </div>
+
+                <div className="flex justify-center">
+                    <svg
+                        viewBox="0 0 360 180"
+                        className="w-full max-w-md"
+                        aria-label={`Graph example: ${example.label}`}
                     >
-                        {ex.label}
-                    </button>
-                ))}
-            </div>
+                        {example.edges.map((edge, i) => (
+                            <EdgeLine
+                                key={`${edge.from}-${edge.to}`}
+                                edge={edge}
+                                nodes={example.nodes}
+                                directed={example.directed}
+                                weighted={example.weighted}
+                                index={i}
+                            />
+                        ))}
+                        {example.nodes.map((node) => (
+                            <NodeCircle key={node.id} node={node} />
+                        ))}
+                    </svg>
+                </div>
 
-            <div className="flex justify-center">
-                <svg
-                    viewBox="0 0 360 180"
-                    className="w-full max-w-md"
-                    aria-label={`Graph example: ${example.label}`}
-                >
-                    {example.edges.map((edge, i) => (
-                        <EdgeLine
-                            key={`${edge.from}-${edge.to}`}
-                            edge={edge}
-                            nodes={example.nodes}
-                            directed={example.directed}
-                            weighted={example.weighted}
-                            index={i}
-                        />
-                    ))}
-                    {example.nodes.map((node) => (
-                        <NodeCircle key={node.id} node={node} />
-                    ))}
-                </svg>
-            </div>
+                <p className="mt-3 text-center text-sm text-gray-300">
+                    <span className="font-bold text-accent">{example.label}</span>
+                    {" — "}
+                    {example.description}
+                </p>
 
-            <p className="mt-3 text-center text-sm text-gray-300">
-                <span className="font-bold text-accent">{example.label}</span>
-                {" — "}
-                {example.description}
-            </p>
-
-            <div className="mt-4 flex justify-center gap-3">
-                <BluePillButton onClick={goToPrevious}>Previous</BluePillButton>
-                <RedPillButton onClick={goToNext}>Next</RedPillButton>
+                <div className="mt-4 flex justify-center gap-3">
+                    <BluePillButton onClick={goToPrevious}>Previous</BluePillButton>
+                    <RedPillButton onClick={goToNext}>Next</RedPillButton>
+                </div>
             </div>
-        </div>
+        </ChartPanel>
     );
 };

--- a/src/components/content/data-structures-and-algorithms/performance-comparison-chart/performance-comparison-chart.test.tsx
+++ b/src/components/content/data-structures-and-algorithms/performance-comparison-chart/performance-comparison-chart.test.tsx
@@ -13,5 +13,10 @@ describe("PerformanceComparisonChart", () => {
             const { container } = render(<PerformanceComparisonChart />);
             expect(container.querySelector(".recharts-responsive-container")).toBeInTheDocument();
         });
+
+        it("wraps the chart in a ChartPanel", () => {
+            const { container } = render(<PerformanceComparisonChart />);
+            expect(container.querySelector("section.glow-container")).toBeInTheDocument();
+        });
     });
 });

--- a/src/components/content/data-structures-and-algorithms/performance-comparison-chart/performance-comparison-chart.tsx
+++ b/src/components/content/data-structures-and-algorithms/performance-comparison-chart/performance-comparison-chart.tsx
@@ -10,7 +10,9 @@ import {
     ResponsiveContainer,
     Legend,
 } from "recharts";
+import { ChartPanel } from "@/components/design-system/molecules/chart/chart-panel";
 import { ChartTooltip } from "@/components/design-system/molecules/chart/chart-tooltip";
+import { chartTheme } from "@/types/configuration/chart-theme";
 
 const data = [
     { n: 10, bubble: 0.01, merge: 0.002, quick: 0.0015 },
@@ -20,31 +22,66 @@ const data = [
 ];
 
 export const PerformanceComparisonChart: FC = () => (
-    <div className="glow-container h-100 w-full p-5 mb-6">
-        <ResponsiveContainer width={"100%"} height={"100%"} initialDimension={{ width: 320, height: 300 }}>
-            <LineChart data={data}>
-                <XAxis
-                    dataKey="n"
-                    label={{
-                        value: "Input size (n)",
-                        position: "insideBottom",
-                    }}
-                />
-                <YAxis
-                    label={{
-                        value: "Execution time (ms)",
-                        angle: -90,
-                        offset: 0,
-                        position: "insideLeft",
-                        style: { textAnchor: "middle" },
-                    }}
-                />
-                <Tooltip content={ChartTooltip} />
-                <Line type="monotone" dataKey="bubble" strokeWidth={3} stroke="#ef4444" name="Bubble Sort" />
-                <Line type="monotone" dataKey="merge" strokeWidth={7} stroke="#3b82f6" name="Merge Sort" />
-                <Line type="monotone" dataKey="quick" strokeWidth={3} stroke="#22c55e" name="Quick Sort" />
-                <Legend verticalAlign="top" height={40} style={{ marginTop: 40 }} />
-            </LineChart>
-        </ResponsiveContainer>
-    </div>
+    <ChartPanel>
+        <div className="h-100 w-full">
+            <ResponsiveContainer width={"100%"} height={"100%"} initialDimension={{ width: 320, height: 300 }}>
+                <LineChart data={data}>
+                    <XAxis
+                        dataKey="n"
+                        tick={{ fill: chartTheme.axis.tickColor, fontSize: chartTheme.axis.tickFontSize }}
+                        tickLine={false}
+                        axisLine={{ stroke: chartTheme.axis.lineColor }}
+                        label={{
+                            value: "Input size (n)",
+                            position: "insideBottom",
+                            style: { fill: chartTheme.axis.tickColor },
+                        }}
+                    />
+                    <YAxis
+                        tick={{ fill: chartTheme.axis.tickColor, fontSize: chartTheme.axis.tickFontSize }}
+                        tickLine={false}
+                        axisLine={{ stroke: chartTheme.axis.lineColor }}
+                        label={{
+                            value: "Execution time (ms)",
+                            angle: -90,
+                            offset: 0,
+                            position: "insideLeft",
+                            style: { textAnchor: "middle", fill: chartTheme.axis.tickColor },
+                        }}
+                    />
+                    <Tooltip
+                        content={<ChartTooltip />}
+                        cursor={{ stroke: chartTheme.cursorStroke, strokeWidth: 1 }}
+                    />
+                    <Line
+                        type="monotone"
+                        dataKey="bubble"
+                        strokeWidth={3}
+                        stroke={chartTheme.series[0]}
+                        name="Bubble Sort"
+                    />
+                    <Line
+                        type="monotone"
+                        dataKey="merge"
+                        strokeWidth={3}
+                        stroke={chartTheme.series[1]}
+                        name="Merge Sort"
+                    />
+                    <Line
+                        type="monotone"
+                        dataKey="quick"
+                        strokeWidth={3}
+                        stroke={chartTheme.series[2]}
+                        name="Quick Sort"
+                    />
+                    <Legend
+                        verticalAlign="top"
+                        height={40}
+                        style={{ marginTop: 40 }}
+                        labelStyle={{ color: chartTheme.legendTextColor }}
+                    />
+                </LineChart>
+            </ResponsiveContainer>
+        </div>
+    </ChartPanel>
 );

--- a/src/components/content/data-structures-and-algorithms/recurrence-tree/recurrence-tree.test.tsx
+++ b/src/components/content/data-structures-and-algorithms/recurrence-tree/recurrence-tree.test.tsx
@@ -13,5 +13,10 @@ describe("RecurrenceTree", () => {
             const { container } = render(<RecurrenceTree />);
             expect(container.querySelector(".recharts-responsive-container")).toBeInTheDocument();
         });
+
+        it("wraps the chart in a ChartPanel", () => {
+            const { container } = render(<RecurrenceTree />);
+            expect(container.querySelector("section.glow-container")).toBeInTheDocument();
+        });
     });
 });

--- a/src/components/content/data-structures-and-algorithms/recurrence-tree/recurrence-tree.tsx
+++ b/src/components/content/data-structures-and-algorithms/recurrence-tree/recurrence-tree.tsx
@@ -10,7 +10,9 @@ import {
     XAxis,
     YAxis,
 } from "recharts";
+import { ChartPanel } from "@/components/design-system/molecules/chart/chart-panel";
 import { ChartTooltip } from "@/components/design-system/molecules/chart/chart-tooltip";
+import { chartTheme } from "@/types/configuration/chart-theme";
 
 const levels = () => {
     const n = 64;
@@ -34,32 +36,55 @@ const levels = () => {
 };
 
 export const RecurrenceTree: FC = () => (
-    <div className="glow-container h-[400px] w-full p-5">
-        <ResponsiveContainer width={"100%"} height={"100%"} initialDimension={{ width: 320, height: 300 }}>
-            <LineChart data={levels()}>
-                <XAxis
-                    dataKey="level"
-                    height={50}
-                    label={{
-                        value: "Recursion Level",
-                        position: "insideBottom",
-                        style: { textAnchor: "middle" },
-                    }}
-                />
-                <YAxis
-                    label={{
-                        value: "Work",
-                        angle: -90,
-                        offset: 10,
-                        position: "insideLeft",
-                        style: { textAnchor: "middle" },
-                    }}
-                />
-                <Tooltip content={ChartTooltip} />
-                <Legend />
-                <Line type="monotone" dataKey="Work per Call" stroke="#8b5cf6" strokeWidth={2} dot={false} />
-                <Line type="monotone" dataKey="Total Work at Level" stroke="#06b6d4" strokeWidth={2} dot={false} />
-            </LineChart>
-        </ResponsiveContainer>
-    </div>
+    <ChartPanel>
+        <div className="h-[400px] w-full">
+            <ResponsiveContainer width={"100%"} height={"100%"} initialDimension={{ width: 320, height: 300 }}>
+                <LineChart data={levels()}>
+                    <XAxis
+                        dataKey="level"
+                        height={50}
+                        tick={{ fill: chartTheme.axis.tickColor, fontSize: chartTheme.axis.tickFontSize }}
+                        tickLine={false}
+                        axisLine={{ stroke: chartTheme.axis.lineColor }}
+                        label={{
+                            value: "Recursion Level",
+                            position: "insideBottom",
+                            style: { textAnchor: "middle", fill: chartTheme.axis.tickColor },
+                        }}
+                    />
+                    <YAxis
+                        tick={{ fill: chartTheme.axis.tickColor, fontSize: chartTheme.axis.tickFontSize }}
+                        tickLine={false}
+                        axisLine={{ stroke: chartTheme.axis.lineColor }}
+                        label={{
+                            value: "Work",
+                            angle: -90,
+                            offset: 10,
+                            position: "insideLeft",
+                            style: { textAnchor: "middle", fill: chartTheme.axis.tickColor },
+                        }}
+                    />
+                    <Tooltip
+                        content={<ChartTooltip />}
+                        cursor={{ stroke: chartTheme.cursorStroke, strokeWidth: 1 }}
+                    />
+                    <Legend labelStyle={{ color: chartTheme.legendTextColor }} />
+                    <Line
+                        type="monotone"
+                        dataKey="Work per Call"
+                        stroke={chartTheme.series[0]}
+                        strokeWidth={2}
+                        dot={false}
+                    />
+                    <Line
+                        type="monotone"
+                        dataKey="Total Work at Level"
+                        stroke={chartTheme.series[1]}
+                        strokeWidth={2}
+                        dot={false}
+                    />
+                </LineChart>
+            </ResponsiveContainer>
+        </div>
+    </ChartPanel>
 );

--- a/src/components/content/data-structures-and-algorithms/space-complexity-visualizer/space-complexity-visualizer.test.tsx
+++ b/src/components/content/data-structures-and-algorithms/space-complexity-visualizer/space-complexity-visualizer.test.tsx
@@ -13,5 +13,10 @@ describe("SpaceComplexityVisualizer", () => {
             const { container } = render(<SpaceComplexityVisualizer />);
             expect(container.querySelector(".recharts-responsive-container")).toBeInTheDocument();
         });
+
+        it("wraps the chart in a ChartPanel", () => {
+            const { container } = render(<SpaceComplexityVisualizer />);
+            expect(container.querySelector("section.glow-container")).toBeInTheDocument();
+        });
     });
 });

--- a/src/components/content/data-structures-and-algorithms/space-complexity-visualizer/space-complexity-visualizer.tsx
+++ b/src/components/content/data-structures-and-algorithms/space-complexity-visualizer/space-complexity-visualizer.tsx
@@ -10,7 +10,9 @@ import {
     XAxis,
     YAxis,
 } from "recharts";
+import { ChartPanel } from "@/components/design-system/molecules/chart/chart-panel";
 import { ChartTooltip } from "@/components/design-system/molecules/chart/chart-tooltip";
+import { chartTheme } from "@/types/configuration/chart-theme";
 
 const data = () => {
     const points = [];
@@ -27,41 +29,76 @@ const data = () => {
 };
 
 export const SpaceComplexityVisualizer: FC = () => (
-    <div className="glow-container h-[400px] w-full p-5">
-        <ResponsiveContainer width={"100%"} height={"100%"} initialDimension={{ width: 320, height: 300 }}>
-            <LineChart data={data()}>
-                <XAxis
-                    dataKey="n"
-                    height={50}
-                    label={{
-                        value: "Input size (n)",
-                        position: "insideBottom",
-                        style: { textAnchor: "middle" },
-                    }}
-                />
-                <YAxis
-                    label={{
-                        value: "Relative Memory Usage",
-                        angle: -90,
-                        offset: 10,
-                        position: "insideLeft",
-                        style: { textAnchor: "middle" },
-                    }}
-                />
-                <Tooltip content={ChartTooltip} />
-                <Legend verticalAlign="top" />
-                <Line type="monotone" dataKey="constant" stroke="#7c3aed" strokeWidth={2.5} dot={false} name="O(1)" />
-                <Line type="monotone" dataKey="logn" stroke="#0ea5e9" strokeWidth={2.5} dot={false} name="O(log n)" />
-                <Line type="monotone" dataKey="linear" stroke="#10b981" strokeWidth={2.5} dot={false} name="O(n)" />
-                <Line
-                    type="monotone"
-                    dataKey="nlogn"
-                    stroke="#f97316"
-                    strokeWidth={2.5}
-                    dot={false}
-                    name="O(n log n)"
-                />
-            </LineChart>
-        </ResponsiveContainer>
-    </div>
+    <ChartPanel>
+        <div className="h-[400px] w-full">
+            <ResponsiveContainer width={"100%"} height={"100%"} initialDimension={{ width: 320, height: 300 }}>
+                <LineChart data={data()}>
+                    <XAxis
+                        dataKey="n"
+                        height={50}
+                        tick={{ fill: chartTheme.axis.tickColor, fontSize: chartTheme.axis.tickFontSize }}
+                        tickLine={false}
+                        axisLine={{ stroke: chartTheme.axis.lineColor }}
+                        label={{
+                            value: "Input size (n)",
+                            position: "insideBottom",
+                            style: { textAnchor: "middle", fill: chartTheme.axis.tickColor },
+                        }}
+                    />
+                    <YAxis
+                        tick={{ fill: chartTheme.axis.tickColor, fontSize: chartTheme.axis.tickFontSize }}
+                        tickLine={false}
+                        axisLine={{ stroke: chartTheme.axis.lineColor }}
+                        label={{
+                            value: "Relative Memory Usage",
+                            angle: -90,
+                            offset: 10,
+                            position: "insideLeft",
+                            style: { textAnchor: "middle", fill: chartTheme.axis.tickColor },
+                        }}
+                    />
+                    <Tooltip
+                        content={<ChartTooltip />}
+                        cursor={{ stroke: chartTheme.cursorStroke, strokeWidth: 1 }}
+                    />
+                    <Legend
+                        verticalAlign="top"
+                        labelStyle={{ color: chartTheme.legendTextColor }}
+                    />
+                    <Line
+                        type="monotone"
+                        dataKey="constant"
+                        stroke={chartTheme.series[0]}
+                        strokeWidth={2.5}
+                        dot={false}
+                        name="O(1)"
+                    />
+                    <Line
+                        type="monotone"
+                        dataKey="logn"
+                        stroke={chartTheme.series[1]}
+                        strokeWidth={2.5}
+                        dot={false}
+                        name="O(log n)"
+                    />
+                    <Line
+                        type="monotone"
+                        dataKey="linear"
+                        stroke={chartTheme.series[2]}
+                        strokeWidth={2.5}
+                        dot={false}
+                        name="O(n)"
+                    />
+                    <Line
+                        type="monotone"
+                        dataKey="nlogn"
+                        stroke={chartTheme.series[3]}
+                        strokeWidth={2.5}
+                        dot={false}
+                        name="O(n log n)"
+                    />
+                </LineChart>
+            </ResponsiveContainer>
+        </div>
+    </ChartPanel>
 );

--- a/src/components/content/data-structures-and-algorithms/stack-frame-comparison-chart/stack-frame-comparison-chart.test.tsx
+++ b/src/components/content/data-structures-and-algorithms/stack-frame-comparison-chart/stack-frame-comparison-chart.test.tsx
@@ -13,5 +13,10 @@ describe("StackFrameComparisonChart", () => {
             const { container } = render(<StackFrameComparisonChart />);
             expect(container.querySelector(".recharts-responsive-container")).toBeInTheDocument();
         });
+
+        it("wraps the chart in a ChartPanel", () => {
+            const { container } = render(<StackFrameComparisonChart />);
+            expect(container.querySelector("section.glow-container")).toBeInTheDocument();
+        });
     });
 });

--- a/src/components/content/data-structures-and-algorithms/stack-frame-comparison-chart/stack-frame-comparison-chart.tsx
+++ b/src/components/content/data-structures-and-algorithms/stack-frame-comparison-chart/stack-frame-comparison-chart.tsx
@@ -10,7 +10,9 @@ import {
     XAxis,
     YAxis,
 } from "recharts";
+import { ChartPanel } from "@/components/design-system/molecules/chart/chart-panel";
 import { ChartTooltip } from "@/components/design-system/molecules/chart/chart-tooltip";
+import { chartTheme } from "@/types/configuration/chart-theme";
 
 type StackFrameData = {
     step: number;
@@ -34,48 +36,62 @@ export const StackFrameComparisonChart: FC = () => {
     const data = generateData(10);
 
     return (
-        <div className="glow-container h-[400px] w-full p-5">
-            <ResponsiveContainer width={"100%"} height={"100%"} initialDimension={{ width: 320, height: 300 }}>
-                <LineChart data={data}>
-                    <XAxis
-                        dataKey="step"
-                        height={50}
-                        label={{
-                            value: "Recursion Depth (n)",
-                            position: "insideBottom",
-                            style: { textAnchor: "middle" },
-                        }}
-                    />
-                    <YAxis
-                        label={{
-                            value: "Stack Frames Used",
-                            angle: -90,
-                            offset: 10,
-                            position: "insideLeft",
-                            style: { textAnchor: "middle" },
-                        }}
-                        domain={[0, "dataMax + 1"]}
-                    />
-                    <Tooltip content={ChartTooltip} />
-                    <Legend verticalAlign="top" />
-                    <Line
-                        type="monotone"
-                        dataKey="normal"
-                        stroke="#ef4444"
-                        dot={false}
-                        strokeWidth={2}
-                        name="Normal Recursion"
-                    />
-                    <Line
-                        type="monotone"
-                        dataKey="tail"
-                        stroke="#4ade80"
-                        dot={false}
-                        strokeWidth={2}
-                        name="Tail Recursion"
-                    />
-                </LineChart>
-            </ResponsiveContainer>
-        </div>
+        <ChartPanel>
+            <div className="h-[400px] w-full">
+                <ResponsiveContainer width={"100%"} height={"100%"} initialDimension={{ width: 320, height: 300 }}>
+                    <LineChart data={data}>
+                        <XAxis
+                            dataKey="step"
+                            height={50}
+                            tick={{ fill: chartTheme.axis.tickColor, fontSize: chartTheme.axis.tickFontSize }}
+                            tickLine={false}
+                            axisLine={{ stroke: chartTheme.axis.lineColor }}
+                            label={{
+                                value: "Recursion Depth (n)",
+                                position: "insideBottom",
+                                style: { textAnchor: "middle", fill: chartTheme.axis.tickColor },
+                            }}
+                        />
+                        <YAxis
+                            tick={{ fill: chartTheme.axis.tickColor, fontSize: chartTheme.axis.tickFontSize }}
+                            tickLine={false}
+                            axisLine={{ stroke: chartTheme.axis.lineColor }}
+                            label={{
+                                value: "Stack Frames Used",
+                                angle: -90,
+                                offset: 10,
+                                position: "insideLeft",
+                                style: { textAnchor: "middle", fill: chartTheme.axis.tickColor },
+                            }}
+                            domain={[0, "dataMax + 1"]}
+                        />
+                        <Tooltip
+                            content={<ChartTooltip />}
+                            cursor={{ stroke: chartTheme.cursorStroke, strokeWidth: 1 }}
+                        />
+                        <Legend
+                            verticalAlign="top"
+                            labelStyle={{ color: chartTheme.legendTextColor }}
+                        />
+                        <Line
+                            type="monotone"
+                            dataKey="normal"
+                            stroke={chartTheme.series[0]}
+                            dot={false}
+                            strokeWidth={2}
+                            name="Normal Recursion"
+                        />
+                        <Line
+                            type="monotone"
+                            dataKey="tail"
+                            stroke={chartTheme.series[1]}
+                            dot={false}
+                            strokeWidth={2}
+                            name="Tail Recursion"
+                        />
+                    </LineChart>
+                </ResponsiveContainer>
+            </div>
+        </ChartPanel>
     );
 };

--- a/src/components/content/data-structures-and-algorithms/time-space-tradeoff/time-space-tradeoff.test.tsx
+++ b/src/components/content/data-structures-and-algorithms/time-space-tradeoff/time-space-tradeoff.test.tsx
@@ -13,5 +13,10 @@ describe("TimeVsSpaceTradeoffVisualizer", () => {
             const { container } = render(<TimeVsSpaceTradeoffVisualizer />);
             expect(container.querySelector(".recharts-responsive-container")).toBeInTheDocument();
         });
+
+        it("wraps the chart in a ChartPanel", () => {
+            const { container } = render(<TimeVsSpaceTradeoffVisualizer />);
+            expect(container.querySelector("section.glow-container")).toBeInTheDocument();
+        });
     });
 });

--- a/src/components/content/data-structures-and-algorithms/time-space-tradeoff/time-space-tradeoff.tsx
+++ b/src/components/content/data-structures-and-algorithms/time-space-tradeoff/time-space-tradeoff.tsx
@@ -14,7 +14,9 @@ import {
     ZAxis,
     type LabelProps,
 } from "recharts";
+import { ChartPanel } from "@/components/design-system/molecules/chart/chart-panel";
 import { ChartTooltip } from "@/components/design-system/molecules/chart/chart-tooltip";
+import { chartTheme } from "@/types/configuration/chart-theme";
 
 const data = [
     { time: 1, space: 1, name: "O(1)" },
@@ -32,7 +34,7 @@ const renderLabel = ({ x, y, value }: LabelProps) => {
             x={x}
             y={y - 10}
             textAnchor="middle"
-            fill="#fff"
+            fill={chartTheme.axis.tickColor}
             fontSize={14}
             style={{ whiteSpace: "pre" }}
             dominantBaseline="central"
@@ -43,39 +45,58 @@ const renderLabel = ({ x, y, value }: LabelProps) => {
 };
 
 export const TimeVsSpaceTradeoffVisualizer: FC = () => (
-    <div className="bg-general-background glow-container my-4 h-80 w-full shadow-sm">
-        <ResponsiveContainer width={"100%"} height={"100%"} initialDimension={{ width: 320, height: 300 }}>
-            <ScatterChart margin={{ top: 40, right: 40, bottom: 40, left: 40 }}>
-                <CartesianGrid strokeDasharray="3 3" />
-                <XAxis
-                    type="number"
-                    dataKey="time"
-                    name="Time Complexity"
-                    label={{
-                        value: "Time",
-                        position: "insideBottomRight",
-                    }}
-                    domain={[0, 11]}
-                />
-                <YAxis
-                    type="number"
-                    dataKey="space"
-                    name="Space Complexity"
-                    label={{
-                        value: "Space",
-                        position: "insideLeft",
-                        angle: -90,
-                        style: { textAnchor: "middle" },
-                    }}
-                    domain={[0, 11]}
-                />
-                <ZAxis range={[80, 120]} />
-                <Tooltip cursor={{ strokeDasharray: "3 3" }} content={ChartTooltip} />
-                <Legend wrapperStyle={{ color: "var(--color-accent)" }} />
-                <Scatter data={data} fill="#00FF41" name="Complexity Class">
-                    <LabelList dataKey="name" content={renderLabel} />
-                </Scatter>
-            </ScatterChart>
-        </ResponsiveContainer>
-    </div>
+    <ChartPanel>
+        <div className="h-80 w-full">
+            <ResponsiveContainer width={"100%"} height={"100%"} initialDimension={{ width: 320, height: 300 }}>
+                <ScatterChart margin={{ top: 40, right: 40, bottom: 40, left: 40 }}>
+                    <CartesianGrid
+                        strokeDasharray="3 3"
+                        stroke={chartTheme.gridStroke}
+                    />
+                    <XAxis
+                        type="number"
+                        dataKey="time"
+                        name="Time Complexity"
+                        tick={{ fill: chartTheme.axis.tickColor, fontSize: chartTheme.axis.tickFontSize }}
+                        tickLine={false}
+                        axisLine={{ stroke: chartTheme.axis.lineColor }}
+                        label={{
+                            value: "Time",
+                            position: "insideBottomRight",
+                            style: { fill: chartTheme.axis.tickColor },
+                        }}
+                        domain={[0, 11]}
+                    />
+                    <YAxis
+                        type="number"
+                        dataKey="space"
+                        name="Space Complexity"
+                        tick={{ fill: chartTheme.axis.tickColor, fontSize: chartTheme.axis.tickFontSize }}
+                        tickLine={false}
+                        axisLine={{ stroke: chartTheme.axis.lineColor }}
+                        label={{
+                            value: "Space",
+                            position: "insideLeft",
+                            angle: -90,
+                            style: { textAnchor: "middle", fill: chartTheme.axis.tickColor },
+                        }}
+                        domain={[0, 11]}
+                    />
+                    <ZAxis range={[80, 120]} />
+                    <Tooltip
+                        cursor={{ stroke: chartTheme.cursorStroke, strokeWidth: 1 }}
+                        content={<ChartTooltip />}
+                    />
+                    <Legend labelStyle={{ color: chartTheme.legendTextColor }} />
+                    <Scatter
+                        data={data}
+                        fill={chartTheme.series[0]}
+                        name="Complexity Class"
+                    >
+                        <LabelList dataKey="name" content={renderLabel} />
+                    </Scatter>
+                </ScatterChart>
+            </ResponsiveContainer>
+        </div>
+    </ChartPanel>
 );

--- a/src/components/content/data-structures-and-algorithms/tree-types-visualizer/tree-types-visualizer.test.tsx
+++ b/src/components/content/data-structures-and-algorithms/tree-types-visualizer/tree-types-visualizer.test.tsx
@@ -29,6 +29,11 @@ describe("TreeTypesVisualizer", () => {
             const descriptionEl = document.querySelector("p.text-center");
             expect(descriptionEl?.textContent).toMatch(/Full Binary Tree/);
         });
+
+        it("wraps the visualizer in a ChartPanel", () => {
+            const { container } = render(<TreeTypesVisualizer />);
+            expect(container.querySelector("section.glow-container")).toBeInTheDocument();
+        });
     });
 
     describe("navigation", () => {

--- a/src/components/content/data-structures-and-algorithms/tree-types-visualizer/tree-types-visualizer.tsx
+++ b/src/components/content/data-structures-and-algorithms/tree-types-visualizer/tree-types-visualizer.tsx
@@ -5,6 +5,7 @@ import {
     RedPillButton,
     BluePillButton,
 } from "@/components/design-system/molecules/buttons/pills-buttons";
+import { ChartPanel } from "@/components/design-system/molecules/chart/chart-panel";
 import { useTreeTypesVisualizerStore } from "./use-tree-types-visualizer-store";
 
 interface TreeNodeData {
@@ -216,48 +217,54 @@ export const TreeTypesVisualizer: FC = () => {
     const example = treeExamples[selectedIndex];
 
     return (
-        <div className="w-full">
-            <div className="mb-4 flex flex-wrap items-center justify-center gap-2">
-                {treeExamples.map((ex, i) => (
-                    <button
-                        key={ex.label}
-                        onClick={selectIndex(i)}
-                        className={`rounded-lg border px-3 py-1 text-sm font-mono transition-colors ${
-                            i === selectedIndex
-                                ? "border-accent bg-primary-dark text-accent"
-                                : "border-gray-600 bg-transparent text-gray-400 hover:border-accent hover:text-accent"
-                        }`}
+        <ChartPanel>
+            <div className="w-full">
+                <div className="mb-4 flex flex-wrap items-center justify-center gap-2">
+                    {treeExamples.map((ex, i) => (
+                        <button
+                            key={ex.label}
+                            onClick={selectIndex(i)}
+                            className={`rounded-lg border px-3 py-1 text-sm font-mono transition-colors ${
+                                i === selectedIndex
+                                    ? "border-accent bg-primary-dark text-accent"
+                                    : "border-gray-600 bg-transparent text-gray-400 hover:border-accent hover:text-accent"
+                            }`}
+                        >
+                            {ex.label}
+                        </button>
+                    ))}
+                </div>
+
+                <div className="flex justify-center">
+                    <svg
+                        viewBox="0 0 360 200"
+                        className="w-full max-w-md"
+                        aria-label={`Tree example: ${example.label}`}
                     >
-                        {ex.label}
-                    </button>
-                ))}
-            </div>
+                        {example.edges.map((edge) => (
+                            <TreeEdgeLine
+                                key={`${edge.from}-${edge.to}`}
+                                edge={edge}
+                                nodes={example.nodes}
+                            />
+                        ))}
+                        {example.nodes.map((node) => (
+                            <TreeNodeCircle key={node.id} node={node} />
+                        ))}
+                    </svg>
+                </div>
 
-            <div className="flex justify-center">
-                <svg viewBox="0 0 360 200" className="w-full max-w-md" aria-label={`Tree example: ${example.label}`}>
-                    {example.edges.map((edge) => (
-                        <TreeEdgeLine
-                            key={`${edge.from}-${edge.to}`}
-                            edge={edge}
-                            nodes={example.nodes}
-                        />
-                    ))}
-                    {example.nodes.map((node) => (
-                        <TreeNodeCircle key={node.id} node={node} />
-                    ))}
-                </svg>
-            </div>
+                <p className="mt-3 text-center text-sm text-gray-300">
+                    <span className="font-bold text-accent">{example.label}</span>
+                    {" — "}
+                    {example.description}
+                </p>
 
-            <p className="mt-3 text-center text-sm text-gray-300">
-                <span className="font-bold text-accent">{example.label}</span>
-                {" — "}
-                {example.description}
-            </p>
-
-            <div className="mt-4 flex justify-center gap-3">
-                <BluePillButton onClick={goToPrevious}>Previous</BluePillButton>
-                <RedPillButton onClick={goToNext}>Next</RedPillButton>
+                <div className="mt-4 flex justify-center gap-3">
+                    <BluePillButton onClick={goToPrevious}>Previous</BluePillButton>
+                    <RedPillButton onClick={goToNext}>Next</RedPillButton>
+                </div>
             </div>
-        </div>
+        </ChartPanel>
     );
 };

--- a/src/content/data-structures-and-algorithms/topic/string/content.mdx
+++ b/src/content/data-structures-and-algorithms/topic/string/content.mdx
@@ -98,6 +98,10 @@ function buildFrequencyMap(s: string): Record<string, number> {
 }
 ```
 
+Running `buildFrequencyMap` on a small string produces a count per character, as shown below.
+
+<FrequencyMapChart />
+
 This algorithm runs in $O(n)$ time and uses $O(1)$ auxiliary space, assuming a fixed-size alphabet (e.g., ASCII).
 For Unicode strings, space complexity becomes $O(k)$, where $k$ is the number of unique characters.
 

--- a/src/types/configuration/chart-theme.ts
+++ b/src/types/configuration/chart-theme.ts
@@ -1,0 +1,12 @@
+export const chartTheme = {
+    axis: {
+        tickColor: "#9fbf9f",
+        tickFontSize: 12,
+        lineColor: "#1f5a2e",
+    },
+    cursorFill: "#39FF141a",
+    cursorStroke: "#39FF1466",
+    gridStroke: "#1f5a2e",
+    legendTextColor: "#9fbf9f",
+    series: ["#00FF41", "#36c5f0", "#ffb703", "#ff6ec7", "#b18cff", "#ff8c42", "#ff5c5c"],
+} as const;


### PR DESCRIPTION
Align all DSA chart/graph visualizers with the blog-stats chart style: same ChartPanel background, themed axes, shared tooltip, and a single validated Matrix-anchored series palette.

## Description
- New `src/types/configuration/chart-theme.ts` — single source of truth for chart axis colors (`#9fbf9f` ticks, `#1f5a2e` lines), tooltip cursor fill/stroke, legend text color, and a fixed-order 7-slot categorical palette anchored on `#00FF41` (validated for CVD separation and ≥3:1 contrast on `#001100`, adjacent- and all-pairs).
- 4 blog-stats charts deduped onto the theme module (pixel-identical output).
- 9 DSA recharts visualizers (complexity-growth, performance-comparison, amortized-analysis, time-space-tradeoff, space-complexity, frequency-map, stack-frame-comparison, divide-and-conquer-tree, recurrence-tree) wrapped in the `ChartPanel` design-system molecule with themed axes, `ChartTooltip` everywhere, themed legend text, and palette slot colors; the off-theme purple box on frequency-map-chart is gone and the stray `CartesianGrid` is restyled to the axis-line green.
- 2 SVG visualizers (graph-properties, tree-types) get the panel background; internals untouched.
- `FrequencyMapChart` was imported but never rendered (pre-existing dead code) — now rendered in the string topic's Frequency Counting section.

## Motivation and Context
The DSA visualizers had drifted: bare wrappers, unstyled recharts default axes (grey on near-black), Tailwind multi-hue series colors breaking the Matrix theme, and one light-purple panel. This aligns every chart on the site into one visual family with a colorblind-checked palette.

## How Has This Been Tested?
Automated (lint, validate-architecture, knip, typecheck, Vitest 1008 tests, build, Playwright e2e 58/58) + two-round independent code review + agent-browser live QA on the complexity/graph/tree/string topic pages and a /blog/stats regression check (themed tooltip, axes, panels, and palette verified in-browser).

## Types of changes
- [ ] Bug fix :bug: (non-breaking change which fixes an issue)
- [X] New feature :sparkles: (non-breaking change which adds functionality)
- [ ] Breaking change :boom: (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project :beers:.
- [X] My change requires a change to the documentation :bulb: and I have updated the documentation accordingly.
- [X] I have read the [CONTRIBUTING](https://github.com/chicio/chicio.github.io/blob/master/CONTRIBUTING.md) document :busts_in_silhouette:.
- [X] I have added tests to cover my changes :tada:.
- [X] All new and existing tests passed :white_check_mark:.

🤖 Generated with [Claude Code](https://claude.com/claude-code)