### PR TITLE
fix(capabilities): 🐛 repair llms.txt, derive its page list from the registry, raise the coverage floor

### DIFF
--- a/src/app/llms.txt/route.test.ts
+++ b/src/app/llms.txt/route.test.ts
@@ -1,9 +1,10 @@
 import { describe, it, expect, vi } from "vitest";
 
-const { mockListPosts, mockGetTags, mockListDsaTopics } = vi.hoisted(() => ({
+const { mockListPosts, mockGetTags, mockListDsaTopics, mockPageContent } = vi.hoisted(() => ({
     mockListPosts: vi.fn(),
     mockGetTags: vi.fn(),
     mockListDsaTopics: vi.fn(),
+    mockPageContent: vi.fn(),
 }));
 
 vi.mock("@/lib/content/posts/posts", () => ({
@@ -15,7 +16,21 @@ vi.mock("@/lib/content/data-structures-and-algorithms/data-structures-and-algori
     topics: { list: mockListDsaTopics },
 }));
 
+/**
+ * The page list comes from the registry, so a fake one proves the derivation without depending on how
+ * many pages the site currently has. The real registry's contents are asserted in registry.test.ts.
+ */
+vi.mock("@/lib/content/registry", () => ({
+    contentRegistry: [
+        { slug: "/", markdown: vi.fn() },
+        { slug: "/videogames", markdown: vi.fn() },
+        { slug: "/an-mdx-page", markdown: vi.fn(), content: mockPageContent },
+        { slug: "/blog/post/[year]/[month]/[day]/[slug]", markdown: vi.fn(), params: vi.fn(() => []) },
+    ],
+}));
+
 import { GET } from "./route";
+import { siteMetadata } from "@/types/configuration/site-metadata";
 
 const makeFakePost = (slug: string, title: string) => ({
     slug: { formatted: `/blog/post/2024/01/01/${slug}` },
@@ -94,6 +109,55 @@ describe("GET /llms.txt", () => {
             const text = await response.text();
             expect(text).toContain("typescript");
             expect(text).toContain("7 posts");
+        });
+
+        it("links every single page the registry knows about, so a registered section is advertised", async () => {
+            mockListPosts.mockReturnValue([]);
+            mockGetTags.mockReturnValue([]);
+            mockListDsaTopics.mockReturnValue([]);
+            mockPageContent.mockReturnValue([]);
+
+            const text = await (await GET()).text();
+
+            expect(text).toContain(`(${siteMetadata.siteUrl}/videogames)`);
+            expect(text).toContain(`(${siteMetadata.siteUrl}/an-mdx-page)`);
+        });
+
+        it("describes an MDX page with its own frontmatter title and description", async () => {
+            mockListPosts.mockReturnValue([]);
+            mockGetTags.mockReturnValue([]);
+            mockListDsaTopics.mockReturnValue([]);
+            mockPageContent.mockReturnValue([
+                { slug: { formatted: "/an-mdx-page", params: {} }, frontmatter: { title: "Real Title", description: "Real description" } },
+            ]);
+
+            const text = await (await GET()).text();
+
+            expect(text).toContain("[Real Title]");
+            expect(text).toContain("Real description");
+        });
+
+        it("links the homepage without a trailing slash, and never stringifies a slug object", async () => {
+            mockListPosts.mockReturnValue([]);
+            mockGetTags.mockReturnValue([]);
+            mockListDsaTopics.mockReturnValue([]);
+            mockPageContent.mockReturnValue([]);
+
+            const text = await (await GET()).text();
+
+            expect(text).toContain(`[Home](${siteMetadata.siteUrl})`);
+            expect(text).not.toContain("[object Object]");
+        });
+
+        it("does not expand a collection template into a page link", async () => {
+            mockListPosts.mockReturnValue([]);
+            mockGetTags.mockReturnValue([]);
+            mockListDsaTopics.mockReturnValue([]);
+            mockPageContent.mockReturnValue([]);
+
+            const text = await (await GET()).text();
+
+            expect(text).not.toContain("[year]");
         });
 
         it("lists DSA topics with links", async () => {

--- a/src/app/llms.txt/route.ts
+++ b/src/app/llms.txt/route.ts
@@ -1,9 +1,43 @@
 import { topics } from "@/lib/content/data-structures-and-algorithms/data-structures-and-algorithms";
 import { posts, getTags } from "@/lib/content/posts/posts";
+import { contentRegistry } from "@/lib/content/registry";
 import { siteMetadata } from "@/types/configuration/site-metadata";
 import { slugs } from "@/types/configuration/slug";
 
-export const dynamic = 'force-static';
+export const dynamic = "force-static";
+
+/**
+ * Labels for the pages that aggregate other content and so have no frontmatter of their own. Every
+ * other page describes itself through its MDX, and nothing needs listing here to be announced: the page
+ * list comes from the content registry, so a registered section is an advertised one.
+ */
+const aggregatePageLabels: Record<string, { title: string; description: string }> = {
+    "/": { title: "Home", description: "Landing page with latest posts and featured content" },
+    [slugs.blog.home]: { title: "Blog", description: "Technical articles and tutorials" },
+    [slugs.blog.stats]: { title: "Blog Stats", description: "Publishing history and blog statistics" },
+    [slugs.contact]: { title: "Contact", description: "Get in touch with Fabrizio" },
+    [slugs.dataStructuresAndAlgorithms.home]: {
+        title: "Data Structures & Algorithms",
+        description: "A structured course covering data structures, algorithms and problem-solving techniques",
+    },
+    [slugs.videogames.home]: {
+        title: "Videogames",
+        description: "Personal videogame console and game collection",
+    },
+};
+
+const mainPages = (): string =>
+    contentRegistry
+        .filter((entry) => !entry.params)
+        .map((entry) => {
+            const [content] = entry.content?.() ?? [];
+            const label = aggregatePageLabels[entry.slug];
+            const title = content?.frontmatter.title ?? label?.title ?? entry.slug;
+            const description = content?.frontmatter.description ?? label?.description ?? "";
+
+            return `- [${title}](${siteMetadata.siteUrl}${entry.slug === "/" ? "" : entry.slug}): ${description}`;
+        })
+        .join("\n");
 
 export async function GET() {
     const allPosts = posts.list();
@@ -16,16 +50,15 @@ export async function GET() {
 
 This website contains technical blog posts about software engineering, computer graphics, mobile development, and web development, along with interactive tutorials on data structures and algorithms.
 
+Every page is also available as Markdown: request it with the \`Accept: text/markdown\` header, or fetch ${siteMetadata.siteUrl}/markdown followed by the page path.
+
 ## Main Pages
 
-- [Home](${siteMetadata.siteUrl}): Landing page with latest posts and featured content
-- [Blog](${siteMetadata.siteUrl}${slugs.blog}): Main blog section with technical articles and tutorials
+${mainPages()}
 - [Blog Archive](${siteMetadata.siteUrl}${slugs.blog.blogArchive}): Complete chronological archive of all blog posts
 - [Blog Tags](${siteMetadata.siteUrl}${slugs.blog.tags}): Browse all available topic tags
+- [Blog Authors](${siteMetadata.siteUrl}${slugs.blog.authors}): The people who write here
 - [Chat](${siteMetadata.siteUrl}${slugs.chat}): AI-powered chat interface to discuss blog content
-- [Art](${siteMetadata.siteUrl}${slugs.art}): Creative and artistic projects showcase
-- [About Me](${siteMetadata.siteUrl}${slugs.aboutMe}): Author bio and professional background
-- [Cookie Policy](${siteMetadata.siteUrl}${slugs.cookiePolicy}): Privacy and cookie usage information
 
 ## Blog Posts
 
@@ -34,7 +67,7 @@ Articles with descriptions:
 ${allPosts
     .map(
         (post) =>
-            `- [${post.frontmatter.title}](${siteMetadata.siteUrl}${post.slug.formatted}): ${post.frontmatter.description}`
+            `- [${post.frontmatter.title}](${siteMetadata.siteUrl}${post.slug.formatted}): ${post.frontmatter.description}`,
     )
     .join("\n")}
 
@@ -43,22 +76,31 @@ ${allPosts
 Browse posts by topic/tags:
 
 ${tags
-    .map((tag) => `- [${tag.tagValue}](${siteMetadata.siteUrl}${tag.slug}): ${tag.count} ${tag.count === 1 ? "post" : "posts"}`)
-    .join("\n")}    
+    .map(
+        (tag) =>
+            `- [${tag.tagValue}](${siteMetadata.siteUrl}${tag.slug}): ${tag.count} ${tag.count === 1 ? "post" : "posts"}`,
+    )
+    .join("\n")}
 
 ## Data Structures & Algorithms
 
 Interactive tutorials and educational content on fundamental computer science concepts:
 
-${topics.list()
-    .map((topic) => `- [${topic.frontmatter.title}](${siteMetadata.siteUrl}${topic.slug.formatted}): ${topic.frontmatter.description}`)
+${topics
+    .list()
+    .map(
+        (topic) =>
+            `- [${topic.frontmatter.title}](${siteMetadata.siteUrl}${topic.slug.formatted}): ${topic.frontmatter.description}`,
+    )
     .join("\n")}
 
 ## Additional Information:
 
-- [Blog Pagination](${siteMetadata.siteUrl}${slugs.blog.blogPostsPage}/2): Browse posts page by page. Pay attention that the first page is just ${siteMetadata.siteUrl}${slugs.blog.blogPostsPage}.
-- Blog post URLs follow the pattern: ${siteMetadata.siteUrl}${slugs.blog.blogPost}/YYYY/MM/DD/slug
+- [Blog Pagination](${siteMetadata.siteUrl}${slugs.blog.blogPostsPage}/2): Browse posts page by page. Pay attention that the first page is just ${siteMetadata.siteUrl}${slugs.blog.home}.
+- Blog post URLs follow the pattern: ${siteMetadata.siteUrl}/blog/post/YYYY/MM/DD/slug
 - Tag URLs follow the pattern: ${siteMetadata.siteUrl}${slugs.blog.tag}/tag-name
+- Videogame URLs follow the pattern: ${siteMetadata.siteUrl}/videogames/console/console-name, then /game/game-name for a single game
+- DSA exercise URLs follow the pattern: ${siteMetadata.siteUrl}/data-structures-and-algorithms/topic/topic-name/exercise/exercise-name
 `;
 
     return new Response(content, {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -18,10 +18,10 @@ export default defineConfig({
             provider: "v8",
             reporter: ["text", "json-summary"],
             thresholds: {
-                statements: 64,
-                branches: 59,
-                functions: 61,
-                lines: 65,
+                statements: 91,
+                branches: 84,
+                functions: 88,
+                lines: 92,
             },
             include: ["src/lib/**", "src/components/design-system/**"],
             // Matrix CG/canvas effects cannot run in jsdom, so they are excluded from


### PR DESCRIPTION
## The bugs

`llms.txt` is the file that tells AI agents where things are, and it was shipping a broken link plus an out-of-date map of the site.

**1. A published `[object Object]`** — `${slugs.blog}` interpolated the slug *object*:

```
- [Blog](https://www.fabrizioduroni.it[object Object]): Main blog section with...
```

**2. A nonsense URL pattern** — `${slugs.blog.blogPost}/YYYY/MM/DD/slug` appended to a slug that already contains the template:

```
- Blog post URLs follow the pattern: .../blog/post/[year]/[month]/[day]/[slug]/YYYY/MM/DD/slug
```

**3. Six pages missing:** `/videogames`, `/data-structures-and-algorithms`, `/mcp`, `/contact`, `/blog/stats`, `/easter-egg-hunt`. The DSA course home only *looked* present because topic URLs share its prefix.

## The cause, and the fix

The same drift the sitemap had in #489, from the same cause: a hand-written list of what the site contains, sitting next to a registry that already knows.

The Main Pages list now derives from `contentRegistry`, so **a registered section is an advertised one**. Each MDX page describes itself with its own frontmatter title and description instead of a second copy written here; only the aggregate pages, which have no frontmatter, keep a label in this file.

Also added: a pointer telling agents the `/markdown` endpoint exists, a `/blog/authors` link, and the videogame and DSA-exercise URL shapes.

## Coverage floor raised

`.claude/rules/testing.md` says *"Raise the floor whenever tests improve coverage; never lower it."* It hadn't been raised since 2026-06-28 and was ~27 points stale after this stream of work:

```
floor:  64 / 59 / 61 / 65   ->   91 / 84 / 88 / 92
actual: 91.94 / 84.39 / 89.23 / 92.49
```

## Tests

Four new cases on the derivation: that every registry single page is linked, that an MDX page uses its own frontmatter, that the homepage has no trailing slash and the output **never contains `[object Object]`**, and that a collection template is not expanded into a page link.

## Verification note

lint, validate-architecture, knip, typecheck and coverage all pass locally. **`build` could not run** — the machine ran out of disk part-way through, so the generated `llms.txt` is unverified locally and CI is covering it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `/llms.txt` endpoint now dynamically lists available pages and uses page titles and descriptions when provided.
  * Added Markdown access guidance for listed pages.
  * Expanded URL pattern information for blog posts, videogames, and DSA exercises.
  * Improved homepage linking and prevents collection templates from appearing as concrete pages.

* **Tests**
  * Added coverage for dynamic page listings, MDX metadata, URL formatting, and collection handling.
  * Increased test coverage requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->