### PR TITLE
chore: :wrench: scope the website's env vars to the website

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@ project root; in a workspace it prints `allowScripts in workspace … is ignored
 npm version is declared as `devEngines.packageManager` with a same-major range (`^11.0.0`) — Turborepo
 requires a package manager to be declared and rejects a range spanning majors.
 
-**Environment variables must be declared in `turbo.json`'s `globalEnv`.** Turborepo filters the
+**Environment variables must be declared in `turbo.json`.** The website's secrets live in `apps/website/turbo.json`, on the tasks that run the app (`build`, `dev`, `start`, `test:e2e`) — not in the root `globalEnv`, where every entry becomes a cache key for every task in every workspace and a changed `GROQ_API_KEY` needlessly rebuilds the design system. Only `CI` and `NODE_ENV` are global. Turborepo filters the
 environment it passes to tasks, so an undeclared variable is silently stripped. The list cannot be
 derived by grepping for `process.env.X`: `GROQ_API_KEY` is read implicitly by `@ai-sdk/groq` and
 never appears in the source, and the `GOOGLE_ANALYTICS_*` keys are destructured from an injected

--- a/apps/website/turbo.json
+++ b/apps/website/turbo.json
@@ -1,0 +1,76 @@
+{
+    "$schema": "https://turborepo.com/schema.json",
+    "extends": [
+        "//"
+    ],
+    // Only this app reads these, so they belong here rather than in the root globalEnv, where
+    // every variable is a cache key for every task in every workspace: changing GROQ_API_KEY
+    // there invalidates the design system's build, which cannot possibly use it.
+    //
+    // Listed only on the tasks that actually run this app's code. Turborepo's strict env mode
+    // filters the environment it hands a task, so a variable missing here is silently undefined
+    // rather than an error — and /blog/stats is prerendered, which means the Google Analytics
+    // ones are read during `next build`, not only at request time.
+    "tasks": {
+        "build": {
+            "env": [
+                "CONTACT_EMAIL",
+                "GOOGLE_ANALYTICS_API_SECRET",
+                "GOOGLE_ANALYTICS_PROPERTY_ID",
+                "GOOGLE_ANALYTICS_SA_CLIENT_EMAIL",
+                "GOOGLE_ANALYTICS_SA_PRIVATE_KEY",
+                "GROQ_API_KEY",
+                "RESEND_API_KEY",
+                "UPSTASH_REDIS_REST_TOKEN",
+                "UPSTASH_REDIS_REST_URL",
+                "UPSTASH_VECTOR_REST_TOKEN",
+                "UPSTASH_VECTOR_REST_URL"
+            ]
+        },
+        "dev": {
+            "env": [
+                "CONTACT_EMAIL",
+                "GOOGLE_ANALYTICS_API_SECRET",
+                "GOOGLE_ANALYTICS_PROPERTY_ID",
+                "GOOGLE_ANALYTICS_SA_CLIENT_EMAIL",
+                "GOOGLE_ANALYTICS_SA_PRIVATE_KEY",
+                "GROQ_API_KEY",
+                "RESEND_API_KEY",
+                "UPSTASH_REDIS_REST_TOKEN",
+                "UPSTASH_REDIS_REST_URL",
+                "UPSTASH_VECTOR_REST_TOKEN",
+                "UPSTASH_VECTOR_REST_URL"
+            ]
+        },
+        "start": {
+            "env": [
+                "CONTACT_EMAIL",
+                "GOOGLE_ANALYTICS_API_SECRET",
+                "GOOGLE_ANALYTICS_PROPERTY_ID",
+                "GOOGLE_ANALYTICS_SA_CLIENT_EMAIL",
+                "GOOGLE_ANALYTICS_SA_PRIVATE_KEY",
+                "GROQ_API_KEY",
+                "RESEND_API_KEY",
+                "UPSTASH_REDIS_REST_TOKEN",
+                "UPSTASH_REDIS_REST_URL",
+                "UPSTASH_VECTOR_REST_TOKEN",
+                "UPSTASH_VECTOR_REST_URL"
+            ]
+        },
+        "test:e2e": {
+            "env": [
+                "CONTACT_EMAIL",
+                "GOOGLE_ANALYTICS_API_SECRET",
+                "GOOGLE_ANALYTICS_PROPERTY_ID",
+                "GOOGLE_ANALYTICS_SA_CLIENT_EMAIL",
+                "GOOGLE_ANALYTICS_SA_PRIVATE_KEY",
+                "GROQ_API_KEY",
+                "RESEND_API_KEY",
+                "UPSTASH_REDIS_REST_TOKEN",
+                "UPSTASH_REDIS_REST_URL",
+                "UPSTASH_VECTOR_REST_TOKEN",
+                "UPSTASH_VECTOR_REST_URL"
+            ]
+        }
+    }
+}

--- a/turbo.json
+++ b/turbo.json
@@ -6,18 +6,7 @@
     ],
     "globalEnv": [
         "CI",
-        "CONTACT_EMAIL",
-        "GOOGLE_ANALYTICS_API_SECRET",
-        "GOOGLE_ANALYTICS_PROPERTY_ID",
-        "GOOGLE_ANALYTICS_SA_CLIENT_EMAIL",
-        "GOOGLE_ANALYTICS_SA_PRIVATE_KEY",
-        "GROQ_API_KEY",
-        "NODE_ENV",
-        "RESEND_API_KEY",
-        "UPSTASH_REDIS_REST_TOKEN",
-        "UPSTASH_REDIS_REST_URL",
-        "UPSTASH_VECTOR_REST_TOKEN",
-        "UPSTASH_VECTOR_REST_URL"
+        "NODE_ENV"
     ],
     "tasks": {
         "build": {


### PR DESCRIPTION
## Why

Every entry in the root `globalEnv` is a cache key for **every task in every workspace**. Measured on `main`:

```
$ GROQ_API_KEY=x turbo run build --filter=matrix-design-system
matrix-component-store:build: cache miss, executing
matrix-design-system:build:   cache miss, executing
```

The design system cannot read `GROQ_API_KEY`, but rebuilt anyway.

## After

```
$ GROQ_API_KEY=fresh turbo run build --filter=matrix-design-system
matrix-design-system:build: cache hit, replaying logs     ← unaffected

$ GROQ_API_KEY=fresh turbo run build --filter=website
website:build: cache miss, executing                      ← still correct
```

## What

The eleven secrets move to `apps/website/turbo.json` (`extends: ["//"]`), listed on the tasks that actually run the app: `build`, `dev`, `start`, `test:e2e`. Only `CI` and `NODE_ENV` stay global — those genuinely change how every task behaves.

Two things that are easy to get wrong here:

- **`dev` and `start` need them despite being uncached.** Strict env mode filters the environment handed to a task regardless of caching, so omitting them would start the dev server with no secrets.
- **`build` needs them.** `/blog/stats` is prerendered, so the Google Analytics variables are read during `next build`, not only at request time. Verified both stats routes are still in `.next/prerender-manifest.json` afterwards.

## Verification

- `turbo --dry=json` confirms the split: `website#build` 11 vars, all three package builds 0.
- All 13 turbo gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)