### PR TITLE
fix(capabilities): :bug: stop GET /api/mcp hanging until the 300s serverless timeout

### DIFF
--- a/.claude/agent-memory/fabrizioduroni-implementer/MEMORY.md
+++ b/.claude/agent-memory/fabrizioduroni-implementer/MEMORY.md
@@ -74,6 +74,9 @@
 ## Features (continued 12)
 - [Console Startup Section](feature_console_startup_section.md) — Startup section (10/11 consoles) via existing Youtube molecule; fixed hardcoded iframe title bug; mdx-to-markdown already handled Youtube+ParagraphTitleWithIcon; search index never sees body text
 
+## Bug Fixes
+- [MCP GET SSE timeout fix](feature_mcp_get_sse_timeout_fix.md) — GET /api/mcp now 405s (stateless, no session for SSE notifications); fixed Vercel 300s hang loop (2026-08-15)
+
 ## Feedback
 - [Review-fix workflow](feedback_review_fix_disk_and_reset_soft.md) — git reset --soft path-restaging to reshape commits; disk-full is often transient (retry, don't clean system caches); e2e hangs on a long-lived ad hoc port are stale-server artifacts, not regressions — verify with a fresh port + origin/main control
 - [PWA & State Patterns](feedback_pwa_patterns.md) — useSyncExternalStore for localStorage state, consent-gated UI, banner/error page alignment rules

--- a/.claude/agent-memory/fabrizioduroni-implementer/feature_mcp_get_sse_timeout_fix.md
+++ b/.claude/agent-memory/fabrizioduroni-implementer/feature_mcp_get_sse_timeout_fix.md
@@ -1,0 +1,33 @@
+---
+name: feature_mcp_get_sse_timeout_fix
+description: GET /api/mcp SSE stream caused 300s Vercel timeouts; fixed by returning 405
+type: project
+---
+
+`src/app/api/mcp/route.ts` GET used to delegate to the same `handleMcpRequest` helper as POST/DELETE, which builds
+a `WebStandardStreamableHTTPServerTransport` and calls `transport.handleRequest(req)`. In the MCP Streamable HTTP
+transport, GET opens a long-lived SSE notification stream. Because the MCP server here is stateless
+(`sessionIdGenerator: undefined`, fresh transport/server per request, see [[feature_mcp_server]]), there is no
+session to correlate notifications to, so the stream is pure overhead. The SDK's `handleGetRequest` has no
+stateless guard and opens the stream unconditionally, so it never closed and hung until Vercel's 300s serverless
+ceiling killed the function, at which point clients reconnected and repeated the loop (224+ occurrences from
+2026-06-18 onward).
+
+Fix (PR branch `fix/mcp-get-sse-timeout`, 2026-08-15): GET now returns `405 Method Not Allowed` immediately, with
+an `Allow: POST, DELETE, OPTIONS` header (deliberately excludes GET) and the same `withCors`/`CORS_HEADERS` reuse
+as the other handlers, plus a small JSON body explaining the server is stateless and offers no SSE stream. This is
+spec-legal: the MCP Streamable HTTP transport's standalone GET SSE stream is optional, and clients handle a 405 by
+not reopening it. `src/lib/mcp/**` was untouched, only the route handler changed.
+
+Verified locally with dev server + curl: GET with `Accept: text/event-stream` returns 405 in well under a second
+(no hang); POST with an `initialize` JSON-RPC payload still returns 200 with `serverInfo` in the body as before.
+
+Test file `src/app/api/mcp/route.test.ts` follows a `vi.hoisted()` mock pattern for
+`createMcpServer`/`WebStandardStreamableHTTPServerTransport`/`handleRequest`. The regression guard for this fix is
+asserting `mockCreateMcpServer`/`mockConnect`/`mockHandleRequest` are NOT called on GET — that's what would fail if
+someone reinstated the old delegation.
+
+**Why:** avoid re-diagnosing this if the GET behavior question resurfaces (e.g., someone asks "why doesn't GET
+support SSE notifications").
+**How to apply:** if MCP ever moves to stateful sessions (real `sessionIdGenerator`), this 405 would need to be
+revisited since a real session could then have server-initiated notifications worth streaming.

--- a/src/app/api/mcp/route.test.ts
+++ b/src/app/api/mcp/route.test.ts
@@ -67,6 +67,19 @@ describe("/api/mcp", () => {
             expect(response.headers.get("Access-Control-Allow-Origin")).toBe("*");
         });
 
+        it("reports the refusal as a JSON-RPC error, matching the shape the SDK uses", async () => {
+            const response = await GET();
+            expect(response.headers.get("Content-Type")).toBe("application/json");
+            await expect(response.json()).resolves.toEqual({
+                jsonrpc: "2.0",
+                error: {
+                    code: -32000,
+                    message: "This MCP server is stateless and does not offer a standalone SSE stream via GET.",
+                },
+                id: null,
+            });
+        });
+
         it("does not construct the transport or the MCP server", async () => {
             await GET();
             expect(mockCreateMcpServer).not.toHaveBeenCalled();

--- a/src/app/api/mcp/route.test.ts
+++ b/src/app/api/mcp/route.test.ts
@@ -47,23 +47,31 @@ describe("/api/mcp", () => {
     });
 
     describe("GET", () => {
-        it("creates an MCP server and connects a transport", async () => {
-            const req = new Request("https://www.fabrizioduroni.it/api/mcp");
-            await GET(req);
-            expect(mockCreateMcpServer).toHaveBeenCalledTimes(1);
-            expect(mockConnect).toHaveBeenCalledTimes(1);
+        it("returns 405 instead of opening the SSE stream", async () => {
+            const response = await GET();
+            expect(response.status).toBe(405);
         });
 
-        it("delegates the request to the transport handler", async () => {
-            const req = new Request("https://www.fabrizioduroni.it/api/mcp");
-            await GET(req);
-            expect(mockHandleRequest).toHaveBeenCalledWith(req);
+        it("advertises the supported methods without GET in the Allow header", async () => {
+            const response = await GET();
+            const allow = response.headers.get("Allow");
+            expect(allow).not.toBeNull();
+            expect(allow).not.toContain("GET");
+            expect(allow).toContain("POST");
+            expect(allow).toContain("DELETE");
+            expect(allow).toContain("OPTIONS");
         });
 
-        it("attaches CORS headers to the response", async () => {
-            const req = new Request("https://www.fabrizioduroni.it/api/mcp");
-            const response = await GET(req);
+        it("attaches CORS headers to the 405 response", async () => {
+            const response = await GET();
             expect(response.headers.get("Access-Control-Allow-Origin")).toBe("*");
+        });
+
+        it("does not construct the transport or the MCP server", async () => {
+            await GET();
+            expect(mockCreateMcpServer).not.toHaveBeenCalled();
+            expect(mockConnect).not.toHaveBeenCalled();
+            expect(mockHandleRequest).not.toHaveBeenCalled();
         });
     });
 

--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -38,7 +38,12 @@ export async function GET(): Promise<Response> {
     return withCors(
         new Response(
             JSON.stringify({
-                error: "This MCP server is stateless and does not offer a standalone SSE stream via GET.",
+                jsonrpc: "2.0",
+                error: {
+                    code: -32000,
+                    message: "This MCP server is stateless and does not offer a standalone SSE stream via GET.",
+                },
+                id: null,
             }),
             { status: 405, headers: { "Content-Type": "application/json", Allow: "POST, DELETE, OPTIONS" } }
         )

--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -27,8 +27,22 @@ const handleMcpRequest = async (req: Request): Promise<Response> => {
     return withCors(response);
 };
 
-export async function GET(req: Request): Promise<Response> {
-    return handleMcpRequest(req);
+// GET opens the MCP Streamable HTTP standalone SSE notification stream. This transport is
+// constructed with sessionIdGenerator: undefined (stateless mode), so every request gets a fresh
+// server/transport pair with no session to correlate server-initiated notifications to: there is
+// nothing to push over that stream. The SDK's handleGetRequest has no stateless guard though, so
+// delegating GET here would open a stream that never closes and hangs until Vercel's 300s
+// serverless timeout kills it. The MCP spec makes this stream optional, so refuse it with 405
+// instead: clients handle that by simply not reopening the GET stream.
+export async function GET(): Promise<Response> {
+    return withCors(
+        new Response(
+            JSON.stringify({
+                error: "This MCP server is stateless and does not offer a standalone SSE stream via GET.",
+            }),
+            { status: 405, headers: { "Content-Type": "application/json", Allow: "POST, DELETE, OPTIONS" } }
+        )
+    );
 }
 
 export async function POST(req: Request): Promise<Response> {


### PR DESCRIPTION
Refuse the MCP standalone SSE stream with `405` so `GET /api/mcp` stops hanging until Vercel kills it.

## Description

`GET /api/mcp` now returns **405 Method Not Allowed** immediately, with `Allow: POST, DELETE, OPTIONS`, the existing CORS headers, and a JSON-RPC error body matching the shape the MCP SDK itself returns from `handleUnsupportedRequest`.

`POST`, `DELETE`, `OPTIONS` and everything under `src/lib/mcp/**` are untouched.

## Motivation and Context

Production has been logging `Vercel Runtime Timeout Error: Task timed out after 300 seconds` on `/api/mcp` **224+ times since 2026-06-18**, and it is still firing. Every occurrence is a `GET`, and the timestamps are spaced exactly 5 minutes and 1 second apart:

```
09:24:23, 09:29:24, 09:34:25, 09:39:27, 09:44:28,
09:49:30, 09:54:32, 09:59:33, 10:04:35, 10:09:36, 10:14:38
```

That is the 300s ceiling plus reconnect latency: a client whose stream is killed reconnects immediately, forever.

In MCP's Streamable HTTP transport, `GET` opens a long-lived SSE channel for *server to client* notifications. The SDK's `handleGetRequest` builds a `ReadableStream` with `Content-Type: text/event-stream` that the server never closes, so the function sits holding it open until Vercel terminates it.

The stream could never carry anything. The transport is built with `sessionIdGenerator: undefined` (stateless mode), and in stateless mode the SDK uses a fresh transport and a fresh server per request, so there is no session to correlate notifications to and nothing to push. `handleGetRequest` has no stateless guard, so it opens the stream regardless.

The MCP spec makes this stream optional, and a server that does not offer one should answer `405`. Clients handle that by not reopening it. All real MCP traffic (`initialize`, `tools/list`, `tools/call`) goes over `POST` and is unaffected.

## How Has This Been Tested?

Automated (lint, validate-architecture, knip, typecheck, Vitest 1559 tests, build) plus live curl against a running server, since unit tests mock away the exact runtime behavior that was broken.

Before, `GET` with `Accept: text/event-stream` hung indefinitely and never closed. After:

```
HTTP/1.1 405 Method Not Allowed
access-control-allow-origin: *
allow: POST, DELETE, OPTIONS
{"jsonrpc":"2.0","error":{"code":-32000,"message":"This MCP server is stateless and does not offer a standalone SSE stream via GET."},"id":null}
>>> total_time=0.671058s
```

`POST initialize` still returns `serverInfo` correctly in 0.014s.

New tests cover the 405 status, the `Allow` header excluding `GET`, CORS on the 405, the JSON-RPC body shape, and, as the actual regression guard, that `GET` never constructs the transport or connects the MCP server.

## Types of changes
- [X] Bug fix :bug: (non-breaking change which fixes an issue)
- [ ] New feature :sparkles: (non-breaking change which adds functionality)
- [ ] Breaking change :boom: (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project :beers:.
- [X] My change requires a change to the documentation :bulb: and I have updated the documentation accordingly.
- [X] I have read the [CONTRIBUTING](https://github.com/chicio/chicio.github.io/blob/master/CONTRIBUTING.md) document :busts_in_silhouette:.
- [X] I have added tests to cover my changes :tada:.
- [X] All new and existing tests passed :white_check_mark:.

🤖 Generated with [Claude Code](https://claude.com/claude-code)