### PR TITLE
content: 🔤 add section headings to 24 previously headingless posts

### DIFF
--- a/src/content/blog/post/2017/05/13/first-threejs-scene/content.mdx
+++ b/src/content/blog/post/2017/05/13/first-threejs-scene/content.mdx
@@ -30,6 +30,8 @@ the end of this post you will have a scene like the one in the following image:
 
 ![The 3D scene that you will get at the end of the following tutorial on threejs](/media/content/blog/post/2017/05/13/first-threejs-scene/threejs-scene.jpg)
 
+## The setup
+
 The mesh We will use are a simplified version of the ones available from
 the [Stanford scan repository](https://graphics.stanford.edu/data/3Dscanrep/
 "Stanford scan repository") in PLY format.  
@@ -61,6 +63,8 @@ below). We will put our assets (mesh, textures etc.) in the folder `/assets/mode
 </body>
 </html>
 ```
+
+## The scene, the camera, and the renderer
 
 The first thing we will need to create is a `Scene`. We will also need to create a `Camera`, a `TextureLoader` for
 texture loading, a `PLYLoader` to load our PLY meshes and a `WebGLRenderer`. Finally we will need an instance
@@ -142,6 +146,8 @@ function createOrbitsControls(camera, renderer) {
 }
 ```
 
+## The lights
+
 Now we can add the renderer to the DOM (we attach it to the body) of the page. We can now start to customize the scene
 by setting the background color to indaco (0x303F9F) (remember: the recommended way to set color in three.js is by HEX
 value). We can then add the main light and the hemisphere light.
@@ -208,6 +214,8 @@ function createHemisphereLight() {
   return new THREE.HemisphereLight(0x303F9F, 0x000000, 1);
 }
 ```
+
+## The models
 
 Now we can start to add the stars, the PLY mesh models and the floor mesh model. Each mesh model is added to the scene
 at the end of its load method.
@@ -373,6 +381,8 @@ function loadFloor(textureLoader, completionFunction) {
 }
 ```
 
+## The rendering loop
+
 We are ready to render our scene. We just need to create
 the [rendering loop](https://gameprogrammingpatterns.com/game-loop.html "rendering loop") with the following code:
 
@@ -384,6 +394,8 @@ var render = function() {
   renderer.render(scene, camera);
 };
 ```
+
+## Conclusion
 
 You can find the entire scene code is [this github gist](https://gist.github.com/chicio/af13397f22c21a05b6ac007c83f84403).  
 Yeah!!! You made it!! You create a 3D computer graphics web application using three.js :blush:!! And it is also a scene

--- a/src/content/blog/post/2017/08/11/model-view-presenter-architecture-ios-swift-unit-test/content.mdx
+++ b/src/content/blog/post/2017/08/11/model-view-presenter-architecture-ios-swift-unit-test/content.mdx
@@ -39,6 +39,8 @@ use it in all my code. Below you can find a mockup of what we want to achieve.
 
 ![A mockup of the final app we will obtain at the end of this post](/media/content/blog/post/2017/08/11/model-view-presenter-architecture-ios-swift-unit-test/mockup-model-view-presenter.jpg)
 
+## The model and the repository
+
 Let's start by creating a `Product` struct that we will use to describe our products. Each product will be composed of a
 name, a description and an image (identified by its name):
 
@@ -130,6 +132,8 @@ class ProductsRepositoryTests: XCTestCase {
     }
 }
 ```
+
+## The presenter
 
 Now it's time to develop our `ProductsPresenter` presenter. It will need a view to which it will delegate the real user
 interface operation and the Repository to retrieve the products data. It will be responsible to manage:
@@ -313,6 +317,8 @@ class ProductsPresenterTests: XCTestCase {
 }
 ```
 
+## The view controller
+
 It easy to see that the unit tests for our presenter describe the entire presentation flow. This basically means that
 our unit tests are the documentation of our presentation logic. Cool!!!! :sunglasses:
 Now the next big question is: who is going to implement our `ProductsView` protocol? As we said in the introduction, our
@@ -406,6 +412,8 @@ class ProductsViewController: UIViewController, UITableViewDataSource, UITableVi
     }
 }
 ```
+
+## The product detail
 
 You don't need unit tests for the controller: the presenter unit tests assure that our presentation logic is the one
 expected. The view controller is only updating iOS specific User Interface components (something we hope Apple tested
@@ -556,6 +564,8 @@ class ProductDetailViewController: UIViewController, ProductDetailView {
     }
 }
 ```
+
+## Conclusion
 
 Yeah you made it!! You're at the end of this never ending post :satisfied:!!  
 Now you can start to create your high quality unit tested apps :relieved:. One final note about the implementation

--- a/src/content/blog/post/2018/01/03/scene-kit-physically-based-rendering/content.mdx
+++ b/src/content/blog/post/2018/01/03/scene-kit-physically-based-rendering/content.mdx
@@ -34,6 +34,8 @@ end of this post you will be able to render the scene contained in the image bel
 
 ![A physically based scene created using SceneKit](/media/content/blog/post/2018/01/03/scene-kit-physically-based-rendering/physically-based-rendering-scene-right.jpg)
 
+## The lights and the lighting environment
+
 The general approach used in the construction of the scene will be the following: for each main scene category component
 we will create a class that encapsulate the creation of the corresponding `SCNNode`, the base SceneKit unit element, and
 its setup to obtain the feature we want.  
@@ -157,6 +159,8 @@ class PhysicallyBasedLightingEnviroment {
 }
 ```
 
+## The camera
+
 Next step: the camera. We create a `Camera` class, that will contain a reference, again, to a `SCNNode` on which
 an `SCNCamera` has been defined. For the camera we need to set first of all some geometric properties like the position,
 rotation and the pivot point that we will use as reference for the animation of the camera. Last but not least we set
@@ -195,6 +199,8 @@ class Camera {
     }
 }
 ```
+
+## The objects and the materials
 
 Now it's time to think about the objects we want to display in the scene. For that reason we create a `Object` class
 that will represent each kind of object we want to show in the scene. Obviously as for the previous classes, also
@@ -294,6 +300,8 @@ class PhysicallyBasedMaterial {
     }
 }
 ```
+
+## The scene
 
 Now it's time to construct our scene :relieved:!! We start by creating a new class `PhysicallyBasedScene`, subclass
 of `SCNScene`. In this way we can customize the default initializer with the step needed to add all the element of our
@@ -482,6 +490,8 @@ We are ready to render our scene. Assign an instance of our `PhysicallyBasedScen
 results of our work. Below you can find a video of the scene we created.
 
 <Youtube videoId="yDMdAtv-3Bg" />
+
+## Conclusion
 
 That's it!! You've made it!! Now you can show to your friends your physically based scene and be proud of it :
 sunglasses:. You can find this example with other scenes

--- a/src/content/blog/post/2018/01/31/blender-tutorial-1-user-interface/content.mdx
+++ b/src/content/blog/post/2018/01/31/blender-tutorial-1-user-interface/content.mdx
@@ -18,6 +18,8 @@ free in the market. In this series of posts I will guide you through its feature
 list. At the time of this writing the available version of Bender used for this tutorials is the 2.79. All the tutorials
 are written using Blender on a MacBook Pro. Let's start from the user interface.
 
+## The editors
+
 The default layout is composed of individual panels, and inside each one of them we can find an editor. The main editors
 are:
 
@@ -37,6 +39,8 @@ We can switch a panel from one editor to another by clicking on the icon that sh
 with all the available editors will be shown and we can choose one of them.
 
 ![The switch editor](/media/content/blog/post/2018/01/31/blender-tutorial-1-user-interface/blender-ui-2-switch-editor.jpg)
+
+## The 3D window
 
 On the left side of the viewport we can find a series of tabs that contain some operations, tools and actions we can
 apply to the 3D window content. This tabs will change based on the fact that we selected or not an object and also based
@@ -63,6 +67,8 @@ The menus on the left of the editing mode selector will change accordingly to th
 
 ![The 3D window editor](/media/content/blog/post/2018/01/31/blender-tutorial-1-user-interface/blender-ui-3-3Dwindow.jpg)
 
+## Navigating the 3D space
+
 To navigate in the 3D space, usually Blender require a 3 button mouse (we will see below how to emulate a 3 buttons
 mouse). Anyway, as we're on a MacBook pro we can do the following basic operation with the "alternative" default
 mapping:
@@ -77,6 +83,8 @@ There are also some other basic useful 3D navigation commands:
   Center Cursor*)
 * align view to one side with the options *Left, Right, Top, Bottom, Front, Back* contained in the *View menu*
 * change between orthographic and perspective view with the menu option *View -> View Persp/Ortho*
+
+## User preferences
 
 You can change the user preferences by going to *File -> User Preferences*. Here you can modify settings for:
 

--- a/src/content/blog/post/2018/02/17/blender-tutorial-2-selecting-transforming-objects/content.mdx
+++ b/src/content/blog/post/2018/02/17/blender-tutorial-2-selecting-transforming-objects/content.mdx
@@ -25,6 +25,8 @@ cube is the last object selected.
 
 ![Object selection in Blender](/media/content/blog/post/2018/02/17/blender-tutorial-2-selecting-transforming-objects/blender-selecting-objects-1.jpg)
 
+## Selecting objects
+
 To deselect an object we can just right click on it again. We can also **select all the objects** in a scene, including
 cameras and lights, by pressing the *"a" key*.  
 There's also a select menu that gives us more control over the selections we can do. In particular, we have the **Circle
@@ -33,6 +35,8 @@ select objects based on a squared pattern of selection. There are also other opt
 the current selection.
 
 ![Selection menu in Blender](/media/content/blog/post/2018/02/17/blender-tutorial-2-selecting-transforming-objects/blender-selecting-objects-2.jpg)
+
+## Translating objects
 
 To **translate objects**, we can use the transform tools. We can find them under *Tools -> Transform*. As a consequence
 of the fact that we are trying to translate an object in 3D space using the mouse pointer that works in 2D space, it is
@@ -52,6 +56,8 @@ you will see three axes. Drag one of them to translate the object in that direct
 
 ![Moving objects in Blender](/media/content/blog/post/2018/02/17/blender-tutorial-2-selecting-transforming-objects/blender-translating-objects-2.jpg)
 
+## Rotating and scaling objects
+
 We can rotate and scaling an object using the same tools we used for the translation:
 
 * the transformation tools
@@ -62,6 +68,8 @@ defines the orientation of the transform operation. This is very important becau
 transform operation. You can change the transform orientation in the 3D manipulator widget.
 
 ![3D manipulator widget](/media/content/blog/post/2018/02/17/blender-tutorial-2-selecting-transforming-objects/blender-translating-objects-3.jpg)
+
+## Origin and pivot point
 
 The 3D manipulator widget will place the start of the **transform based on the origin of an objects**. We can **change
 it** by selecting one of the option under Object -> Transform in object mode:
@@ -79,6 +87,8 @@ selection. We can choose it by selecting one of the option available from the li
 widget.
 
 ![Pivot Change](/media/content/blog/post/2018/02/17/blender-tutorial-2-selecting-transforming-objects/blender-change-pivot-objects-1.jpg)
+
+## Conclusion
 
 That's all for selection and transform of objects. In the next post we will start to explore the art of modeling in
 Blender.

--- a/src/content/blog/post/2018/03/02/code-review-whats-it-is-and-why-it-is-important/content.mdx
+++ b/src/content/blog/post/2018/03/02/code-review-whats-it-is-and-why-it-is-important/content.mdx
@@ -37,6 +37,8 @@ with another [definition](http://codingdojo.org/WhatIsCodingDojo/ "coding dojo")
 
 > A Coding Dojo is a meeting where a bunch of coders get together to work on a programming challenge. They have fun and they engage in order to improve their skills.
 
+## The Minesweeper problem
+
 During the dojo that I attended with Angelo we tried to resolve
 the [Minesweeper problem](http://codingdojo.org/kata/Minesweeper/ "Minesweeper"). Basically we had to write an automatic
 Minesweeper resolver (do you remember the Windows game? :heart_eyes:). At the end of the dojo we didn't complete the
@@ -57,6 +59,8 @@ This one describes Angelo's implementation.
 
 ![Class diagram of Angelo Sciarra implementation of minesweeper](/media/content/blog/post/2018/03/02/code-review-whats-it-is-and-why-it-is-important/minesweeper-angelo.jpg)
 
+## Technology suggestions
+
 So let's start to see which kind of observation I received from Angelo, that basically include most of the observation
 you could receive during a code review. The first observation I received from Angelo is about the java JDK version I
 used for my project. I did the setup of the project using JDK 1.5 instead of JDK 1.8 (as you may know, this is a more
@@ -72,6 +76,8 @@ knowledge you can absorb from the experience of your code reviewer.
 ![Functional improvements to the original class](/media/content/blog/post/2018/03/02/code-review-whats-it-is-and-why-it-is-important/03-functional-field.jpg)
 
 ![A new field class has been introduced to describe a list of fields](/media/content/blog/post/2018/03/02/code-review-whats-it-is-and-why-it-is-important/04-new-fields-class.jpg)
+
+## Software design
 
 Another important aspect that is one of the main subject of the code review is software design. In fact Angelo
 discovered a series of improvement and refactoring opportunities in my code:
@@ -91,6 +97,8 @@ discovered a series of improvement and refactoring opportunities in my code:
 
 ![A new ParsingContext class keeps the current status of the parsing](/media/content/blog/post/2018/03/02/code-review-whats-it-is-and-why-it-is-important/07-parsing-status-become-parsing-content-lightweight.jpg)
 
+## Code conventions
+
 As you can see from these kind of comments the code review could really improve the general architectural design of your
 application :heart_eyes::relieved:. Code convention are another important thing to check during code review. For example
 Angelo told me to move all the constants at the beginning of some of the classes. Usually tools like Github or Gitlab
@@ -100,11 +108,15 @@ let you discuss your code review by adding comments directly to the code.
 
 ![A comment related to a team guideline](/media/content/blog/post/2018/03/02/code-review-whats-it-is-and-why-it-is-important/06-guidelines.jpg)
 
+## Meaningful names
+
 Last but not least, if you are a real fan of clean code, you know
 that [meaningful names are important](/2017/09/11/clean-code-meaningful-names/ "clean code meaningful names"). So
 you can suggest some more meaningful name for a class, variable or method.
 
 ![An example of using meaningful names](/media/content/blog/post/2018/03/02/code-review-whats-it-is-and-why-it-is-important/10-rename-masker.jpg)
+
+## Conclusion
 
 That's all for code review. I hope you understood how much important it is to do it and how much your codebase can
 improve if you use code review as a validation tool and as a tool to find new refactoring opportunities (anyway, I hope

--- a/src/content/blog/post/2018/04/03/blender-tutorial-3-modeling-basics-part-1/content.mdx
+++ b/src/content/blog/post/2018/04/03/blender-tutorial-3-modeling-basics-part-1/content.mdx
@@ -37,6 +37,8 @@ we can customize the properties of the mesh.
 
 ![How to create primitive meshes](/media/content/blog/post/2018/04/03/blender-tutorial-3-modeling-basics-part-1/blender-modeling-create-primitive-meshes.jpg)
 
+## Selecting vertices, edges and faces
+
 As we said before, we can start from a primitive mesh and model a more complex one. So the first thing we need to learn
 is how we can **select vertices, edges and faces**. How can we do that? First, we need to choose *edit mode*, by
 selecting the mesh and by choosing it from the editing/interaction mode menu component in the 3D window (or alternately
@@ -44,6 +46,8 @@ by pressing the *"tab" key*). After that, we can choose the selection mode betwe
 bar of the 3D window or by pressing *"ctrl + tab" keys*.
 
 ![How to select edges, faces and vertices](/media/content/blog/post/2018/04/03/blender-tutorial-3-modeling-basics-part-1/blender-select-edges-faces-vertices.jpg)
+
+## Modifying a mesh
 
 After selecting the edges, vertices or faces that we want to modify, 3D axis will be shown near your selection. They are
 similar to the ones shown for transformations. By *dragging one of these axes* the selected vertices, edges or faces
@@ -53,6 +57,8 @@ in this way we will be able to **select edges loops**, a series of connected clo
 the selection by using the more/less option to select entire levels of edges/vertices/faces.
 
 ![How to modify a mesh](/media/content/blog/post/2018/04/03/blender-tutorial-3-modeling-basics-part-1/blender-modified-mesh.jpg)
+
+## Proportional editing
 
 By selecting individual edges, vertices and faces you can start modeling you meshes. Anyway, sometimes you will need to
 be able to do a more soft modeling than the one we already described above in this article (for example while working on
@@ -67,5 +73,7 @@ Below you can find an example of two meshes modified with and without the propor
 the difference.
 
 ![Two meshes modified with and without the proportional editing enable](/media/content/blog/post/2018/04/03/blender-tutorial-3-modeling-basics-part-1/blender-modeling-proportional-editing-example.jpg)
+
+## Conclusion
 
 In the next post we will continue to talk about the fundamental of modeling.

--- a/src/content/blog/post/2018/05/08/id3tageditor-swift-read-write-id3-tag-mp3/content.mdx
+++ b/src/content/blog/post/2018/05/08/id3tageditor-swift-read-write-id3-tag-mp3/content.mdx
@@ -20,6 +20,8 @@ how I developed it. Below you can find the library logo.
 
 ![The ID3TagEditor logo](/media/content/blog/post/2018/05/08/id3tageditor-swift-read-write-id3-tag-mp3/id3tageditor-logo.jpg)
 
+## The ID3 tag standard
+
 But before going deeper in the details of ID3TagEditor it useful to know how the ID3 tag standard works (you can find
 the full reference on the [official site](http://id3.org/ "id3 standard")). The definition reported on it for the ID3
 standard is:
@@ -56,6 +58,8 @@ specific frame flags/options and the frame content. Below you can find an exampl
 
 ![An ID3 frame example](/media/content/blog/post/2018/05/08/id3tageditor-swift-read-write-id3-tag-mp3/id3-frame-example.jpg)
 
+## The framework API
+
 Last but not least at the end of the ID3 tag there are also 2 KB of offset (you can see it in the previous images, that
 series of endless `0x00` at the end of the tag :relieved:). How does ID3TagEditor read and write all this information?
 The main api of the framework are two simple methods:
@@ -86,6 +90,8 @@ public func read(from path: String) throws -> ID3Tag?
 public func write(tag: ID3Tag, to path: String, andSaveTo newPath: String? = nil) throws
 
 ```
+
+## Parsing an mp3 file
 
 So the ID3TagEditor framework has two main parts: one for read/parse an mp3 file and one for write an ID3 tag to the mp3
 file.  
@@ -245,6 +251,8 @@ class ID3FrameContentParsingOperationFactory {
 }
 ```
 
+## Writing a new tag
+
 Let's see instead how ID3TagEditor write a new tag to an mp3 file. The creation of the tag is done by
 the `ID3TagCreator` class used inside the `Mp3WithID3TagBuilder` class, the one that execute the real write on the mp3
 file with the new tag on disk. The main function of the `ID3TagCreator` class is `create(id3Tag: ID3Tag) throws -> Data`
@@ -360,6 +368,8 @@ class ID3FrameCreatorsChainFactory {
     }
 }
 ```
+
+## Conclusion
 
 That's it!!! This is the general structure of the ID3TagEditor framework. If you want to discover more about this
 framework you can have a look at [my github repo](https://github.com/chicio/ID3TagEditor "ID3TagEditor repo") and start

--- a/src/content/blog/post/2018/05/09/mp3id3tagger-macos-tag-mp3-id3-rxswift-rxcocoa/content.mdx
+++ b/src/content/blog/post/2018/05/09/mp3id3tagger-macos-tag-mp3-id3-rxswift-rxcocoa/content.mdx
@@ -19,6 +19,8 @@ of [ID3TagEditor](/2018/05/08/id3tageditor-swift-read-write-id3-tag-mp3/). Below
 
 ![The MP3ID3Tagger logo](/media/content/blog/post/2018/05/09/mp3id3tagger-macos-tag-mp3-id3-rxswift-rxcocoa/mp3id3tagger-logo.jpg)
 
+## Model View ViewModel
+
 So how did I develop MP3ID3Tagger? I was about to start the development following the classic approach to develop an app
 on every Apple
 OS: [Model View Controller](https://en.wikipedia.org/wiki/Model%E2%80%93view%E2%80%93controller "Model View Controller")
@@ -40,6 +42,8 @@ are:
 * the *View model*, that usually represents an abstraction of the view exposing public properties and commands.
 * the *Binder* interprets bindings defined in the View, observes the View Model for changes in state and updates the
   View and finally observes the View for changes in state and updates the View Model.
+
+## RxSwift, RxCocoa, and Reactive Extensions
 
 From the definition above we see that the MVVM needs something to bind the view to the view model in a platform
 independent way. This is why we need [RxSwift](https://github.com/ReactiveX/RxSwift "RxSWift")
@@ -66,6 +70,8 @@ components and let us work with generic observable UI component. This basically 
 * the ID3TagEditor will be the Model of the MVVM
 * the ViewModel will connect the View and the ID3TagEditor Model in a platform UI independent way
 
+## Implementation
+
 With this architecture we can also think about using the same Model and ViewModel on different platform. So if in the
 future I will develop an iOS version of Mp3ID3Tagger, I will only have to develop the View part. So let's start to see
 how I implemented Mp3ID3Tagger, the app subject of this post. Let's start from the UI to see how MP3ID3Tagger does look
@@ -74,6 +80,8 @@ button on the left to select the cover and all the textual/numeric values on the
 a list are implemented as `NSPopUpButton` components.
 
 ![The MP3ID3Tagger interface](/media/content/blog/post/2018/05/09/mp3id3tagger-macos-tag-mp3-id3-rxswift-rxcocoa/mp3id3tagger-interface.jpg)
+
+### The view model
 
 The first building block is the `ViewModel` base class. This class is useful to centralize the setup of a `disposeBag`.
 The `DisposeBag` it’s an RxSwift component that keeps a reference to all the `Disposable` you add to it.
@@ -118,6 +126,8 @@ class Mp3ID3TaggerViewModel: ViewModel {
     }
 }
 ```
+
+### The view model collaborators
 
 Now we can see the details of all these collaborators of our view model. Let's start from the `ID3TagReader`. This class
 keeps a reference to an instance of the `ID3TagEditor`. Its main function is `read(_ finish: @escaping (ID3Tag?) -> ()`.
@@ -430,6 +440,8 @@ class AttachedPictureField {
 
 ```
 
+### The view
+
 Now it's time to see the view controller of the app that basically corresponds to the View of the MVVM. Its name
 is `Mp3ID3TaggerViewController`. This controller will implement a protocol I defined: the `BindableView` protocol. This
 protocol represents the View part in the MVVM architecture. This protocol must be implemented only by subclasses of
@@ -575,6 +587,8 @@ class Mp3ID3TaggerViewController: NSViewController, BindableView {
     }
 }
 ```
+
+## Conclusion
 
 We're done with Mp3ID3Tagger. I hope you liked my architectural choices and how I developed it by leveraging the power
 of RxSwift and RxCocoa :sunglasses::relieved:. Obviously don't forget to see

--- a/src/content/blog/post/2018/06/02/blender-tutorial-4-modeling-basics-part-2/content.mdx
+++ b/src/content/blog/post/2018/06/02/blender-tutorial-4-modeling-basics-part-2/content.mdx
@@ -25,6 +25,8 @@ its properties:
 
 ![Sculpting mode](/media/content/blog/post/2018/06/02/blender-tutorial-4-modeling-basics-part-2/blender-sculpting.jpg)
 
+## Edge loop modeling and the extrude tool
+
 Sculpt mode supports also paint textures and strokes. But more important it supports symmetry: by selecting and axis any
 change on one side will be mirrored on the other one.  
 Another interesting option is the **edge loop modeling**. Basically this means that if we select a edge loop with *alt +
@@ -36,11 +38,15 @@ elements selected as a single block. The extrude individual will extrude the ele
 
 ![The extrude tool](/media/content/blog/post/2018/06/02/blender-tutorial-4-modeling-basics-part-2/blender-extrude.jpg)
 
+## Smooth shading
+
 Another useful tool that we can use for modeling is **smooth shading**. We can use these to smooth the surface of
 objects where the polygons of the mesh have too much hard edges. We can find the it under *Tools -> Shading* while an
 object is selected in Object mode or under *Shading -> Faces/Edges/Vertices* while an object is in Edit mode.
 
 ![Smooth shading](/media/content/blog/post/2018/06/02/blender-tutorial-4-modeling-basics-part-2/blender-smooth-shading.jpg)
+
+## Subdividing a mesh
 
 The last tool we can use for some simple modeling is the **subdividing mesh tool**. There are two ways to do
 subdivision:

--- a/src/content/blog/post/2018/07/04/react-native-typescript-existing-app/content.mdx
+++ b/src/content/blog/post/2018/07/04/react-native-typescript-existing-app/content.mdx
@@ -26,6 +26,8 @@ decided to integrated React Native in the existing code base and:
   already had in place for some features (for example the login).
 * write the new stuff completely in React Native whenever possible.
 
+## TypeScript
+
 We also took another important decision when we started the project: we choose TypeScript instead of Javascript as main
 language to write our React Native stuff. What is TypeScript? It is an open-source programming language developed and
 maintained by Microsoft. They describe it on its official website with the following definition:
@@ -42,6 +44,8 @@ show the photo of the day that we will read from the [Nasa open API](https://api
 can find what we will achieve. The first screen is a standard native screen. The second one is a React Native screen.
 
 ![The example react native app we are going to create](/media/content/blog/post/2018/07/04/react-native-typescript-existing-app/react-native-typescript-app-screens.jpg)
+
+## The setup
 
 Let's start to setup our project for React Native and TypesScript. First, React Native integration. For this task we can
 just follow
@@ -140,6 +144,8 @@ module.exports = {
 };
 ```
 
+## The testing infrastructure
+
 That's all for the main source code setup. Now we can start to set up also the testing infrastructure. We will
 use [jest](https://jestjs.io/ "jest"), a testing framework from Facebook,
 and [typemoq](https://github.com/florinn/typemoq "typemoq"), a TypeScript specific mocking library. To use Jest with
@@ -181,6 +187,8 @@ module.exports = {
   ],
 };
 ```
+
+## The app
 
 We are now ready to write our app. Basically the screen that shows the nasa photo is the `NasaPhotoViewerScreen`. This
 component uses `NasaPhotoInformationComponent` and some React Native standard component to show the information that
@@ -291,6 +299,8 @@ const styles = StyleSheet.create({
   }
 });
 ```
+
+## Conclusion
 
 You can check all the code of the sample described above
 in [this github repository](https://github.com/chicio/React-Native-Typescript-Existing-App "React Native Typescript Existing App")

--- a/src/content/blog/post/2018/07/05/distribution-enterprise-app-ios-beta/content.mdx
+++ b/src/content/blog/post/2018/07/05/distribution-enterprise-app-ios-beta/content.mdx
@@ -48,6 +48,8 @@ operation to put in place our beta program:
   store development snapshots of the ipa).
 * Put in place a mini website, configured specifically for the distribution of the beta app.
 
+## The bundle identifier and the provisioning profile
+
 To show you the details and some screenshots of the operation we made I will use a sample project `SampleBetaApp` with
 bundle identifier `it.chicio.SampleBetaApp`.  
 Let's start from the first step: configuration on the Apple developer account for our new enterprise program. As already
@@ -58,6 +60,8 @@ Identities & Profiles" (and maybe there's a high chance that, if you're reading 
 one app on the Apple app store so you already know the stuff to do :smirk:).
 
 ![Certificates, Identities & Profiles section on the developer Apple website](/media/content/blog/post/2018/07/05/distribution-enterprise-app-ios-beta/enterprise-profiles.jpg)
+
+## The beta build configuration
 
 After that we created in our iOS project a new Beta configuration by duplicating the release one. In this way we were
 able to generate an ipa similar to the release one and were also able to customize some settings of our app.
@@ -83,6 +87,8 @@ The Build Setting that we customized are:
   to customize the "Other Swift Flags" field.
 
 ![Set a new beta preprocessor macro](/media/content/blog/post/2018/07/05/distribution-enterprise-app-ios-beta/beta-preprocessor-macro.jpg)
+
+## The build and upload scripts
 
 Then we created the scripts needed to automatize the build on Jenkins and the upload of our artifacts repository to
 Nexus. As I said before we were already using Fastlane to automatize the releases of our app to the store. For the beta
@@ -155,6 +161,8 @@ mvn deploy:deploy-file -DgroupId="<group id project identifier>"
     </dict>
 </plist>
 ```
+
+## The Jenkins job and the beta website
 
 At this moment we were ready to create the new Jenkins job to build our beta. We decided to trigger it using Jenkins
 webhook triggers. In this way we were able to trigger the build and release of a new beta by just calling an url. This
@@ -242,6 +250,8 @@ profile from *Settings -> Profiles & Device Management*. If they don't do it the
 screenshot below.
 
 ![You need to accept the developer certificate before using the app](/media/content/blog/post/2018/07/05/distribution-enterprise-app-ios-beta/enterprise-untrusted-developer.jpg)
+
+## Conclusion
 
 That's it!!! Go to your boss and tell her/him you're ready to create you custom iOS beta internal program!!! :
 sunglasses::apple:

--- a/src/content/blog/post/2018/08/21/blender-tutorial-5-advanced-modeling/content.mdx
+++ b/src/content/blog/post/2018/08/21/blender-tutorial-5-advanced-modeling/content.mdx
@@ -22,6 +22,8 @@ wrench icon*. Here we can select a modifier from the list *Add modifier*.
 
 ![The add modifier feature](/media/content/blog/post/2018/08/21/blender-tutorial-5-advanced-modeling/blender-add-modifier.jpg)
 
+## Modifiers
+
 For example let's try to add a simple deform to a cube. After adding it we see our cube deformed. We can than tweak the
 parameters of the deformation as we prefer. Each modifier as its own properties, based of which type of modification it
 applies to the mesh. Anyway there are some common button to:
@@ -63,6 +65,8 @@ by calculate difference, union and intersection between them.
 
 ![The boolean modifier options](/media/content/blog/post/2018/08/21/blender-tutorial-5-advanced-modeling/blender-boolean-modifier-operation-option.jpg)
 
+## Loop cuts and joining meshes
+
 Another interesting tool is the **"Loop Cut and Slide"**. With this option we can add edge loops to our mesh. This tool
 is useful especially when you need to have more mesh polygon to model the mesh details you want.
 
@@ -77,6 +81,8 @@ apply the join mesh using:
 * *the shortcut "ctrl + j keys"*
 
 ![Join meshes tool](/media/content/blog/post/2018/08/21/blender-tutorial-5-advanced-modeling/blender-join-meshes.jpg)
+
+## Stitching and merging vertices
 
 After joining two or more meshes, we will need to fill the gap between then. We can do that by using the **merge tool**,
 the **remove double tool** and the **snap element tool** to stitch the vertices that are on the border of the meshes.
@@ -98,6 +104,8 @@ appear that will tell us the number of duplicated vertices removed.
 
 ![Merge remove tools](/media/content/blog/post/2018/08/21/blender-tutorial-5-advanced-modeling/blender-merge-remove-tools.jpg)
 
+## Modeling text and vertex groups
+
 In blender it is **possible to model also text**. We can add text by selecting *Add -> Text*. We can modify the text by
 selecting the edit mode: a text cursor will appear so that we can modify the text. In the property panel a special tab
 will let as customize the text property.
@@ -114,5 +122,7 @@ buttons to:
 * *select/deselect the vertices of a group*
 
 ![The vertex group tool](/media/content/blog/post/2018/08/21/blender-tutorial-5-advanced-modeling/blender-vertex-group.jpg)
+
+## Conclusion
 
 In the next post we will discuss about outliner, layers, groups, hierarchies and scenes.

--- a/src/content/blog/post/2018/10/18/blender-tutorial-6-outliner-layers-groups-hierarchies-scenes/content.mdx
+++ b/src/content/blog/post/2018/10/18/blender-tutorial-6-outliner-layers-groups-hierarchies-scenes/content.mdx
@@ -23,6 +23,8 @@ choosing *rename*. To the right of each mesh we have the *restriction column*. I
 
 ![The outliner](/media/content/blog/post/2018/10/18/blender-tutorial-6-outliner-layers-groups-hierarchies-scenes/blender-outliner.jpg)
 
+## Layers
+
 Now let's talk about **layers**. We can find the layer panel at the bottom of the 3D window. Each layer is represented
 with a button similar to a checkbox. We can turn on/off a layer by clicking on their corresponding button. We can add a
 mesh to a specific layer by selecting the layer and creating the mesh we want (primitive or import it). We can also move
@@ -30,11 +32,15 @@ layer by using the *m key* shortcut or by using the menu *Object -> Move to laye
 
 ![The layers panel](/media/content/blog/post/2018/10/18/blender-tutorial-6-outliner-layers-groups-hierarchies-scenes/blender-layers.jpg)
 
+## Groups
+
 Another way to organize our objects is by using **groups**. With groups you can select multiple objects at once. We can
 create groups and add an object to an existing group by using the menu in the property panel or by using the *ctrl + g
 keys* shortcut.
 
 ![Groups, a way to select multiple object at once](/media/content/blog/post/2018/10/18/blender-tutorial-6-outliner-layers-groups-hierarchies-scenes/blender-groups.jpg)
+
+## Scenes
 
 After layers and group we have **scenes**. Scenes allow us to create different set of our objects or new set with new
 object inside our project. We can create and manage scenes by using the outliner and the ad hoc menu at the top of the
@@ -45,11 +51,15 @@ object inside our project. We can create and manage scenes by using the outliner
 
 ![An example of a Blender scene](/media/content/blog/post/2018/10/18/blender-tutorial-6-outliner-layers-groups-hierarchies-scenes/blender-scene.jpg)
 
+## Hierarchies
+
 Last but not least we have **hierarchies**. We can create hierarchies of objects by selecting them and by choosing *
 Object ->  Parent*. Here we can find all the possible type of parental relationships that we can create. After creating
 a hierarchies of objects, they will be shown grouped in the outliner. We will use hierarchies extensively when we will
 talk about animation.
 
 ![Hierarchies of objects](/media/content/blog/post/2018/10/18/blender-tutorial-6-outliner-layers-groups-hierarchies-scenes/blender-hierarchies.jpg)
+
+## Conclusion
 
 In the next post we will talk about materials.

--- a/src/content/blog/post/2019/01/03/swift-package-manager-linux-macos-create-library-executable/content.mdx
+++ b/src/content/blog/post/2019/01/03/swift-package-manager-linux-macos-create-library-executable/content.mdx
@@ -31,6 +31,8 @@ First of all, if you are starting with a new library project, you will use the f
 swift package init --type library
 ```
 
+## The Package.swift file
+
 This command will create all the files and folders you need to develop your library. But in my case, I was working on an
 existing project. This is why I created all the needed files manually and I will describe them in details so you can
 understand better the meaning of each one of them.  
@@ -102,6 +104,8 @@ Let's see in details the meaning of each option:
       of this writing the SPM doesn't support resource bundles**.
 * `swiftLanguageVersions`, that contains the set of supported Swift language versions.
 
+## The test manifests
+
 Next I had to create a `XCTestManifests.swift` file inside the `Tests` folder. This file contains an extension for
 each `XCTestCase` subclass I included in my test target. This extension contains an array `__allTest` that exposes a
 list of all my test methods inside my `XCTestCase` subclasses. At the end of this file you can find a `__allTests()`
@@ -162,6 +166,8 @@ tests += ID3TagEditorTests.__allTests()
 XCTMain(tests)
 ```
 
+## Installing Swift on Linux
+
 Now I was ready to test `ID3TagEditor` using the SPM on macOS and Linux. To do this I used Ubuntu as distro. The distro
 version used at the moment of this writing is the 18.04 LTS.  
 First of all, how do I install Swift on linux? I downloaded the Swift release for Linux from
@@ -183,6 +189,8 @@ tar xzf swift-<VERSION>-<PLATFORM>.tar.gz
 export PATH=/<path to the Swift release folder>/usr/bin:"${PATH}"
 ```
 
+## The demo executable
+
 The setup was done. Now I was able to test  `ID3TagEditor` as a SPM library on Linux. To do this I created a new project
 inside the demo folder of the ID3TagEditor project called `Demo Ubuntu`. This is an executable SPM project that
 has `ID3TagEditor` as package dependencies. The executable is a command line application that opens a mp3 file, parses
@@ -201,6 +209,8 @@ after you execute the `swift run` command.
 ![ID3TagEditor now works as expected on Ubuntu](/media/content/blog/post/2019/01/03/swift-package-manager-linux-macos-create-library-executable/spm-id3tageditor-demo-linux.jpg)
 
 ![ID3TagEditor works as expected also on macOS](/media/content/blog/post/2019/01/03/swift-package-manager-linux-macos-create-library-executable/spm-id3tageditor-demo-macos.jpg)
+
+## Conclusion
 
 Cool! Now the ID3TagEditor is fully compatible with the SPM and could be used in Swift applications for both macOS and
 Linux. You can see the entire codebase of the `ID3TagEditor`

--- a/src/content/blog/post/2019/03/21/blender-tutorial-7-materials/content.mdx
+++ b/src/content/blog/post/2019/03/21/blender-tutorial-7-materials/content.mdx
@@ -18,6 +18,8 @@ To set a material on an object we can select the material tab from the propertie
 
 ![blender create material](/media/content/blog/post/2019/03/21/blender-tutorial-7-materials/blender-create-material.jpg)
 
+## Material types and components
+
 After creating we material a new list of option to customize it appears. We have the possibility to change the
 material's name. We can select the material type. The available options are:
 
@@ -54,6 +56,8 @@ We can assign multiple material to the same objects. To do it we just need to :
 
 ![It is possible to assign multiple material to the same objects](/media/content/blog/post/2019/03/21/blender-tutorial-7-materials/blender-multiple-material.jpg)
 
+## The diffuse and specular components
+
 Now let's star to have a deeper look at the **diffuse component**. As we said before, the diffuse component defines the
 main color of our object. The default shader applied to it is the lambert shader. Lambertian is an ideal diffuse
 reflection that ideally reflect equally the light in all direction. We have also the possibility to choose one of the
@@ -88,6 +92,8 @@ starting values for ramp contains two color, but we can add as many intermediate
 
 ![The ramp material](/media/content/blog/post/2019/03/21/blender-tutorial-7-materials/blender-ramp-material.jpg)
 
+## Shading and reflection
+
 We have also some shading option that we can use to set other to surface components. In particular we can set the
 ambient and emit components using the slider contained in this section. We can also completely turn off the shader by
 using the shadeless option, or using the tangent shading option to create tangent specular highlights.
@@ -106,6 +112,8 @@ the Mirror component. We have some options to customize the final result of our 
 Remember that the mirror material result is visible only in the final render view.
 
 ![The mirror material useful to implement reflection](/media/content/blog/post/2019/03/21/blender-tutorial-7-materials/blender-reflection.jpg)
+
+## Transparency and subsurface scattering
 
 After mirror material we can take a look at the **transparency component**. To make a transparent material we have to
 activate this component. There are 3 option:
@@ -131,5 +139,7 @@ We have some parameter to modify the final result of this component:
 * *blend*
 
 ![Subsurface scattering](/media/content/blog/post/2019/03/21/blender-tutorial-7-materials/blender-subsurface-scattering.jpg)
+
+## Conclusion
 
 In the next post we will talk about textures.

--- a/src/content/blog/post/2019/03/22/blender-tutorial-8-textures-part-1/content.mdx
+++ b/src/content/blog/post/2019/03/22/blender-tutorial-8-textures-part-1/content.mdx
@@ -20,11 +20,15 @@ changes the options displayed: there will be a specific section of properties fo
 
 ![Create a texture](/media/content/blog/post/2019/03/22/blender-tutorial-8-textures-part-1/blender-create-texture.jpg)
 
+## The influence section
+
 In the various section of the texture panel we have the "influence section". This section is very important because it
 let us customize how the texture will affect the final material. This means that we can use textures to change not only
 the final color of the material but also the shading components, geometry, specular highlight and so on.
 
 ![The influence section](/media/content/blog/post/2019/03/22/blender-tutorial-8-textures-part-1/blender-texture-influence.jpg)
+
+## Images and texture mapping
 
 To add the image to be used as texture we have to select the type "Image or movie". After that we can scroll in the
 option of the texture to the Image section and we can choose between create a new image or open an existing one.
@@ -37,6 +41,8 @@ coordinates on the image. By default is set to generated, that means that the co
 the defaults primitives. Then there's the UV option, that maps to coordinates baked into the object.
 
 ![Choose texture mapping](/media/content/blog/post/2019/03/22/blender-tutorial-8-textures-part-1/blender-texture-choose-mapping.jpg)
+
+## The UV editor
 
 Remember that after an images has been selected as texture, it will not be shown in the 3D window if we choose the
 texture visualization unless we load it in the UV editor. To do it choose UV editing layout and load the texture using
@@ -59,10 +65,14 @@ the unwrapped mesh to fit into the texture. After that we will finally see the t
 
 ![Blender texture unwrap b](/media/content/blog/post/2019/03/22/blender-tutorial-8-textures-part-1/blender-texture-unwrap-2.jpg)
 
+## UV projection
+
 We can also create projection mapping using the UV projection. This basically means projecting a sphere, cylinder or a
 cube onto our project to get some rough mapping that we can tweak later. We can find UV projection under Mesh -> UV
 Unwrap -> "Sphere/Cylinder/Cube" projection.
 
 ![Blender uv projection](/media/content/blog/post/2019/03/22/blender-tutorial-8-textures-part-1/blender-uv-projection.jpg)
+
+## Conclusion
 
 In the next post we will talk about other textures technique available in Blender.

--- a/src/content/blog/post/2019/03/23/blender-tutorial-9-textures-part-2/content.mdx
+++ b/src/content/blog/post/2019/03/23/blender-tutorial-9-textures-part-2/content.mdx
@@ -20,6 +20,8 @@ geometry details. It is possible to modify the quality of the map by adjusting t
 
 ![Normal mapping](/media/content/blog/post/2019/03/23/blender-tutorial-9-textures-part-2/blender-normal-mapping.jpg)
 
+## Displacement mapping
+
 Another interesting texture technique useful to add details to our models is the displacement mapping. Instead of
 creating the illusion of additional details, the displacement mapping modifies the geometry of an object. We can
 activate the displacement mapping under the influence section of the texture tab. To obtain better result with the
@@ -27,11 +29,15 @@ displacement mapping, it is useful to apply a subdivision surface modifier to th
 
 ![Displacement mapping](/media/content/blog/post/2019/03/23/blender-tutorial-9-textures-part-2/blender-displacement-mapping.jpg)
 
+## The node editor
+
 One final tool we have for textures is the node editor. With it we can join multiple textures into a single one to
 obtain a more complex texture. We can activate it in a new window by selecting the "Node Editor" visualization. After we
 activate the "Use nodes" option we compose complex texture by adding more node (with the menu at the bottom of the view)
 and we can compose them to obtain our final texture.
 
 ![The node editor](/media/content/blog/post/2019/03/23/blender-tutorial-9-textures-part-2/blender-node-editor.jpg)
+
+## Conclusion
 
 In the next post we will talk about light.

--- a/src/content/blog/post/2019/03/24/blender-tutorial-10-light-part-1/content.mdx
+++ b/src/content/blog/post/2019/03/24/blender-tutorial-10-light-part-1/content.mdx
@@ -20,6 +20,8 @@ example a simple point light.
 
 ![Add a light to the scene](/media/content/blog/post/2019/03/24/blender-tutorial-10-light-part-1/blender-add-light.jpg)
 
+## Point light properties
+
 We can then customize the light properties using the related tab in the properties panel. In this section you can find
 specific customizable properties for each type of light. For example for a point light we can customize:
 
@@ -31,6 +33,8 @@ specific customizable properties for each type of light. For example for a point
 
 ![Point light properties panel](/media/content/blog/post/2019/03/24/blender-tutorial-10-light-part-1/blender-point-light.jpg)
 
+## Ray shadows
+
 For the point light (and also some other kind of light) it is possible to enable shadows. To do that we have to choose
 ray shadow in the light properties panel and customize the look and feel of the shadow. Here we can also define the
 number of samples to be used to generate the shadows: the higher the better shadow we obtain (if you want to know more
@@ -41,6 +45,8 @@ the shadow, we need also to set the shadow flag enable in the renderer settings 
 ![Shadow panel properties](/media/content/blog/post/2019/03/24/blender-tutorial-10-light-part-1/blender-shadow-enable-1.jpg)
 
 ![Enable shadow in the shading section](/media/content/blog/post/2019/03/24/blender-tutorial-10-light-part-1/blender-shadow-enable-2.jpg)
+
+## Spot lamps
 
 There are other types of lights. For example we have spot lamps. These are light with a specific dim that simulate a
 cone of light. We can customize its properties in the light tab in the properties panel. One thing to note for spot
@@ -59,6 +65,8 @@ buffer shadow:
 
 ![Add shadow to a spot light](/media/content/blog/post/2019/03/24/blender-tutorial-10-light-part-1/blender-spot-light-shadow.jpg)
 
+## Hemi and area lamps
+
 Another type of light is Hemi-lamps. This are used to create an overall directional light for you scene. As a
 consequence of the fact that it is a directional light, the position of it doesn't change the final lighting result.
 Only the orientation influences the final lighting result. As always, we can customize its behaviour in the properties
@@ -73,5 +81,7 @@ attenuation result. the distance is represented in the 3D window as a dashed lin
 ray traced shadow. We can also customize the shape of the shadow: different shapes influence the final rendering result.
 
 ![An area lamps](/media/content/blog/post/2019/03/24/blender-tutorial-10-light-part-1/blender-area-lamps.jpg)
+
+## Conclusion
 
 In the next post we will talk about how to do other cool stuff with lights in Blender.

--- a/src/content/blog/post/2019/03/25/blender-tutorial-11-light-part-2/content.mdx
+++ b/src/content/blog/post/2019/03/25/blender-tutorial-11-light-part-2/content.mdx
@@ -26,11 +26,15 @@ In the same section there's also an ambient color property. The ambient color le
 
 ![Add a background ambient color](/media/content/blog/post/2019/03/25/blender-tutorial-11-light-part-2/blender-background-ambient-color.jpg)
 
+## Adding a background image
+
 We can also choose to add a background image. To do that we have to go from the world tab directly to the texture tab.
 Blender will detect this operation and it will know that we are adding a texture to the background of our scene. From
 here we can choose the type of texture we want and we can apply it.
 
 ![Add a background texture](/media/content/blog/post/2019/03/25/blender-tutorial-11-light-part-2/blender-background-texture.jpg)
+
+## The sun lamp and ambient occlusion
 
 We also have a specific type of light to simulate the sun: the sun lamp. It behaves in a similar way to the Hemi lamp.
 One particular feature it has is the possibility to add a sky as background and simulate a sun in terms of shape and
@@ -45,5 +49,7 @@ one, we can activate the environment light. This kind of effect will generate am
 use (if we choose it) the sky/sky texture as color.
 
 ![Add ambient occlusion environment lighting](/media/content/blog/post/2019/03/25/blender-tutorial-11-light-part-2/blender-ambient-occlusion-enviroment-lighting.jpg)
+
+## Conclusion
 
 In the next post about Blender we will talk about cameras and rendering.

--- a/src/content/blog/post/2019/03/26/blender-tutorial-12-camera-rendering/content.mdx
+++ b/src/content/blog/post/2019/03/26/blender-tutorial-12-camera-rendering/content.mdx
@@ -32,12 +32,16 @@ dimension (in scene units) of the portion of space captured from the camera.
 
 ![Camera options](/media/content/blog/post/2019/03/26/blender-tutorial-12-camera-rendering/blender-camera-options.jpg)
 
+## Camera constraints
+
 We can place cameras manually or we can use constraints. We can create a constraint by clicking the specific constraint
 tab (the one with the chain as icon) in the properties panel of the camera and add a new constraint. We can use for
 example a Damped Track and correlate the movement of our camera to the position of an object we select as the one to be
 tracked.
 
 ![Camera constraints](/media/content/blog/post/2019/03/26/blender-tutorial-12-camera-rendering/blender-camera-constraints.jpg)
+
+## Rendering options
 
 For what concerns rendering, we have the possibility to control it in the properties panel under the render tab (the one
 with the camera). For example we can customize where the render will happen. By default the render will show the result
@@ -50,6 +54,8 @@ output of the rendering.
 
 ![Rendering option](/media/content/blog/post/2019/03/26/blender-tutorial-12-camera-rendering/blender-render-option.jpg)
 
+## Motion blur
+
 As we said before in Blender it is possible to render animation. We will go through all the details about animation in a
 future post. For now we can see how to achieve cool rendering effects, for example motion blur. The motion blur is an
 effect you have when an object is moving in the length of the exposure of the camera. We can achieve this effect by
@@ -58,6 +64,8 @@ shutter to change the final result of the motion blur (the default value for sam
 because with the value of 1 we will have no motion blur).
 
 ![Add motion blur](/media/content/blog/post/2019/03/26/blender-tutorial-12-camera-rendering/blender-motion-blur.jpg)
+
+## Depth of field
 
 One last effect we can achieve with the Blender render is depth of field. This effect simulate the fact that only a part
 of the scene is in focus, based on the focal distance from the camera. To setup the depth of field in our scene, first
@@ -75,5 +83,7 @@ filter, and again the image to the composite final result.
 ![Setup defocus](/media/content/blog/post/2019/03/26/blender-tutorial-12-camera-rendering/blender-depth-of-field-4.jpg)
 
 ![The depth of field final result](/media/content/blog/post/2019/03/26/blender-tutorial-12-camera-rendering/blender-depth-of-field-5.jpg)
+
+## Conclusion
 
 That's all for camera and rendering. In the next post we will talk about animation.

--- a/src/content/blog/post/2019/03/27/blender-tutorial-13-animation/content.mdx
+++ b/src/content/blog/post/2019/03/27/blender-tutorial-13-animation/content.mdx
@@ -21,6 +21,8 @@ There is also the possibility to set a start and end frame of the animation.
 
 ![The animation timeline](/media/content/blog/post/2019/03/27/blender-tutorial-13-animation/blender-animation-timeline.jpg)
 
+## Setting keyframes
+
 To create an animation we need first of all to set keyframes. To do this we have to select the frame that we want as
 keyframe in the timeline, and the go in the space properties panel, change one of the spatial properties we want to
 animate (location, rotation or scale) and right click on them to show a menu where we can select "Insert keyframes".
@@ -41,6 +43,8 @@ After settings the second keyframe we finally have our first animation. In the v
 
 <Youtube videoId="qTLJL-HF9vY" />
 
+## Animating any property
+
 In our previous first animation we animated the movement of the object. In Blender we are not limited to location or
 rotation for animation: we can basically animate any property we want. We can animate color, scale, light camera and so
 on. Let's see for example how we can animate the energy property of a light. To do this we basically have to follow the
@@ -50,6 +54,8 @@ can be played (remember to switch the 3D window to texture mode if you want to s
 render).
 
 <Youtube videoId="Ledh539mZKo" />
+
+## The graph editor
 
 Sometimes we will need to do to a more precise setup of our animation: change the values between keyframes, change the
 interpolation method and so on. To do these operation we can use the graph editor. This is a a separate editor that we
@@ -63,6 +69,8 @@ choosing Key -> Interpolation mode from the menu.
 
 ![Interpolation mode](/media/content/blog/post/2019/03/27/blender-tutorial-13-animation/blender-animation-interpolation-mode.jpg)
 
+## The dope sheet and animation paths
+
 The graph editor in not the only animation editor. We can use also the dope sheet. It could be more faster to edit an
 animation in it instead of the animation editor. In it we don't have the curve of interpolation of the animation. We
 just have a representation of the keyframes and we can edit them by dragging after selection with a right click of the
@@ -73,5 +81,7 @@ After that we can set the keyframes using the same approach showed before.
 ![Add curve path](/media/content/blog/post/2019/03/27/blender-tutorial-13-animation/blender-path-add-curve.jpg)
 
 ![Set path constraint](/media/content/blog/post/2019/03/27/blender-tutorial-13-animation/blender-path-set-constraint.jpg)
+
+## Conclusion
 
 That's all for animation. In the next post we will talk about character rigging.

--- a/src/content/blog/post/2019/03/28/blender-tutorial-14-armatures-character-rigging/content.mdx
+++ b/src/content/blog/post/2019/03/28/blender-tutorial-14-armatures-character-rigging/content.mdx
@@ -34,11 +34,15 @@ character.
 
 ![Add bones](/media/content/blog/post/2019/03/28/blender-tutorial-14-armatures-character-rigging/blender-bones.jpg)
 
+## Creating a complete armature
+
 To create a complete armature we have some tools similar to the one we previously seen for modeling. After selecting
 edit mode, in the left panel of the 3D window we have the options extrude and subdivide that let us create a complete
 skeleton for a character. In the scene we will find our armature object with all the bones connected.
 
 ![Add armature](/media/content/blog/post/2019/03/28/blender-tutorial-14-armatures-character-rigging/blender-armature.jpg)
+
+## Adding the armature to an object
 
 We can now start to add the armature to an object. To do that we just have to place/create the bones inside our object.
 After that we select the object and the bones (in this specific order), and we choose from the menu at the bottom of the
@@ -50,6 +54,8 @@ contains that bone will move accordingly.
 
 <Youtube videoId="GpkMgUqWZJo" />
 
+## Inverse kinematics
+
 Sometimes we will also need to constraint a bone to the move of other bones. Instead of doing it manually, we can use
 Inverse kinematics. To be more clear this is an extract of the blender doc:
 
@@ -60,9 +66,13 @@ properties panel. This tab will appear only when we are in pose mode.
 
 ![Inverse kinematics](/media/content/blog/post/2019/03/28/blender-tutorial-14-armatures-character-rigging/blender-inverse-kinematics.jpg)
 
+## Animating the character
+
 After setting bones, armature and inverse kinematics we are ready to animate our character. To do that, we just need to
 be in Pose mode and set the keyframes as we did for standard animation.
 
 <Youtube videoId="Q5m1rnjT6Rw" />
+
+## Conclusion
 
 That's all for character rigging. In the next post we will talk about the rendering engine Cycles.

--- a/src/content/blog/post/2019/03/29/blender-tutorial-15-cycles/content.mdx
+++ b/src/content/blog/post/2019/03/29/blender-tutorial-15-cycles/content.mdx
@@ -27,6 +27,8 @@ navigate through it. Wonderful :heart_eyes:!!!
 
 ![Start the cycles engine](/media/content/blog/post/2019/03/29/blender-tutorial-15-cycles/blender-cycles-start.jpg)
 
+## Materials in Cycles
+
 How do we create material for cycles? We can create a material from the same tab we previously saw. When the cycles
 render is selected the option to customize the material change accordingly. In particular there's a *surface* option
 where we can select from a list of BSDF the type of surface BSDF we want. The other option will change accordingly based
@@ -34,6 +36,8 @@ on this selection. We can also add texture like for standard material. To do tha
 option and select the texture we want.
 
 ![Cycles material](/media/content/blog/post/2019/03/29/blender-tutorial-15-cycles/blender-cycles-material.jpg)
+
+## Lights in Cycles
 
 For what concern lights, Cycles support different type of lights. The type of lights and their setup are similar to the
 one we can find in the standard Blender engine:


### PR DESCRIPTION
#510 fixed the 43 posts whose headings sat at the wrong level. These 24 had **no headings at all** — they arrive as one undifferentiated block for a reader skimming and for an LLM chunker with nothing to split on.

**113 headings** across 7 long technical posts and the complete 15-part Blender series.

| | Before | After |
|---|---|---|
| Headingless posts | 44 | **20** |

The 20 that remain are all under 500 words, where sections would be noise rather than structure, plus the personal essay (`memories-failures-18-years`), deliberately left as continuous narrative.

## Structure only, and it is provable

No sentence was added, removed, reworded or reordered.

Verified mechanically across all 24 files: **strip every added `##`/`###` line and its trailing blank, and each file is byte-identical to its version in `HEAD`.** 0 removals, 0 non-heading additions. That check catches reflowing and reordering, which a line-count check would not.

## Naming shapes, chosen per post

- **Project write-up** → concept sections, then `## Implementation`, then `## Conclusion`
- **Component walkthrough** → name the components, because a component outline beats one giant "Implementation" entry (precedent: the Spring Boot post's `## The application` / `## RestTemplate` / `## WebClient`)
- **Process write-up** → name the steps the post already lists (the enterprise-beta post)
- **Category-per-section essay** → name the categories (the code-review post)

The Blender series follows a single scheme so all 15 read consistently: flat `##`, sections named for the Blender feature or task, **each post using its own vocabulary rather than a normalised one** (tutorial 1 says "3D window", not "viewport"), boundaries following the screenshots, 3 to 5 sections.

## Known limitation, not an oversight

Several posts fuse an intro recap and the first real topic into a single paragraph with two-space hard breaks. A heading cannot go inside one without splitting prose, so in those posts **the first topic stays under the unheaded intro and gets no outline entry** — sculpt mode, primitive meshes, the outliner, normal maps, creating a material, camera lens properties, and others.

Taking the later boundary was the deliberate trade: correct structure over edited writing. Fixing it would mean splitting paragraphs, which is a prose change and needs its own decision.

## Judgement calls worth a look

- **Tutorial 15 got only 2 sections** and was not padded to reach a count.
- **Tutorial 10's `## Hemi and area lamps`** merges two one-paragraph lamp types to stay within 5 sections; splitting them means 6.
- **Tutorials 5 and 7 (1081 words each)** sit above the range the scheme was calibrated for, so features were paired — "subdivision surface", "mirror" and "boolean" are collapsed under `## Modifiers` and do not appear in the outline.
- **`## Conclusion` was omitted** in tutorials 1, 4 and 15, where the sign-off is hard-break-glued to preceding content and heading it would file unrelated instructions under "Conclusion".

## How Has This Been Tested?

`lint`, `typecheck`, **1444 tests**, and a full build of **1214 static pages** all pass.

## Types of changes

- [X] Bug fix :bug: (non-breaking change which fixes an issue)
- [ ] New feature :sparkles: (non-breaking change which adds functionality)
- [ ] Breaking change :boom: (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] My code follows the code style of this project :beers:.
- [X] My change requires a change to the documentation :bulb: and I have updated the documentation accordingly.
- [X] I have read the [CONTRIBUTING](https://github.com/chicio/chicio.github.io/blob/master/CONTRIBUTING.md) document :busts_in_silhouette:.
- [X] I have added tests to cover my changes :tada:.
- [X] All new and existing tests passed :white_check_mark:.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved readability and navigation across tutorials and technical articles by adding descriptive section headings.
  * Organized content into clearer topic areas, including setup, implementation, modeling, rendering, animation, architecture, and conclusions.
  * Existing instructional content, code examples, and media remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->