### PR TITLE
fix(capabilities): 🐛 sitemap from the content registry — 22 missing pages, 2 broken image paths

### DIFF
--- a/src/app/sitemap.test.ts
+++ b/src/app/sitemap.test.ts
@@ -1,100 +1,139 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 
-const { mockGetPosts, mockGetTags, mockGetPostsTotalPages, mockGetIndexableContent } = vi.hoisted(() => ({
-    mockGetPosts: vi.fn(),
-    mockGetTags: vi.fn(),
-    mockGetPostsTotalPages: vi.fn(),
-    mockGetIndexableContent: vi.fn(),
-}));
+const { mockGetTags, mockGetPostsTotalPages, mockGetAuthorsWithPosts, mockIndexed, mockCollectionParams } = vi.hoisted(
+    () => ({
+        mockGetTags: vi.fn(),
+        mockGetPostsTotalPages: vi.fn(),
+        mockGetAuthorsWithPosts: vi.fn(),
+        mockIndexed: vi.fn(),
+        mockCollectionParams: vi.fn(),
+    }),
+);
 
 vi.mock("@/lib/content/posts/posts", () => ({
-    posts: { list: mockGetPosts },
     getTags: mockGetTags,
     getPostsTotalPages: mockGetPostsTotalPages,
+    getAuthorsWithPosts: mockGetAuthorsWithPosts,
 }));
 
-vi.mock("@/lib/content/indexable-content", () => ({
-    getIndexableContent: mockGetIndexableContent,
+/**
+ * The sitemap's own job is composing registry entries and the post-derived listings into URLs, so it is
+ * tested against a small fake registry. What the real registry contains is asserted in registry.test.ts.
+ */
+vi.mock("@/lib/content/registry", () => ({
+    contentRegistry: [
+        { slug: "/", markdown: vi.fn() },
+        { slug: "/plain-page", markdown: vi.fn() },
+        { slug: "/gallery", markdown: vi.fn(), sitemapImage: "/art-featured.jpg" },
+        { slug: "/things/[thing]", markdown: vi.fn(), params: mockCollectionParams, indexed: mockIndexed },
+    ],
 }));
 
 import sitemap from "./sitemap";
+import { siteMetadata } from "@/types/configuration/site-metadata";
 
-const makeFakePost = (slug: string) => ({
-    slug: { formatted: `/blog/post/2024/01/01/${slug}` },
-    frontmatter: {
-        date: { formatted: "2024-01-01" },
-        image: "/test-image.jpg",
-        title: "Test Post",
-    },
-});
+const url = (path: string) => `${siteMetadata.siteUrl}${path}`;
 
-const makeFakeTag = (tagValue: string) => ({
-    tagValue,
-    slug: `/blog/tag/${tagValue}`,
-    count: 3,
-    tagSlugText: tagValue,
+const findEntry = (path: string) => sitemap().find((entry) => entry.url === url(path));
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetTags.mockReturnValue([]);
+    mockGetPostsTotalPages.mockReturnValue(0);
+    mockGetAuthorsWithPosts.mockReturnValue([]);
+    mockCollectionParams.mockReturnValue([{ thing: "one" }]);
+    mockIndexed.mockReturnValue([
+        {
+            slug: { formatted: "/things/one", params: { thing: "one" } },
+            frontmatter: { date: { formatted: "2024-03-04" }, image: "/one.jpg", title: "One" },
+        },
+    ]);
 });
 
 describe("sitemap", () => {
-    describe("output shape", () => {
-        it("includes the homepage entry", () => {
-            mockGetPostsTotalPages.mockReturnValue(1);
-            mockGetPosts.mockReturnValue([makeFakePost("my-post")]);
-            mockGetTags.mockReturnValue([makeFakeTag("typescript")]);
-            mockGetIndexableContent.mockReturnValue([makeFakePost("my-post")]);
-
-            const entries = sitemap();
-            const urls = entries.map((e) => e.url);
-            expect(urls).toContain("https://www.fabrizioduroni.it");
+    describe("registry content", () => {
+        it("announces the homepage without a trailing slash", () => {
+            expect(findEntry("")).toBeDefined();
         });
 
-        it("includes the blog home entry", () => {
-            mockGetPostsTotalPages.mockReturnValue(1);
-            mockGetPosts.mockReturnValue([]);
-            mockGetTags.mockReturnValue([]);
-            mockGetIndexableContent.mockReturnValue([]);
-
-            const entries = sitemap();
-            const urls = entries.map((e) => e.url);
-            expect(urls).toContain("https://www.fabrizioduroni.it/blog");
+        it("announces a single page from the registry", () => {
+            expect(findEntry("/plain-page")).toBeDefined();
         });
 
-        it("generates pagination pages based on total pages", () => {
+        it("takes the date and image of an indexed item from its own frontmatter", () => {
+            const entry = findEntry("/things/one");
+
+            expect(entry?.lastModified).toEqual(new Date("2024-03-04"));
+            expect(entry?.images).toEqual([url("/one.jpg")]);
+        });
+
+        it("falls back to the site featured image for a page that carries no content", () => {
+            expect(findEntry("/plain-page")?.images).toEqual([url(siteMetadata.featuredImage)]);
+        });
+
+        it("honours an entry's own sitemap image", () => {
+            expect(findEntry("/gallery")?.images).toEqual([url("/art-featured.jpg")]);
+        });
+
+        it("expands an indexed collection from its content rather than from its params", () => {
+            sitemap();
+
+            expect(mockIndexed).toHaveBeenCalled();
+            expect(mockCollectionParams).not.toHaveBeenCalled();
+        });
+    });
+
+    describe("post-derived listings", () => {
+        it("announces the archive, tags and authors listings", () => {
+            expect(findEntry("/blog/archive")).toBeDefined();
+            expect(findEntry("/blog/tags")).toBeDefined();
+            expect(findEntry("/blog/authors")).toBeDefined();
+        });
+
+        it("announces one entry per pagination page, starting at one", () => {
             mockGetPostsTotalPages.mockReturnValue(3);
-            mockGetPosts.mockReturnValue([]);
-            mockGetTags.mockReturnValue([]);
-            mockGetIndexableContent.mockReturnValue([]);
 
-            const entries = sitemap();
-            const paginationUrls = entries
-                .map((e) => e.url)
-                .filter((u) => u.includes("/blog/posts/"));
-            expect(paginationUrls).toHaveLength(3);
-            expect(paginationUrls).toContain("https://www.fabrizioduroni.it/blog/posts/1");
-            expect(paginationUrls).toContain("https://www.fabrizioduroni.it/blog/posts/3");
+            expect(findEntry("/blog/posts/1")).toBeDefined();
+            expect(findEntry("/blog/posts/3")).toBeDefined();
+            expect(findEntry("/blog/posts/4")).toBeUndefined();
         });
 
-        it("includes tag entries for each tag", () => {
-            mockGetPostsTotalPages.mockReturnValue(1);
-            mockGetPosts.mockReturnValue([]);
-            mockGetTags.mockReturnValue([makeFakeTag("react"), makeFakeTag("typescript")]);
-            mockGetIndexableContent.mockReturnValue([]);
+        it("announces every tag", () => {
+            mockGetTags.mockReturnValue([
+                { tagValue: "swift", slug: "/blog/tag/swift", count: 2, tagSlugText: "swift" },
+            ]);
 
-            const entries = sitemap();
-            const urls = entries.map((e) => e.url);
-            expect(urls).toContain("https://www.fabrizioduroni.it/blog/tag/react");
-            expect(urls).toContain("https://www.fabrizioduroni.it/blog/tag/typescript");
+            expect(findEntry("/blog/tag/swift")).toBeDefined();
         });
 
-        it("includes indexable content entries", () => {
-            mockGetPostsTotalPages.mockReturnValue(1);
-            mockGetPosts.mockReturnValue([]);
-            mockGetTags.mockReturnValue([]);
-            mockGetIndexableContent.mockReturnValue([makeFakePost("hello-world")]);
+        it("announces every author who has posts", () => {
+            mockGetAuthorsWithPosts.mockReturnValue([{ author: { id: "ada_lovelace" }, postCount: 2 }]);
 
-            const entries = sitemap();
-            const urls = entries.map((e) => e.url);
-            expect(urls).toContain("https://www.fabrizioduroni.it/blog/post/2024/01/01/hello-world");
+            expect(findEntry("/blog/author/ada-lovelace")).toBeDefined();
+        });
+
+        it("leaves out the site owner, whose author page is about-me instead", () => {
+            mockGetAuthorsWithPosts.mockReturnValue([{ author: { id: "fabrizio_duroni" }, postCount: 9 }]);
+
+            expect(findEntry("/blog/author/fabrizio-duroni")).toBeUndefined();
+        });
+    });
+
+    describe("output", () => {
+        it("gives every entry an absolute url and a priority", () => {
+            mockGetPostsTotalPages.mockReturnValue(1);
+
+            sitemap().forEach((entry) => {
+                expect(entry.url.startsWith(siteMetadata.siteUrl)).toBe(true);
+                expect(entry.priority).toBe(1);
+            });
+        });
+
+        it("announces no url twice", () => {
+            mockGetPostsTotalPages.mockReturnValue(2);
+            const urls = sitemap().map((entry) => entry.url);
+
+            expect(new Set(urls).size).toBe(urls.length);
         });
     });
 });

--- a/src/app/sitemap.test.ts
+++ b/src/app/sitemap.test.ts
@@ -1,11 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-const { mockGetTags, mockGetPostsTotalPages, mockGetAuthorsWithPosts, mockIndexed, mockCollectionParams } = vi.hoisted(
+const { mockGetTags, mockGetPostsTotalPages, mockGetAuthorsWithPosts, mockContent, mockGalleryContent, mockCollectionParams } = vi.hoisted(
     () => ({
         mockGetTags: vi.fn(),
         mockGetPostsTotalPages: vi.fn(),
         mockGetAuthorsWithPosts: vi.fn(),
-        mockIndexed: vi.fn(),
+        mockContent: vi.fn(),
+        mockGalleryContent: vi.fn(),
         mockCollectionParams: vi.fn(),
     }),
 );
@@ -24,8 +25,8 @@ vi.mock("@/lib/content/registry", () => ({
     contentRegistry: [
         { slug: "/", markdown: vi.fn() },
         { slug: "/plain-page", markdown: vi.fn() },
-        { slug: "/gallery", markdown: vi.fn(), sitemapImage: "/art-featured.jpg" },
-        { slug: "/things/[thing]", markdown: vi.fn(), params: mockCollectionParams, indexed: mockIndexed },
+        { slug: "/gallery", markdown: vi.fn(), content: mockGalleryContent },
+        { slug: "/things/[thing]", markdown: vi.fn(), params: mockCollectionParams, content: mockContent },
     ],
 }));
 
@@ -42,7 +43,13 @@ beforeEach(() => {
     mockGetPostsTotalPages.mockReturnValue(0);
     mockGetAuthorsWithPosts.mockReturnValue([]);
     mockCollectionParams.mockReturnValue([{ thing: "one" }]);
-    mockIndexed.mockReturnValue([
+    mockGalleryContent.mockReturnValue([
+        {
+            slug: { formatted: "/gallery", params: {} },
+            frontmatter: { date: { formatted: "2018-11-15" }, image: "/media/content/art/featured.png", title: "Art" },
+        },
+    ]);
+    mockContent.mockReturnValue([
         {
             slug: { formatted: "/things/one", params: { thing: "one" } },
             frontmatter: { date: { formatted: "2024-03-04" }, image: "/one.jpg", title: "One" },
@@ -60,7 +67,7 @@ describe("sitemap", () => {
             expect(findEntry("/plain-page")).toBeDefined();
         });
 
-        it("takes the date and image of an indexed item from its own frontmatter", () => {
+        it("takes the date and image of a content item from its own frontmatter", () => {
             const entry = findEntry("/things/one");
 
             expect(entry?.lastModified).toEqual(new Date("2024-03-04"));
@@ -71,14 +78,18 @@ describe("sitemap", () => {
             expect(findEntry("/plain-page")?.images).toEqual([url(siteMetadata.featuredImage)]);
         });
 
-        it("honours an entry's own sitemap image", () => {
-            expect(findEntry("/gallery")?.images).toEqual([url("/art-featured.jpg")]);
+        it("takes a page's image from its frontmatter rather than from a second declaration", () => {
+            expect(findEntry("/gallery")?.images).toEqual([url("/media/content/art/featured.png")]);
         });
 
-        it("expands an indexed collection from its content rather than from its params", () => {
+        it("takes a page's date from its frontmatter, not the build time", () => {
+            expect(findEntry("/gallery")?.lastModified).toEqual(new Date("2018-11-15"));
+        });
+
+        it("expands a collection from its content rather than from its params", () => {
             sitemap();
 
-            expect(mockIndexed).toHaveBeenCalled();
+            expect(mockContent).toHaveBeenCalled();
             expect(mockCollectionParams).not.toHaveBeenCalled();
         });
     });

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,77 +1,73 @@
 import type { MetadataRoute } from "next";
-import { getPostsTotalPages, getTags } from "@/lib/content/posts/posts";
+import { getAuthorsWithPosts, getPostsTotalPages, getTags } from "@/lib/content/posts/posts";
+import { authorIdToSlug, ownerAuthorId } from "@/lib/content/authors/author-slug";
+import { contentRegistry } from "@/lib/content/registry";
+import { slugFor } from "@/lib/content/slug-template";
 import { siteMetadata } from "@/types/configuration/site-metadata";
 import { slugs } from "@/types/configuration/slug";
-import { getIndexableContent } from "@/lib/content/indexable-content";
 
-const getPostListPages = (defaultImage: string[]) => {
-  const totalPages = getPostsTotalPages();
-  const blogPaginationPages: MetadataRoute.Sitemap = [];
+const absoluteUrl = (path: string) => `${siteMetadata.siteUrl}${path === "/" ? "" : path}`;
 
-  for (let i = 1; i <= totalPages; i++) {
-    blogPaginationPages.push({
-      url: `${siteMetadata.siteUrl}${slugs.blog.blogPostsPage}/${i}`,
-      lastModified: new Date(),
-      changeFrequency: "yearly",
-      priority: 1,
-      images: defaultImage,
+const defaultImage = [absoluteUrl(siteMetadata.featuredImage)];
+
+/**
+ * Everything the content registry knows about: every single page, and every item of every collection.
+ * The registry is the record of what real content exists, so registering a section is all it takes for
+ * its pages to be announced here.
+ *
+ * An indexed entry carries real content, so its own frontmatter supplies the date and image. The rest
+ * are aggregate or config-driven pages with no date of their own, and report the build time.
+ */
+const contentUrls = (): MetadataRoute.Sitemap =>
+    contentRegistry.flatMap((entry) => {
+        const indexed = entry.indexed?.();
+
+        if (indexed) {
+            return indexed.map((content) => ({
+                url: absoluteUrl(content.slug.formatted),
+                lastModified: new Date(content.frontmatter.date.formatted),
+                priority: 1,
+                images: [absoluteUrl(content.frontmatter.image)],
+            }));
+        }
+
+        return (entry.params?.() ?? [{}]).map((params) => ({
+            url: absoluteUrl(slugFor(entry.slug, params)),
+            lastModified: new Date(),
+            changeFrequency: "yearly" as const,
+            priority: 1,
+            images: entry.sitemapImage ? [absoluteUrl(entry.sitemapImage)] : defaultImage,
+        }));
     });
-  }
 
-  return blogPaginationPages;
+/**
+ * Routes that index the posts rather than being content themselves: pagination, the archive, and the
+ * tag and author listings. They have no registry entry because they have no content of their own —
+ * they are views over the posts, derived from post frontmatter.
+ */
+const navigationUrls = (): MetadataRoute.Sitemap => {
+    const listings = [slugs.blog.blogArchive, slugs.blog.tags, slugs.blog.authors];
+
+    const paginationPages = Array.from(
+        { length: getPostsTotalPages() },
+        (_, index) => `${slugs.blog.blogPostsPage}/${index + 1}`,
+    );
+
+    const tagPages = getTags().map((tag) => tag.slug);
+
+    const authorPages = getAuthorsWithPosts()
+        .filter((entry) => entry.author.id !== ownerAuthorId)
+        .map((entry) => slugs.blog.author.replace("[authorId]", authorIdToSlug(entry.author.id)));
+
+    return [...listings, ...paginationPages, ...tagPages, ...authorPages].map((path) => ({
+        url: absoluteUrl(path),
+        lastModified: new Date(),
+        changeFrequency: "yearly" as const,
+        priority: 1,
+        images: defaultImage,
+    }));
 };
 
 export default function sitemap(): MetadataRoute.Sitemap {
-  const defaultImage = [`${siteMetadata.siteUrl}${siteMetadata.featuredImage}`];
-
-  return [
-    {
-      url: siteMetadata.siteUrl,
-      lastModified: new Date(),
-      changeFrequency: "yearly",
-      priority: 1,
-      images: defaultImage,
-    },
-    {
-      url: `${siteMetadata.siteUrl}${slugs.blog.home}`,
-      lastModified: new Date(),
-      changeFrequency: "yearly",
-      priority: 1,
-      images: defaultImage,
-    },
-    ...getPostListPages(defaultImage),
-    {
-      url: `${siteMetadata.siteUrl}${slugs.blog.blogArchive}`,
-      lastModified: new Date(),
-      changeFrequency: "yearly",
-      priority: 1,
-      images: [`${siteMetadata.siteUrl}${siteMetadata.featuredImage}`],
-    },
-    {
-      url: `${siteMetadata.siteUrl}${slugs.blog.tags}`,
-      lastModified: new Date(),
-      changeFrequency: "yearly",
-      priority: 1,
-      images: defaultImage,
-    },
-    ...getTags().map((tag) => ({
-      url: `${siteMetadata.siteUrl}${tag.slug}`,
-      lastModified: new Date(),
-      priority: 1,
-      images: defaultImage,
-    })),
-    {
-      url: `${siteMetadata.siteUrl}${slugs.art}`,
-      lastModified: new Date(),
-      changeFrequency: "yearly",
-      priority: 1,
-      images: [`${siteMetadata.siteUrl}${siteMetadata.featuredArtImage}`],
-    },
-    ...getIndexableContent().map((content) => ({
-      url: `${siteMetadata.siteUrl}${content.slug.formatted}`,
-      lastModified: new Date(content.frontmatter.date.formatted),
-      priority: 1,
-      images: [`${siteMetadata.siteUrl}${content.frontmatter.image}`],
-    })),
-  ];
+    return [...contentUrls(), ...navigationUrls()];
 }

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -15,19 +15,19 @@ const defaultImage = [absoluteUrl(siteMetadata.featuredImage)];
  * The registry is the record of what real content exists, so registering a section is all it takes for
  * its pages to be announced here.
  *
- * An indexed entry carries real content, so its own frontmatter supplies the date and image. The rest
- * are aggregate or config-driven pages with no date of their own, and report the build time.
+ * An entry that has content takes its date and image from that content's own frontmatter. The rest are
+ * aggregate pages with no date or image of their own, and report the build time.
  */
 const contentUrls = (): MetadataRoute.Sitemap =>
     contentRegistry.flatMap((entry) => {
-        const indexed = entry.indexed?.();
+        const content = entry.content?.();
 
-        if (indexed) {
-            return indexed.map((content) => ({
-                url: absoluteUrl(content.slug.formatted),
-                lastModified: new Date(content.frontmatter.date.formatted),
+        if (content) {
+            return content.map((item) => ({
+                url: absoluteUrl(item.slug.formatted),
+                lastModified: new Date(item.frontmatter.date.formatted),
                 priority: 1,
-                images: [absoluteUrl(content.frontmatter.image)],
+                images: [absoluteUrl(item.frontmatter.image)],
             }));
         }
 
@@ -36,7 +36,7 @@ const contentUrls = (): MetadataRoute.Sitemap =>
             lastModified: new Date(),
             changeFrequency: "yearly" as const,
             priority: 1,
-            images: entry.sitemapImage ? [absoluteUrl(entry.sitemapImage)] : defaultImage,
+            images: defaultImage,
         }));
     });
 

--- a/src/content/art/content.mdx
+++ b/src/content/art/content.mdx
@@ -2,7 +2,7 @@
 title: "Art"
 description: "A collection of drawings from Fabrizio Duroni's ongoing journey learning to draw: tattoo-inspired sketches, anatomy studies, and pop culture homages."
 date: 2018-11-15
-image: /chicio-art-featured.png
+image: /media/content/art/chicio-art-featured.png
 tags: [art, drawing]
 authors: [fabrizio_duroni]
 ---

--- a/src/lib/content/indexable-content.ts
+++ b/src/lib/content/indexable-content.ts
@@ -1,7 +1,8 @@
 import { contentRegistry } from "./registry";
 
 /**
- * Everything the site search indexes, derived from the content registry: an entry appears here exactly
- * when it declares how it is `indexed`.
+ * Everything the site search indexes: the content of every registry entry that declares itself
+ * searchable.
  */
-export const getIndexableContent = () => contentRegistry.flatMap((entry) => entry.indexed?.() ?? []);
+export const getIndexableContent = () =>
+    contentRegistry.filter((entry) => entry.searchable).flatMap((entry) => entry.content?.() ?? []);

--- a/src/lib/content/registry.test.ts
+++ b/src/lib/content/registry.test.ts
@@ -92,8 +92,8 @@ describe("contentRegistry", () => {
     });
 
     describe("search index", () => {
-        it("indexes exactly the entries that carry real content", () => {
-            const indexed = contentRegistry.filter((entry) => entry.indexed).map((entry) => entry.slug);
+        it("indexes exactly the entries that carry searchable content", () => {
+            const indexed = contentRegistry.filter((entry) => entry.searchable).map((entry) => entry.slug);
 
             expect(indexed.sort()).toEqual(
                 [
@@ -113,9 +113,16 @@ describe("contentRegistry", () => {
         it("does not index the aggregate listing pages, whose content lives on the pages they link to", () => {
             [slugs.blog.home, slugs.blog.stats, slugs.videogames.home, slugs.dataStructuresAndAlgorithms.home, "/"].forEach(
                 (slug) => {
-                    expect(entryFor(slug)?.indexed).toBeUndefined();
+                    expect(entryFor(slug)?.searchable).toBeUndefined();
                 },
             );
+        });
+
+        it("keeps mcp, cookie-policy and art out of search while still knowing their content", () => {
+            [slugs.mcp, slugs.cookiePolicy, slugs.art].forEach((slug) => {
+                expect(entryFor(slug)?.searchable).toBeUndefined();
+                expect(entryFor(slug)?.content?.()).toHaveLength(1);
+            });
         });
     });
 });

--- a/src/lib/content/registry.ts
+++ b/src/lib/content/registry.ts
@@ -1,10 +1,7 @@
 import { Content } from "@/types/content/content";
-import { siteMetadata } from "@/types/configuration/site-metadata";
 import { slugs } from "@/types/configuration/slug";
-import { aboutMe } from "./about-me/about-me";
 import {
     dsaExercisesList,
-    dsaRoadmap,
     exercises,
     topics,
 } from "./data-structures-and-algorithms/data-structures-and-algorithms";
@@ -14,7 +11,6 @@ import {
     dsaMarkdown,
     dsaTopicMarkdown,
 } from "./data-structures-and-algorithms/data-structures-and-algorithms-markdown";
-import { easterEggHunt } from "./easter-eggs/easter-eggs";
 import { posts } from "./posts/posts";
 import { blogListingMarkdown, blogPostMarkdown, homepageMarkdown } from "./posts/posts-markdown";
 import { consoles, games } from "./videogames/videogames";
@@ -22,6 +18,7 @@ import { consoleMarkdown, gameMarkdown, videogamesMarkdown } from "./videogames/
 import { contactMarkdown } from "./contact/contact-markdown";
 import { blogStatsMarkdown } from "@/lib/blog-stats/blog-stats-markdown";
 import { mdxPageMarkdown } from "@/lib/mdx/mdx-page-markdown";
+import { createSection } from "./section";
 
 /**
  * One description of a routable piece of content, from which the subsystems that need to enumerate the
@@ -30,7 +27,7 @@ import { mdxPageMarkdown } from "@/lib/mdx/mdx-page-markdown";
  *
  * A single page and a collection share this one shape. A collection supplies `params` (every concrete
  * param set its `slug` template expands to); a page omits it, meaning the template expands to exactly
- * one path. `indexed` is omitted by anything that should not appear in site search.
+ * one path. `content` is what a page actually is; `searchable` says whether it reaches site search.
  */
 export interface ContentRegistryEntry {
     /** Route shape, with dynamic segments in brackets — see `slug-template.ts`. */
@@ -39,14 +36,14 @@ export interface ContentRegistryEntry {
     params?: () => Record<string, string>[];
     /** Markdown for one concrete path; returns null when that path has no content. */
     markdown: (params: Record<string, string>) => string | null;
-    /** What this entry contributes to the search index. Omitted when it is not indexed. */
-    indexed?: () => Content[];
     /**
-     * Image for this entry in the sitemap. Only needed by entries that are not `indexed`, since an
-     * indexed entry takes its image from the content's own frontmatter; the rest fall back to the
-     * site's featured image.
+     * The content behind this entry, for the entries that have some. It is what supplies each page its
+     * real title, date and image, so anything derived from content reads it here rather than being told
+     * the same values a second time. Omitted by aggregate pages, which have no content of their own.
      */
-    sitemapImage?: string;
+    content?: () => Content[];
+    /** Whether this entry's content belongs in site search. */
+    searchable?: boolean;
 }
 
 const paramsOf = (section: { list: () => Content[] }) => () => section.list().map((item) => item.slug.params);
@@ -58,6 +55,20 @@ const singleItem = (section: { single: () => Content | undefined }) => () => {
 };
 
 /**
+ * A page backed by a standard `src/content/<slug>/content.mdx`: its markdown comes from the generic
+ * generator and its content from the file, so registering one is a single call.
+ */
+const mdxPage = (slug: string): ContentRegistryEntry => {
+    const section = createSection({ slug });
+
+    return {
+        slug,
+        markdown: () => mdxPageMarkdown(slug),
+        content: singleItem(section),
+    };
+};
+
+/**
  * Single pages come first so that an exact literal slug always wins over a collection template of the
  * same length (`/videogames/console/games` must not be read as a console named "games").
  */
@@ -66,55 +77,53 @@ export const contentRegistry: ContentRegistryEntry[] = [
     { slug: slugs.blog.home, markdown: blogListingMarkdown },
     { slug: slugs.blog.stats, markdown: blogStatsMarkdown },
     { slug: slugs.contact, markdown: contactMarkdown },
-    { slug: slugs.aboutMe, markdown: () => mdxPageMarkdown(slugs.aboutMe), indexed: singleItem(aboutMe) },
-    { slug: slugs.mcp, markdown: () => mdxPageMarkdown(slugs.mcp) },
-    { slug: slugs.cookiePolicy, markdown: () => mdxPageMarkdown(slugs.cookiePolicy) },
-    { slug: slugs.art, markdown: () => mdxPageMarkdown(slugs.art), sitemapImage: siteMetadata.featuredArtImage },
-    {
-        slug: slugs.easterEggHunt,
-        markdown: () => mdxPageMarkdown(slugs.easterEggHunt),
-        indexed: singleItem(easterEggHunt),
-    },
+    { ...mdxPage(slugs.aboutMe), searchable: true },
+    mdxPage(slugs.mcp),
+    mdxPage(slugs.cookiePolicy),
+    mdxPage(slugs.art),
+    { ...mdxPage(slugs.easterEggHunt), searchable: true },
     { slug: slugs.dataStructuresAndAlgorithms.home, markdown: dsaMarkdown },
-    {
-        slug: slugs.dataStructuresAndAlgorithms.roadmap,
-        markdown: () => mdxPageMarkdown(slugs.dataStructuresAndAlgorithms.roadmap),
-        indexed: singleItem(dsaRoadmap),
-    },
+    { ...mdxPage(slugs.dataStructuresAndAlgorithms.roadmap), searchable: true },
     {
         slug: slugs.dataStructuresAndAlgorithms.exercises,
         markdown: dsaExercisesListMarkdown,
-        indexed: singleItem(dsaExercisesList),
+        content: singleItem(dsaExercisesList),
+        searchable: true,
     },
     { slug: slugs.videogames.home, markdown: videogamesMarkdown },
     {
         slug: slugs.blog.blogPost,
         params: paramsOf(posts),
         markdown: blogPostMarkdown,
-        indexed: posts.list,
+        content: posts.list,
+        searchable: true,
     },
     {
         slug: slugs.dataStructuresAndAlgorithms.topic,
         params: paramsOf(topics),
         markdown: dsaTopicMarkdown,
-        indexed: topics.list,
+        content: topics.list,
+        searchable: true,
     },
     {
         slug: slugs.dataStructuresAndAlgorithms.exercise,
         params: paramsOf(exercises),
         markdown: dsaExerciseMarkdown,
-        indexed: exercises.list,
+        content: exercises.list,
+        searchable: true,
     },
     {
         slug: slugs.videogames.console,
         params: paramsOf(consoles),
         markdown: consoleMarkdown,
-        indexed: consoles.list,
+        content: consoles.list,
+        searchable: true,
     },
     {
         slug: slugs.videogames.game,
         params: paramsOf(games),
         markdown: gameMarkdown,
-        indexed: games.list,
+        content: games.list,
+        searchable: true,
     },
 ];

--- a/src/lib/content/registry.ts
+++ b/src/lib/content/registry.ts
@@ -1,4 +1,5 @@
 import { Content } from "@/types/content/content";
+import { siteMetadata } from "@/types/configuration/site-metadata";
 import { slugs } from "@/types/configuration/slug";
 import { aboutMe } from "./about-me/about-me";
 import {
@@ -40,6 +41,12 @@ export interface ContentRegistryEntry {
     markdown: (params: Record<string, string>) => string | null;
     /** What this entry contributes to the search index. Omitted when it is not indexed. */
     indexed?: () => Content[];
+    /**
+     * Image for this entry in the sitemap. Only needed by entries that are not `indexed`, since an
+     * indexed entry takes its image from the content's own frontmatter; the rest fall back to the
+     * site's featured image.
+     */
+    sitemapImage?: string;
 }
 
 const paramsOf = (section: { list: () => Content[] }) => () => section.list().map((item) => item.slug.params);
@@ -62,7 +69,7 @@ export const contentRegistry: ContentRegistryEntry[] = [
     { slug: slugs.aboutMe, markdown: () => mdxPageMarkdown(slugs.aboutMe), indexed: singleItem(aboutMe) },
     { slug: slugs.mcp, markdown: () => mdxPageMarkdown(slugs.mcp) },
     { slug: slugs.cookiePolicy, markdown: () => mdxPageMarkdown(slugs.cookiePolicy) },
-    { slug: slugs.art, markdown: () => mdxPageMarkdown(slugs.art) },
+    { slug: slugs.art, markdown: () => mdxPageMarkdown(slugs.art), sitemapImage: siteMetadata.featuredArtImage },
     {
         slug: slugs.easterEggHunt,
         markdown: () => mdxPageMarkdown(slugs.easterEggHunt),

--- a/src/types/configuration/site-metadata.ts
+++ b/src/types/configuration/site-metadata.ts
@@ -4,7 +4,6 @@ export const siteMetadata = {
     description: "Official blog chicio coding. Property of Fabrizio Duroni. Main skills: mobile application development, computer graphics, web development.",
     siteUrl: "https://www.fabrizioduroni.it",
     featuredImage: "/chicio-coding-feature-graphic.jpg",
-    featuredArtImage: "/chicio-art-featured.png",
     author: "Fabrizio Duroni",
     contacts: {
         links: {


### PR DESCRIPTION
## The gaps

Follows #487 (Tier 2, the content registry). The sitemap listed its pages by hand, so it had drifted from what the site actually publishes. Comparing it against the registry surfaced **22 missing URLs** — and reviewing it surfaced **two broken image paths**.

**Registry entries the sitemap never announced (6):**

| Missing | Why it matters |
|---|---|
| `/videogames` | collection landing page |
| `/data-structures-and-algorithms` | course landing page |
| `/mcp` | real content page |
| `/contact` | real page |
| `/blog/stats` | real page |
| `/cookie-policy` | low value, included for consistency |

**Author routes absent since they were built (16):** `/blog/authors` plus all 15 author pages.

## The broken art image

Three paths were in play for the art featured image, and only one was a real file:

```
siteMetadata.featuredArtImage   /chicio-art-featured.png                     404
art/content.mdx frontmatter     /media/content/chicio-art-featured.png       404
the actual file                 /media/content/art/chicio-art-featured.png    ok
```

The frontmatter was missing the `art/` segment that the media copy step adds, so the art page has been advertising a missing image. Fixed in frontmatter — the one place it belongs — and `featuredArtImage` is deleted, having had no other reader.

## The change

The content half of the sitemap derives from `contentRegistry` — the record of what real content exists — so a section reaches the sitemap by being registered rather than by someone remembering.

`indexed` splits into two fields that were conflated:

- **`content`** — what this entry actually is, supplying its real title, date and image
- **`searchable`** — whether that content reaches site search

That split is what lets pages outside search still use their own frontmatter. Previously `mcp`, `cookie-policy` and `art` had to report a build timestamp and the default image despite having real MDX; they now carry their own dates (mcp `2026-04-24`, cookie-policy `2017-11-19`, art `2018-11-14`). Registering an MDX page is now a single `mdxPage(slug)` call, supplying its slug, markdown and content together.

**The post-derived listings stay explicit** — pagination, archive, tags, tag pages, and now the author pages are *views over the posts*, with no content of their own. That's the same boundary the registry draws for the MCP tools: it describes content, not every route.

## Verification

```
sitemap:      622 URLs -> 644    ADDED 22    REMOVED 0
search index: 543 documents -> 543    added []    removed []
/art image:   /media/content/art/chicio-art-featured.png -> EXISTS
```

Homepage keeps its bare URL with no trailing slash. Gates: lint · validate-architecture · knip · typecheck · **1435 tests** · build (1214 pages) — all green.

The sitemap test runs against a fake registry (same approach as the markdown route test), covering the composition rules: frontmatter dates and images, the fallback for pages with no content, pagination bounds, and that the site owner is excluded from the author pages since his author page is `/about-me`.

## Considered and rejected

Migrating **author records to MDX** — 13 of 17 authors are pure config (name, role, image paths, social URLs), and author definitions are resolved *by id inside `grayMatterContent`*, so moving them would make reading any content file require reading author content first. It's the documented `contact` case: config, not prose. A hybrid (config in TS, prose bios in MDX) remains open as a content *feature* if richer author pages are wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)