### PR TITLE
chore(capabilities): 🔒 scrub cleartext personal PII from codebase

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -55,7 +55,8 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at fabrizio.duroni@gmail.com. All
+reported by contacting the project team through the contact form at
+https://www.fabrizioduroni.it/contact. All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.

--- a/src/app/api/contact/route.ts
+++ b/src/app/api/contact/route.ts
@@ -61,7 +61,7 @@ export async function POST(request: NextRequest) {
 
     const { error: notificationError } = await resend.emails.send({
       from: "fabrizioduroni.it Contact Form <contact@fabrizioduroni.it>",
-      to: ["fabrizio.duroni@gmail.com"],
+      to: [process.env.CONTACT_EMAIL!],
       replyTo: email,
       subject: `Chicio Coding - Contact from ${name}`,
       react: ContactNotificationEmail({ name, email, message }),

--- a/src/app/rss.xml/route.ts
+++ b/src/app/rss.xml/route.ts
@@ -15,7 +15,6 @@ export async function GET() {
     link: `${siteMetadata.siteUrl}`,
     author: {
       name: authors.fabrizio_duroni.name,
-      email: "fabrizio.duroni@gmail.com",
       link: authors.fabrizio_duroni.linkedinUrl,
     },
     language: "en",

--- a/src/lib/chat/llm-prompt.ts
+++ b/src/lib/chat/llm-prompt.ts
@@ -3,9 +3,8 @@ PROFESSIONAL PROFILE - FABRIZIO DURONI
 
 === BASIC INFORMATION ===
 Name: Fabrizio Duroni
-Location: Via Leonardo da Vinci 4, Montorfano (CO), Italia
-Phone: +39 3285926828
-Email: fabrizio.duroni@gmail.com
+Location: Italia
+Contact: use the contact form at https://www.fabrizioduroni.it/contact
 Website: https://www.fabrizioduroni.it
 GitHub: @chicio
 LinkedIn: fabrizio-duroni

--- a/src/types/configuration/site-metadata.ts
+++ b/src/types/configuration/site-metadata.ts
@@ -7,7 +7,6 @@ export const siteMetadata = {
     featuredArtImage: "/chicio-art-featured.png",
     author: "Fabrizio Duroni",
     contacts: {
-        email: "fabrizio.duroni@gmail.com",
         links: {
             twitter: "https://twitter.com/chicio86",
             facebook: "https://www.facebook.com/fabrizio.duroni",


### PR DESCRIPTION
## Why

My personal email (and, in the chat LLM prompt, my phone number and home address) were sitting in cleartext in the codebase. This removes them.

## What changed

| File | Change |
|------|--------|
| `src/types/configuration/site-metadata.ts` | Drop the dead `contacts.email` field (nothing read it). |
| `src/app/rss.xml/route.ts` | Remove the author email from the public RSS feed (optional field). |
| `src/app/api/contact/route.ts` | Notification recipient now comes from `process.env.CONTACT_EMAIL` instead of a hardcoded address. |
| `src/lib/chat/llm-prompt.ts` | Strip email, phone, and home address from the LLM profile; point to the contact form. |
| `CODE_OF_CONDUCT.md` | Report conduct issues via the contact form instead of an email. |

Public contact now flows through https://www.fabrizioduroni.it/contact. The domain has **no MX records**, so `contact@fabrizioduroni.it` is a send-only Resend identity and can't receive mail — the form is the right funnel.

## ⚠️ Deploy action required

`CONTACT_EMAIL` must be set in the **Vercel project env vars (Production + Preview)** or the contact form's Resend notification will fail at runtime. It's already added to the local (gitignored) `.env.development` / `.env.production`.

## Note on git history

This scrubs `HEAD` only. The email/phone/address remain in older commits of this public repo; true erasure would require a history rewrite (`git filter-repo` + force-push).

## Verification

typecheck ✅ · lint ✅ · knip ✅ · validate-architecture ✅ · full test suite (1089) ✅ · build ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)