### PR TITLE
feat(ux): :sparkles: add comment system to blog posts (giscus + archived Disqus comments)

### DIFF
--- a/e2e/blog.spec.ts
+++ b/e2e/blog.spec.ts
@@ -50,6 +50,25 @@ test.describe("Blog section", () => {
             await expect(page).not.toHaveURL(startUrl, { timeout: 10000 });
             await expect(page).toHaveURL(/\/blog\/post\//);
         });
+
+        test("renders the giscus live comments widget", async ({ page }) => {
+            await page.goto("/blog/post/2026/06/01/app-js-conf-2026");
+            await expect(page.locator("giscus-widget")).toBeAttached();
+        });
+    });
+
+    test.describe("comments", () => {
+        test("a legacy post shows the archived comments section above the giscus widget", async ({ page }) => {
+            await page.goto("/blog/post/2020/06/02/dynamic-imports-webpack-chunks");
+            await expect(page.getByRole("heading", { name: "Archived comments", level: 2 })).toBeVisible();
+            await expect(page.getByText("Iftikhar Ali", { exact: true })).toBeVisible();
+            await expect(page.locator("giscus-widget")).toBeAttached();
+        });
+
+        test("a non-legacy post shows no archived comments section", async ({ page }) => {
+            await page.goto("/blog/post/2026/06/01/app-js-conf-2026");
+            await expect(page.getByRole("heading", { name: "Archived comments", level: 2 })).toHaveCount(0);
+        });
     });
 
     test.describe("archive page", () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@ai-sdk/groq": "^3.0.42",
         "@ai-sdk/react": "^3.0.176",
+        "@giscus/react": "^3.1.0",
         "@google-analytics/data": "^6.1.0",
         "@mdx-js/loader": "^3.1.1",
         "@mdx-js/react": "^3.1.1",
@@ -1452,6 +1453,18 @@
         }
       }
     },
+    "node_modules/@giscus/react": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@giscus/react/-/react-3.1.0.tgz",
+      "integrity": "sha512-0TCO2TvL43+oOdyVVGHDItwxD1UMKP2ZYpT6gXmhFOqfAJtZxTzJ9hkn34iAF/b6YzyJ4Um89QIt9z/ajmAEeg==",
+      "dependencies": {
+        "giscus": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16 || ^17 || ^18 || ^19",
+        "react-dom": "^16 || ^17 || ^18 || ^19"
+      }
+    },
     "node_modules/@google-analytics/data": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/@google-analytics/data/-/data-6.1.0.tgz",
@@ -2516,6 +2529,21 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/js-sdsl"
+      }
+    },
+    "node_modules/@lit-labs/ssr-dom-shim": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.6.0.tgz",
+      "integrity": "sha512-VHb0ALPMTlgKjM6yIxxoQNnpKyUKLD04VzeQdsiXkMqkvYlAHxq9glGLmgbb889/1GsohSOAjvQYoiBppXFqrQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@lit/reactive-element": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.1.2.tgz",
+      "integrity": "sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0"
       }
     },
     "node_modules/@mdx-js/loader": {
@@ -6508,7 +6536,6 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/unist": {
@@ -12038,6 +12065,15 @@
         "giget": "dist/cli.mjs"
       }
     },
+    "node_modules/giscus": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/giscus/-/giscus-1.6.0.tgz",
+      "integrity": "sha512-Zrsi8r4t1LVW950keaWcsURuZUQwUaMKjvJgTCY125vkW6OiEBkatE7ScJDbpqKHdZwb///7FVC21SE3iFK3PQ==",
+      "license": "MIT",
+      "dependencies": {
+        "lit": "^3.2.1"
+      }
+    },
     "node_modules/git-up": {
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/git-up/-/git-up-8.1.1.tgz",
@@ -14521,6 +14557,37 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lit": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.3.tgz",
+      "integrity": "sha512-fycuvZg/hkpozL00lm1pEJH5nN/lr9ZXd6mJI2HSN4+Bzc+LDNdEApJ6HFbPkdFNHLvOplIIuJvxkS4XUxqirw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit/reactive-element": "^2.1.0",
+        "lit-element": "^4.2.0",
+        "lit-html": "^3.3.0"
+      }
+    },
+    "node_modules/lit-element": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.2.2.tgz",
+      "integrity": "sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0",
+        "@lit/reactive-element": "^2.1.0",
+        "lit-html": "^3.3.0"
+      }
+    },
+    "node_modules/lit-html": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.3.tgz",
+      "integrity": "sha512-el8M6jK2o3RXBnrSHX3ZKrsN8zEV63pSExTO1wYJz7QndGYZ8353e2a5PPX+qHe2aGayfnchQmkAojaWAREOIA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
       }
     },
     "node_modules/locate-path": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "@ai-sdk/groq": "^3.0.42",
     "@ai-sdk/react": "^3.0.176",
+    "@giscus/react": "^3.1.0",
     "@google-analytics/data": "^6.1.0",
     "@mdx-js/loader": "^3.1.1",
     "@mdx-js/react": "^3.1.1",

--- a/public/giscus-matrix.css
+++ b/public/giscus-matrix.css
@@ -1,0 +1,123 @@
+/*!
+ * Matrix-themed custom giscus theme for fabrizioduroni.it (chicio-blog).
+ *
+ * Structured after giscus's own built-in "dark" / "transparent_dark" themes
+ * (https://github.com/giscus/giscus/tree/main/public/themes, MIT License,
+ * Copyright (c) 2018 GitHub Inc.), with every custom property re-mapped to
+ * this site's Matrix green-on-black palette (see src/app/css/globals.css)
+ * and font stack (Open Sans / Courier Prime).
+ *
+ * giscus loads this file as a full replacement stylesheet (via the `theme`
+ * prop set to this file's absolute production URL), so it must define the
+ * complete custom-property set giscus's base styles rely on, not just a
+ * partial override.
+ */
+main {
+    --color-prettylights-syntax-comment: #6b9e6b;
+    --color-prettylights-syntax-constant: #39ff14;
+    --color-prettylights-syntax-entity: #00ff41;
+    --color-prettylights-syntax-storage-modifier-import: #e8ffe8;
+    --color-prettylights-syntax-entity-tag: #39ff14;
+    --color-prettylights-syntax-keyword: #00ff41;
+    --color-prettylights-syntax-string: #9fbf9f;
+    --color-prettylights-syntax-variable: #39ff14;
+    --color-prettylights-syntax-brackethighlighter-unmatched: #ff2a2a;
+    --color-prettylights-syntax-invalid-illegal-text: #e8ffe8;
+    --color-prettylights-syntax-invalid-illegal-bg: #5a0000;
+    --color-prettylights-syntax-carriage-return-text: #e8ffe8;
+    --color-prettylights-syntax-carriage-return-bg: #ff2a2a;
+    --color-prettylights-syntax-string-regexp: #39ff14;
+    --color-prettylights-syntax-markup-list: #39ff14;
+    --color-prettylights-syntax-markup-heading: #00ff41;
+    --color-prettylights-syntax-markup-italic: #e8ffe8;
+    --color-prettylights-syntax-markup-bold: #e8ffe8;
+    --color-prettylights-syntax-markup-deleted-text: #ffdcd7;
+    --color-prettylights-syntax-markup-deleted-bg: #5a0000;
+    --color-prettylights-syntax-markup-inserted-text: #d6ffd6;
+    --color-prettylights-syntax-markup-inserted-bg: #003d10;
+    --color-prettylights-syntax-markup-changed-text: #ffdfb6;
+    --color-prettylights-syntax-markup-changed-bg: #5a3d02;
+    --color-prettylights-syntax-markup-ignored-text: #e8ffe8;
+    --color-prettylights-syntax-markup-ignored-bg: #003d10;
+    --color-prettylights-syntax-meta-diff-range: #00ff41;
+    --color-prettylights-syntax-brackethighlighter-angle: #6b9e6b;
+    --color-prettylights-syntax-sublimelinter-gutter-mark: #00cc33;
+    --color-prettylights-syntax-constant-other-reference-link: #9fbf9f;
+
+    --color-btn-text: #e8ffe8;
+    --color-btn-bg: #002200;
+    --color-btn-border: #39ff1466;
+    --color-btn-shadow: 0 0 #0000;
+    --color-btn-inset-shadow: 0 0 #0000;
+    --color-btn-hover-bg: #003d10;
+    --color-btn-hover-border: #39ff14;
+    --color-btn-active-bg: #001100;
+    --color-btn-active-border: #00ff41;
+    --color-btn-selected-bg: #002200;
+    --color-btn-primary-text: #000000;
+    --color-btn-primary-bg: #00ff41;
+    --color-btn-primary-border: #39ff14;
+    --color-btn-primary-shadow: 0 0 #0000;
+    --color-btn-primary-inset-shadow: 0 0 #0000;
+    --color-btn-primary-hover-bg: #39ff14;
+    --color-btn-primary-hover-border: #00ff41;
+    --color-btn-primary-selected-bg: #00cc33;
+    --color-btn-primary-selected-shadow: 0 0 #0000;
+    --color-btn-primary-disabled-text: #e8ffe880;
+    --color-btn-primary-disabled-bg: #00ff4166;
+    --color-btn-primary-disabled-border: #39ff1440;
+    --color-action-list-item-default-hover-bg: #39ff1426;
+    --color-segmented-control-bg: #39ff141a;
+    --color-segmented-control-button-bg: #001100;
+    --color-segmented-control-button-selected-border: #39ff1466;
+
+    --color-fg-default: #e8ffe8;
+    --color-fg-muted: #00cc33;
+    --color-fg-subtle: #00cc3399;
+    --color-canvas-default: #001100;
+    --color-canvas-overlay: #002200;
+    --color-canvas-inset: #000b00;
+    --color-canvas-subtle: #002200;
+    --color-border-default: #39ff1466;
+    --color-border-muted: #39ff1426;
+    --color-neutral-muted: #39ff141a;
+    --color-accent-fg: #39ff14;
+    --color-accent-emphasis: #00ff41;
+    --color-accent-muted: #39ff1466;
+    --color-accent-subtle: #39ff141a;
+    --color-success-fg: #00ff41;
+    --color-attention-fg: #ffb703;
+    --color-attention-muted: #ffb70366;
+    --color-attention-subtle: #ffb70326;
+    --color-danger-fg: #ff2a2a;
+    --color-danger-muted: #ff2a2a66;
+    --color-danger-subtle: #ff2a2a1a;
+    --color-primer-shadow-inset: 0 0 #0000;
+    --color-scale-gray-7: #002200;
+    --color-scale-blue-8: #003d10;
+
+    /*! Extensions from @primer/css/alerts/flash.scss */
+    --color-social-reaction-bg-hover: var(--color-scale-gray-7);
+    --color-social-reaction-bg-reacted-hover: var(--color-scale-blue-8);
+
+    background-color: transparent;
+    color: #e8ffe8;
+    font-family: "Open Sans", Arial, sans-serif;
+}
+
+main pre,
+main code {
+    font-family: "Courier Prime", "Courier New", monospace;
+}
+
+main a {
+    color: #39ff14;
+}
+
+main .pagination-loader-container {
+    background-image: none;
+}
+
+main .gsc-loading-image {
+    background-image: none;
+}

--- a/src/components/content/blog/archived-comments/archived-comments.test.tsx
+++ b/src/components/content/blog/archived-comments/archived-comments.test.tsx
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { ArchivedComments } from "./index";
+
+describe("ArchivedComments", () => {
+    describe("slug with archived comments", () => {
+        it("renders the archived comments heading", () => {
+            render(<ArchivedComments slug="dynamic-imports-webpack-chunks" />);
+            expect(screen.getByRole("heading", { name: /archived comments/i })).toBeInTheDocument();
+        });
+
+        it("renders the comment author and body", () => {
+            render(<ArchivedComments slug="dynamic-imports-webpack-chunks" />);
+            expect(screen.getByText("Iftikhar Ali")).toBeInTheDocument();
+            expect(screen.getByText(/webpack dynamic import/i)).toBeInTheDocument();
+        });
+
+        it("renders a formatted original comment date", () => {
+            render(<ArchivedComments slug="dynamic-imports-webpack-chunks" />);
+            expect(screen.getByText("Nov 29, 2021")).toBeInTheDocument();
+        });
+
+        it("renders nested replies indented under their parent comment", () => {
+            render(<ArchivedComments slug="dynamic-imports-webpack-chunks" />);
+            expect(screen.getByText("Fabrizio")).toBeInTheDocument();
+            expect(screen.getByText(/web pack dynamic imports are still relevant/i)).toBeInTheDocument();
+        });
+    });
+
+    describe("slug without archived comments", () => {
+        it("renders nothing", () => {
+            const { container } = render(<ArchivedComments slug="a-slug-with-no-archived-comments" />);
+            expect(container).toBeEmptyDOMElement();
+        });
+    });
+});

--- a/src/components/content/blog/archived-comments/archived-comments.tsx
+++ b/src/components/content/blog/archived-comments/archived-comments.tsx
@@ -1,0 +1,65 @@
+import { FC } from "react";
+import { SectionHeading } from "@/components/design-system/molecules/typography/section-heading";
+import { Chip } from "@/components/design-system/atoms/chip";
+import { getArchivedCommentsBy } from "@/lib/content/comments/comments";
+import { ArchivedCommentReply } from "@/types/content/comment";
+
+export interface ArchivedCommentsProps {
+    slug: string;
+}
+
+const formatArchivedDate = (date: string): string =>
+    new Intl.DateTimeFormat("en-US", { day: "2-digit", month: "short", year: "numeric" }).format(new Date(date));
+
+const ArchivedCommentEntry: FC<{ comment: ArchivedCommentReply }> = ({ comment }) => (
+    <>
+        <div className="mb-2 flex flex-wrap items-center gap-2">
+            <Chip>{comment.author}</Chip>
+            <time
+                className="text-secondary-text text-sm"
+                dateTime={comment.date}
+            >
+                {formatArchivedDate(comment.date)}
+            </time>
+        </div>
+        {/* Safe here: message is static, repo-committed, offline pre-sanitized HTML (see src/content/blog/archived-comments.json) */}
+        <div dangerouslySetInnerHTML={{ __html: comment.message }} />
+    </>
+);
+
+export const ArchivedComments: FC<ArchivedCommentsProps> = ({ slug }) => {
+    const comments = getArchivedCommentsBy(slug);
+
+    if (comments.length === 0) {
+        return null;
+    }
+
+    return (
+        <div className="my-12">
+            <SectionHeading
+                title="Archived comments"
+                description="Comments from the old comment system on this blog, preserved here as a read-only archive."
+            />
+            <div className="flex flex-col gap-6">
+                {comments.map((comment) => (
+                    <div
+                        className="glow-container p-4"
+                        key={`${comment.author}-${comment.date}`}
+                    >
+                        <ArchivedCommentEntry comment={comment} />
+                        {comment.replies.length > 0 && (
+                            <div className="border-accent-alpha-25 mt-4 flex flex-col gap-4 border-l-2 pl-4">
+                                {comment.replies.map((reply) => (
+                                    <ArchivedCommentEntry
+                                        comment={reply}
+                                        key={`${reply.author}-${reply.date}`}
+                                    />
+                                ))}
+                            </div>
+                        )}
+                    </div>
+                ))}
+            </div>
+        </div>
+    );
+};

--- a/src/components/content/blog/archived-comments/index.ts
+++ b/src/components/content/blog/archived-comments/index.ts
@@ -1,0 +1,2 @@
+export { ArchivedComments } from "./archived-comments";
+export type { ArchivedCommentsProps } from "./archived-comments";

--- a/src/components/content/blog/blog-comments/blog-comments.test.tsx
+++ b/src/components/content/blog/blog-comments/blog-comments.test.tsx
@@ -1,0 +1,24 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { BlogComments } from "./index";
+
+vi.mock("@giscus/react", () => ({
+    default: (props: Record<string, unknown>) => <div data-testid="giscus" data-props={JSON.stringify(props)} />,
+}));
+
+describe("BlogComments", () => {
+    describe("render", () => {
+        it("mounts the giscus widget", () => {
+            render(<BlogComments />);
+            expect(screen.getByTestId("giscus")).toBeInTheDocument();
+        });
+
+        it("passes the site's giscus configuration to the widget", () => {
+            render(<BlogComments />);
+            const props = JSON.parse(screen.getByTestId("giscus").getAttribute("data-props")!);
+            expect(props.repo).toBe("chicio/chicio-blog");
+            expect(props.mapping).toBe("pathname");
+            expect(props.theme).toBe("https://www.fabrizioduroni.it/giscus-matrix.css");
+        });
+    });
+});

--- a/src/components/content/blog/blog-comments/blog-comments.tsx
+++ b/src/components/content/blog/blog-comments/blog-comments.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import Giscus from "@giscus/react";
+import { FC } from "react";
+import { giscusConfig } from "@/types/configuration/giscus";
+
+/**
+ * Renders the live giscus (GitHub Discussions) comment widget below a blog post.
+ * Pure configuration wrapper with no interactive state of its own — no store,
+ * per the no-pass-through-store convention. Not gated behind cookie consent:
+ * giscus sets no tracking cookies.
+ *
+ * The custom Matrix theme (public/giscus-matrix.css) is served from the absolute
+ * production URL, so on localhost giscus falls back to its unstyled default theme;
+ * this is expected in local development.
+ */
+export const BlogComments: FC = () => <Giscus {...giscusConfig} />;

--- a/src/components/content/blog/blog-comments/index.ts
+++ b/src/components/content/blog/blog-comments/index.ts
@@ -1,0 +1,1 @@
+export { BlogComments } from "./blog-comments";

--- a/src/components/content/blog/blog-post-content/blog-post-content.tsx
+++ b/src/components/content/blog/blog-post-content/blog-post-content.tsx
@@ -9,6 +9,8 @@ import { FC } from "react";
 import { PostAuthors } from "@/components/content/blog/post-authors";
 import { PostMeta } from "@/components/content/blog/post-meta";
 import { PostTags } from "@/components/content/blog/post-tags";
+import { ArchivedComments } from "@/components/content/blog/archived-comments";
+import { BlogComments } from "@/components/content/blog/blog-comments";
 import { RecentPosts } from "./read-next";
 import { ChromeAiFeaturesToolbar } from "./chrome-ai-features-toolbar";
 
@@ -48,6 +50,8 @@ export const BlogPostContent: FC<PostProps> = async ({ post }) => {
                     <>
                         <PostTags tags={frontmatter.tags} />
                         <RecentPosts currentSlug={post.slug.formatted} />
+                        <ArchivedComments slug={post.slug.params.slug} />
+                        <BlogComments />
                     </>
                 }
             >

--- a/src/content/blog/archived-comments.json
+++ b/src/content/blog/archived-comments.json
@@ -1,0 +1,316 @@
+{
+  "first-threejs-scene": [
+    {
+      "author": "Fabrizio",
+      "date": "2017-08-27T15:53:46Z",
+      "message": "<p>Thank you @user!! I hope you will enjoy also the other articles :)</p>",
+      "replies": []
+    }
+  ],
+  "model-view-presenter-architecture-ios-swift-unit-test": [
+    {
+      "author": "Abuzeid Ibrahim",
+      "date": "2018-05-13T22:53:34Z",
+      "message": "<p>Great tutorial, but Could you explain to me how you mocked the ProductDetailView,Where are you came from with ProductDetailViewSpy??</p>",
+      "replies": [
+        {
+          "author": "Fabrizio",
+          "date": "2018-05-14T11:14:06Z",
+          "message": "<p>Hi Abuzeid Ibrahim, thank you for reading my post!! 😊I added the implementation of the ProductDetailViewSpy class in the article. You can find also its implementation on the repository with the code contained in this article (if you want to try it out on your mac):</p><p><a href=\"https://github.com/chicio/Model-View-Presenter/blob/master/iOS/Swift/ProductsMVPTests/ProductDetailViewSpy.swift\" rel=\"nofollow noopener\">https://github.com/chicio/M...</a></p><p>Basically it is a class that implements the View interface (like the UIViewController of the app), and uses some property to keep track of the fact that a method has been called. So for the showTitleHasBeenCalled will be true when the show(title aTitle: String) function has been called. In this way you can test the interaction between the view and the presenter.<br />I had to do this because (maybe as you know) Swift doesn&#x27;t have a real mocking framework (due to the fact that reflection has limited support and subclassing of NSProxy classes isn&#x27;t allow (so no proxy class like other framework OCMock, Mockito...) ). So in Swift generally you write your own Mock/Spy in the way I shown you in this article. In the last time some alternatives has been created, like some mock-alike framework like this one</p><p><a href=\"https://github.com/Brightify/Cuckoo\" rel=\"nofollow noopener\">https://github.com/Brightif...</a></p><p>but honestly I didn&#x27;t try it yet. <br />I hope you find the post helpful and continue to read my blog!! 😊</p>"
+        }
+      ]
+    },
+    {
+      "author": "ingconti",
+      "date": "2018-07-08T12:38:28Z",
+      "message": "<p>nice post.<br />I do start in console and write Unit Test. and after start UI and controllers. (If can develop seriously, if I a have a dumb PM I cannot use Unit test.. &quot;i test dopo che rallentano&quot; they say.</p>",
+      "replies": [
+        {
+          "author": "Fabrizio",
+          "date": "2018-07-08T15:44:10Z",
+          "message": "<p>I know ing. :) It&#x27;s a hard world :( But anyway you can always push PM to &quot;non rompere le palle&quot; :D</p>"
+        }
+      ]
+    },
+    {
+      "author": "Usman",
+      "date": "2018-12-04T09:38:05Z",
+      "message": "<p>Could you please pass through dependencies rather that creating those inside the classes?</p>",
+      "replies": [
+        {
+          "author": "Fabrizio",
+          "date": "2018-12-04T17:53:13Z",
+          "message": "<p>Hi @Usman, first of all thank you for reading my post!! 🙂 The main objective of the post is to show the “model view presenter” architecture to the readers. This is why I kept everything as simple as possible. So I instantiated all the dependencies in the view controllers. Anyway it is possible to use a dependencies injection framework to get all you repositories, presenters and so on (and you must do it 😌). You can check the following dependency injection library available for swift:</p><p><a href=\"https://github.com/Swinject/Swinject\" rel=\"nofollow noopener\">https://github.com/Swinject...</a><br /><a href=\"https://github.com/square/Cleanse/\" rel=\"nofollow noopener\">https://github.com/square/C...</a></p><p>Let me know if you need more help 🙂.</p>"
+        }
+      ]
+    },
+    {
+      "author": "Varun Mehta",
+      "date": "2018-12-19T17:53:07Z",
+      "message": "<p>Great Post!! Well articulated. <br />Just wanted to make one improvement. I see a retain cycle between ProductsPresenter and ProductsViewController. So either of productsView property in ProductsPresenter OR productsPresenter in ProductsViewController should be taken as weak.</p>",
+      "replies": [
+        {
+          "author": "Fabrizio",
+          "date": "2018-12-19T21:06:42Z",
+          "message": "<p>Hi @Varun Mehta, thank you for reading my post!!😊<br />You&#x27;re right: in the previous implementation there was a retain cycle between the controllers and the presenters. I created the post and the example during a night of coding/studying so I missed that bug 😁. When I create a presenter in my daily job I usually set the view on the presenter as unowned. In this way I don&#x27;t need to unwrap it each time I access to it (and I also know for sure that the UIViewController that acts as the presenter view will be the final object to be deallocated). <br />So a big thank you for you bug report!!! Now you can see the github repo code and the article above fixed 😎.</p>"
+        }
+      ]
+    }
+  ],
+  "react-native-multiple-instance-rctrootview": [
+    {
+      "author": "Diego R Galindo",
+      "date": "2018-08-27T08:04:41Z",
+      "message": "<p>amazing! i was super frustrated using the xcode logger. thanks for this tip</p>",
+      "replies": [
+        {
+          "author": "Fabrizio",
+          "date": "2018-08-28T06:16:50Z",
+          "message": "<p>Thank you @Diego R Galindo!! 😊Continue to read my blog for other interesting tips!!! 🙃</p>"
+        }
+      ]
+    },
+    {
+      "author": "Max Pevsner",
+      "date": "2018-10-16T12:26:20Z",
+      "message": "<p>Thank you very much! It&#x27;s the only explanation of the problem I could find. The solution is simple an elegant!</p>",
+      "replies": [
+        {
+          "author": "Fabrizio",
+          "date": "2018-10-16T12:42:07Z",
+          "message": "<p>Thank you @Max Pevsner !! 😊Continue to read my blog for other interesting tips!!! 🙃</p>"
+        }
+      ]
+    }
+  ],
+  "react-native-typescript-existing-app": [
+    {
+      "author": "Priyank Acharya",
+      "date": "2019-01-05T12:08:02Z",
+      "message": "<p>Hey, very nice site. I came across this on Google, and I am stoked that I did. I will definitely be coming back here more often. Wish I could add to the conversation and bring a bit more to the table, but am just taking in as much info as I can at the moment. Thanks for sharing.</p><p><a href=\"http://www.daisoftware.com/Services/Mobile-Application-Development\" rel=\"nofollow noopener\">Mobile Application Development</a></p>",
+      "replies": []
+    }
+  ],
+  "custom-tabbar-swiftui": [
+    {
+      "author": "Ann",
+      "date": "2020-04-20T00:12:26Z",
+      "message": "<p>Great post!!! How can I add more tabs instead of just 2 to this?</p>",
+      "replies": [
+        {
+          "author": "Fabrizio",
+          "date": "2020-04-20T18:36:14Z",
+          "message": "<p>Hi Ann, to add more tabs you just have to add more TabBarItem items into the TabBar class (TabBar.swift).</p>"
+        },
+        {
+          "author": "Ann",
+          "date": "2020-04-21T03:27:17Z",
+          "message": "<p>I tried this but the other two just overlaps the current icons. How do I handle the spacing between them? I&#x27;m trying to have 4 tabs.</p>"
+        },
+        {
+          "author": "Ann",
+          "date": "2020-04-21T04:12:52Z",
+          "message": "<p>I think it is a problem for me in ShowModalTabBar Item. When I delete that line off of TabBar.swift, i have all 4 tabs come up but when I add that line, 2 appears again. Do you know how i can fix this?</p>"
+        }
+      ]
+    }
+  ],
+  "dark-mode-css-sass-scss": [
+    {
+      "author": "Danny",
+      "date": "2020-09-08T06:40:04Z",
+      "message": "<p>This is a great solution! Especially the `$additionalPropertiesPositionIsFront` optional boolean for properties like `box-shadow` where the color can&#x27;t be separated into a different property. Thanks for sharing.</p>",
+      "replies": []
+    }
+  ],
+  "how-to-calculate-reflection-vector": [
+    {
+      "author": "Fabrizio",
+      "date": "2020-11-05T16:45:22Z",
+      "message": "<p>Yes you&#x27;re right @Darken Dark , this was a typo error. &quot;From the law of reflection...&quot; is the correct sentence. Thank you for your feedback.</p>",
+      "replies": []
+    }
+  ],
+  "kotlin-junit5-mockk": [
+    {
+      "author": "Paolo Sciarra",
+      "date": "2021-02-20T13:10:11Z",
+      "message": "<p>Hi Fabrizio,<br />great article. I have just somes ideas I want to share with you: Mockk requires you to instruct your mocks otherwise it will fail because it received an unknown call and it doesn&#x27;t know what to do with that.</p><p>I tend to do this way: when I am mocking a query a method that returns some value, I will do as you did also being specific about the parameters used to get the result for the query, when I am mocking a command, some action I have to do and I need to verify it was executed, I am less specific in the `every` block and I am very specific in the `verify` block.</p><p>Also I drop entirely the verify block for the mocked query because I am more interested in the value I receive then the fact I actually called that collaborator.</p><p>In this way I find the test failures are easier to understand.</p><p>What do you think?</p>",
+      "replies": [
+        {
+          "author": "Fabrizio",
+          "date": "2021-02-21T10:09:23Z",
+          "message": "<p>Hi @Paolo Sciarra ,</p><p>thank you fo your feedback!! ♥️ For the first part:</p><p></p><blockquote>when I am mocking a command, some action I have to do and I need to verify it was executed, I am less specific in the `every` block and I am very specific in the `verify` block.</blockquote><p></p><p>Very interesting, I will try this approach as it seems a good strategy to have a real feedback about what call you&#x27;re expecting and, as you already said, it would make the test failure error more readable (because you will not see the one throw when a mock is missing).</p><p>For the second part:</p><p></p><blockquote>Also I drop entirely the verify block for the mocked query because I am more interested in the value I receive then the fact I actually called that collaborator.</blockquote><p></p><p>Based on what I know and I remember about MockK, this library doesn&#x27;t throw an error if you have the mock instructed in the test but you then you call it with other parameters (this is different with respect to other library like Mockito). This is why I always add a verify block (and again, e.g. in Mockito I was used to setup just the mocked query). But maybe this is something that was happening only in the first versions of the library, so I will check again soon 😎</p>"
+        }
+      ]
+    }
+  ],
+  "dynamic-imports-webpack-chunks": [
+    {
+      "author": "Iftikhar Ali",
+      "date": "2021-11-29T17:52:56Z",
+      "message": "<p>ES6 provides &lt;script type=&quot;module&quot; ..=&quot;&quot;&gt;&lt;/script&gt; which can download other modules on the fly.  Will webpack dynamic import still be relevant with that in place?</p>",
+      "replies": [
+        {
+          "author": "Fabrizio",
+          "date": "2021-11-30T08:52:13Z",
+          "message": "<p>Hi @Iftikhar Ali , thank you for your question. I think web pack dynamic imports are still relevant, because they let you code split your code base in an automatic way without worrying about optimising the modules imports and compilation. Basically it is a &quot;configuration&quot; approach that frees you from the burden of tuning code splitting.</p>"
+        }
+      ]
+    }
+  ],
+  "id3tageditor-swift-read-write-id3-tag-mp3": [
+    {
+      "author": "SouthernYankee",
+      "date": "2022-05-07T02:21:57Z",
+      "message": "<p>Thanks for this framework.  I recently discovered that one cannot use the Swift API&#x27;s to modify and save .mp3 metadata.  Frustrating!  But, your framework has helped me.  Thank you!</p>",
+      "replies": [
+        {
+          "author": "Fabrizio",
+          "date": "2022-05-09T07:35:21Z",
+          "message": "<p>Thank you for your support @SouthernYankee. Remember to ⭐️ star ⭐️ my repo in order to support my open source work</p>"
+        }
+      ]
+    },
+    {
+      "author": "SouthernYankee",
+      "date": "2022-05-07T03:04:59Z",
+      "message": "<p>I have mp3 files that have an attached picture, but iTunes/Music does not read the artwork.  Is this because the picture type is incorrect in the tag?  If so, how would I use your framework to change the picture type to be front cover?</p>",
+      "replies": [
+        {
+          "author": "Fabrizio",
+          "date": "2022-05-09T07:38:18Z",
+          "message": "<p>The general thing I suggest is to update/set the id3 tag of your mp3 to version 3 and play a little bit with the Attached picture frame contained in my framework. At the time I wrote this article iTunes supported only attached picture frame with &quot;other&quot; set as type. You can try to set it with my framework to different types and see how iTunes behave. I hope this can help you!!</p>"
+        }
+      ]
+    }
+  ],
+  "scene-kit-physically-based-rendering": [
+    {
+      "author": "Joice George",
+      "date": "2022-05-09T07:05:34Z",
+      "message": "<p>can we set the position of a node related to another node other than parent? Thank you</p>",
+      "replies": [
+        {
+          "author": "Fabrizio",
+          "date": "2022-05-09T11:50:37Z",
+          "message": "<p>Hi@Joice George, the position represented in this article for the Object class is a SCNVector3. So as long as you pass a vector (that could be also the position of another object that is not strictly the parent) you can set the position as you want.</p>"
+        }
+      ]
+    }
+  ],
+  "react-detect-scroll-direction": [
+    {
+      "author": "Jander Silva",
+      "date": "2022-06-03T15:58:33Z",
+      "message": "<p>Thank you.</p>",
+      "replies": [
+        {
+          "author": "Fabrizio",
+          "date": "2022-06-03T19:31:16Z",
+          "message": "<p>you’re welcome @Jander Silva 😊</p>"
+        }
+      ]
+    },
+    {
+      "author": "DjibDjib",
+      "date": "2022-08-24T09:27:16Z",
+      "message": "<p>Very nice ! Thx !</p>",
+      "replies": [
+        {
+          "author": "Fabrizio",
+          "date": "2022-08-24T17:52:59Z",
+          "message": "<p>Thank you 🙏</p>"
+        }
+      ]
+    },
+    {
+      "author": "Marco Agostinelli",
+      "date": "2022-11-14T14:08:57Z",
+      "message": "<p>Nice! Thank you!</p>",
+      "replies": [
+        {
+          "author": "Fabrizio",
+          "date": "2022-11-14T18:54:56Z",
+          "message": "<p>Thank you @Marco Agostinelli! 🙏</p>"
+        }
+      ]
+    }
+  ],
+  "webpack-workbox-service-worker-typescript": [
+    {
+      "author": "Pablo Alejos",
+      "date": "2022-10-24T22:23:17Z",
+      "message": "<p>How do you build the SV with webpack to have the file available on runtime to register it from the root of the scope?</p>",
+      "replies": [
+        {
+          "author": "Fabrizio",
+          "date": "2022-10-25T18:44:25Z",
+          "message": "<p>Hi Pablo, you can have a look at how I was doing this here <a href=\"https://github.com/chicio/old.chicio.github.io\" rel=\"nofollow noopener\">https://github.com/chicio/o...</a> (this website now has been migrated to GatsbyJS).</p>"
+        }
+      ]
+    }
+  ],
+  "rest-template-webclient-spring-boot": [
+    {
+      "author": "Moe Birchwood",
+      "date": "2023-04-25T05:36:37Z",
+      "message": "<p>Thanks for the cheat sheet, helped me well!</p><p>Just one comment: i guess you did an copy/paste error:</p><p><code>fun deleteSynchronous(): String {<br />    webClient<br />            .put()<br />...</code></p><p>should be</p><p><code>fun deleteSynchronous(): String {<br />    webClient<br />            .delete()<br />...</code></p>",
+      "replies": [
+        {
+          "author": "Fabrizio",
+          "date": "2023-04-25T19:59:44Z",
+          "message": "<p>Hi @@Moe Birchwood, thanks for the feedback 🙏 I updated the article and the example (will be live in a few minutes) 🚀🚀🚀.</p>"
+        }
+      ]
+    }
+  ],
+  "microfrontend-module-federation-dynamic-configuration": [
+    {
+      "author": "Aravinda Kumar",
+      "date": "2023-05-11T22:30:26Z",
+      "message": "<p>Excellent blog. Is there any performance issues in this approach, if yes how much of an hit can it be, from the native bundling approach. And how can these two apps be served, can they be served statically after build.</p>",
+      "replies": []
+    }
+  ],
+  "ios-notification-content-extensions": [
+    {
+      "author": "Roberto Sonzogni",
+      "date": "2023-09-22T10:07:55Z",
+      "message": "<p>Ciao Fabrizio, ma per vedere l&#x27;interfaccia personalizzata, è necessario premere sulla notifica con interfaccia standard?<br />Non si può visualizzare la notifica subito con l&#x27;interfaccia personalizzata?<br />Vorrei visualizzare notifiche in stile Whatsapp/Telegram, non so se questo è il modo giusto per farlo.<br />Grazie</p>",
+      "replies": [
+        {
+          "author": "Fabrizio",
+          "date": "2024-06-19T06:48:19Z",
+          "message": "<p>Ciao  @Roberto Sonzogni , scusa per la risposta tardiva. Non saprei, perchè l&#x27;articolo è un po&#x27; datato e alla fine (ai tempi) non sono riuscito a portare in produzione tale feature (business non era interessato). Probabilmente ora le api dell&#x27;iOS sdk danno piu possibilità su quelle parti.</p>"
+        }
+      ]
+    }
+  ],
+  "widget-ios-swiftui-image-problem": [
+    {
+      "author": "eric",
+      "date": "2024-06-24T03:06:16Z",
+      "message": "<p>this article do me a great favor, thanks a lot.</p>",
+      "replies": [
+        {
+          "author": "Fabrizio",
+          "date": "2024-06-24T10:18:21Z",
+          "message": "<p>@eric thanks for the feedback. Glad my knowledge sharing helped saved you having the same headache I had during widgets development.</p>"
+        }
+      ]
+    },
+    {
+      "author": "Mykyta Khlamov",
+      "date": "2024-09-20T15:45:23Z",
+      "message": "<p>Thanks for this topic!<br />I was facing the same problem and didn&#x27;t know what to do before reading this. Also I got new knowledge about Xcode console (never used it before).<br />Wish you all the best!🔥</p>",
+      "replies": [
+        {
+          "author": "Fabrizio",
+          "date": "2024-09-21T10:04:07Z",
+          "message": "<p>@Mykyta Khlamov thanks for the feedback. It is really satisfying to see that our article is helping people with this kind of problem. Thanks a lot 🙏</p>"
+        }
+      ]
+    }
+  ]
+}

--- a/src/lib/content/comments/comments.test.ts
+++ b/src/lib/content/comments/comments.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+import { getArchivedCommentsBy } from "./comments";
+
+describe("getArchivedCommentsBy", () => {
+    describe("known slug", () => {
+        it("returns the archived comments for that slug", () => {
+            const comments = getArchivedCommentsBy("dynamic-imports-webpack-chunks");
+
+            expect(comments).toHaveLength(1);
+            expect(comments[0].author).toBe("Iftikhar Ali");
+        });
+
+        it("preserves one-level nested replies", () => {
+            const comments = getArchivedCommentsBy("dynamic-imports-webpack-chunks");
+
+            expect(comments[0].replies).toHaveLength(1);
+            expect(comments[0].replies[0].author).toBe("Fabrizio");
+        });
+
+        it("returns comment bodies as sanitized HTML strings", () => {
+            const comments = getArchivedCommentsBy("dynamic-imports-webpack-chunks");
+
+            expect(comments[0].message).toContain("<p>");
+        });
+
+        it("parses date fields as valid ISO dates", () => {
+            const comments = getArchivedCommentsBy("dynamic-imports-webpack-chunks");
+
+            expect(new Date(comments[0].date).toString()).not.toBe("Invalid Date");
+            expect(new Date(comments[0].replies[0].date).toString()).not.toBe("Invalid Date");
+        });
+
+        it("supports multiple top-level comments and replies for a single slug", () => {
+            const comments = getArchivedCommentsBy("custom-tabbar-swiftui");
+
+            expect(comments).toHaveLength(1);
+            expect(comments[0].replies).toHaveLength(3);
+        });
+
+        it("returns an empty replies array when a comment has no replies", () => {
+            const comments = getArchivedCommentsBy("first-threejs-scene");
+
+            expect(comments[0].replies).toEqual([]);
+        });
+    });
+
+    describe("unknown slug", () => {
+        it("returns an empty array", () => {
+            expect(getArchivedCommentsBy("a-slug-with-no-archived-comments")).toEqual([]);
+        });
+    });
+});

--- a/src/lib/content/comments/comments.ts
+++ b/src/lib/content/comments/comments.ts
@@ -1,0 +1,14 @@
+import path from "path";
+import fs from "fs";
+import { cached } from "@/lib/build/build-cache";
+import { ArchivedComment, ArchivedCommentsArchive } from "@/types/content/comment";
+
+const archivedCommentsFilePath = path.join(process.cwd(), "src/content/blog/archived-comments.json");
+
+const readArchivedComments = (): ArchivedCommentsArchive =>
+    cached("archived-comments", (): ArchivedCommentsArchive => {
+        const fileContents = fs.readFileSync(archivedCommentsFilePath, "utf8");
+        return JSON.parse(fileContents) as ArchivedCommentsArchive;
+    });
+
+export const getArchivedCommentsBy = (slug: string): ArchivedComment[] => readArchivedComments()[slug] ?? [];

--- a/src/types/configuration/giscus.ts
+++ b/src/types/configuration/giscus.ts
@@ -1,12 +1,10 @@
-import { GiscusProps } from "@giscus/react";
+import type { GiscusProps } from "@giscus/react";
 
-// categoryId is a placeholder: fill in with the real GitHub Discussions category id
-// (Fabrizio is creating the "Blog comments" category in the GitHub UI) before merging this feature.
 export const giscusConfig: Omit<GiscusProps, "id" | "host"> = {
     repo: "chicio/chicio-blog",
     repoId: "R_kgDONo7oFQ",
     category: "Blog comments",
-    categoryId: "GISCUS_CATEGORY_ID_PENDING",
+    categoryId: "DIC_kwDONo7oFc4DBaAT",
     mapping: "pathname",
     strict: "1",
     reactionsEnabled: "1",

--- a/src/types/configuration/giscus.ts
+++ b/src/types/configuration/giscus.ts
@@ -1,0 +1,17 @@
+import { GiscusProps } from "@giscus/react";
+
+// categoryId is a placeholder: fill in with the real GitHub Discussions category id
+// (Fabrizio is creating the "Blog comments" category in the GitHub UI) before merging this feature.
+export const giscusConfig: Omit<GiscusProps, "id" | "host"> = {
+    repo: "chicio/chicio-blog",
+    repoId: "R_kgDONo7oFQ",
+    category: "Blog comments",
+    categoryId: "GISCUS_CATEGORY_ID_PENDING",
+    mapping: "pathname",
+    strict: "1",
+    reactionsEnabled: "1",
+    inputPosition: "bottom",
+    lang: "en",
+    loading: "lazy",
+    theme: "https://www.fabrizioduroni.it/giscus-matrix.css",
+};

--- a/src/types/content/comment.ts
+++ b/src/types/content/comment.ts
@@ -1,0 +1,11 @@
+export interface ArchivedCommentReply {
+    author: string;
+    date: string;
+    message: string;
+}
+
+export interface ArchivedComment extends ArchivedCommentReply {
+    replies: ArchivedCommentReply[];
+}
+
+export type ArchivedCommentsArchive = Record<string, ArchivedComment[]>;


### PR DESCRIPTION
Add a two-part comment system to blog post pages: a giscus (GitHub Discussions) widget with a custom Matrix theme, plus a server-rendered archive of the 47 legacy Disqus comments on 17 posts.

## Description
- **Live comments**: `BlogComments` — stateless `"use client"` wrapper around `@giscus/react`, backed by the "Blog comments" (Announcement) Discussions category of this repo. `mapping: pathname`, lazy-loaded, unconditional (no consent gating — giscus sets no tracking cookies). Custom theme `public/giscus-matrix.css` (green-on-black, site fonts) built on giscus's dark theme variable set.
- **Archived comments**: `ArchivedComments` — server component rendering the legacy Disqus threads (original authors, original dates, one-level nested replies) from `src/content/blog/archived-comments.json`; renders nothing on posts without legacy comments. Bodies were sanitized offline to a minimal HTML subset (p, a[href http/https, rel="nofollow noopener"], code, blockquote, br); the JSON is static repo-committed data, the only feeder of the `dangerouslySetInnerHTML` sink.
- Lookup lib `src/lib/content/comments/` (build-cached, unit-tested); giscus config constant in `src/types/configuration/giscus.ts`; wiring in `blog-post-content.tsx` afterContent: PostTags → Read next → ArchivedComments → BlogComments.

## Motivation and Context
Re-introduce reader discussion on blog posts (Disqus was dropped years ago for its ads/trackers) without new infrastructure, tracking, or moderation burden — GitHub identity doubles as the spam filter for a developer readership. The legacy Disqus threads on evergreen posts contain real Q&A worth preserving; a static archive keeps them SEO-visible with correct authorship/dates instead of a lossy Discussions import.

## How Has This Been Tested?
Automated (lint, validate-architecture, knip, typecheck, Vitest 1044 tests incl. 14 new, build, Playwright e2e 61/61 incl. 3 new blog-comments specs) + independent review re-ran all gates + agent-browser live QA on legacy/non-legacy posts (rendering, nesting, a11y tree, Matrix styling).

Non-blocking notes from review: archived-date formatting uses runtime timezone (safe in UTC CI; could pin `timeZone: "UTC"`); giscus's built-in *error-state* UI is unthemed (normal UI uses the custom theme) — recheck visually once deployed.

## Types of changes
- [ ] Bug fix :bug: (non-breaking change which fixes an issue)
- [X] New feature :sparkles: (non-breaking change which adds functionality)
- [ ] Breaking change :boom: (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project :beers:.
- [X] My change requires a change to the documentation :bulb: and I have updated the documentation accordingly.
- [X] I have read the [CONTRIBUTING](https://github.com/chicio/chicio.github.io/blob/master/CONTRIBUTING.md) document :busts_in_silhouette:.
- [X] I have added tests to cover my changes :tada:.
- [X] All new and existing tests passed :white_check_mark:.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added live comments to blog posts through a Giscus-powered discussion widget.
  * Added a Matrix-themed appearance for the comments experience.
  * Added archived comments for eligible posts, including authors, dates, replies, and formatted content.
* **Bug Fixes**
  * Blog posts without archived comments no longer display an empty archived-comments section.
* **Tests**
  * Added coverage for live comments, archived comments, nested replies, formatting, and posts without comments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->