### PR TITLE
chore: :construction_worker: wire per-package releases and verify the published surface

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,10 +99,29 @@ jobs:
       - name: Run tests with coverage
         run: npx turbo run test:coverage
 
+  verify-packages:
+    name: Verify published packages
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+      - name: Setup Node
+        uses: actions/setup-node@v5
+        with:
+          node-version-file: 'package.json'
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm ci
+      # Packs the real tarballs, lints the published surface and installs them into a throwaway
+      # app. The website resolves these through the workspace, so nothing else in CI exercises
+      # what the registry would actually serve.
+      - name: Verify published packages
+        run: npm run verify-packages
+
   build:
     name: Build
     runs-on: ubuntu-latest
-    needs: [lint, knip, validate-architecture, typecheck, test]
+    needs: [lint, knip, validate-architecture, typecheck, test, verify-packages]
     steps:
       - name: Checkout
         uses: actions/checkout@v5

--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -1,0 +1,73 @@
+name: Release package
+
+# Manual on purpose: these are public artifacts, and a release should be a decision rather than a
+# side effect of merging. Mirrors the flow matrix-rain-webgpu already uses.
+on:
+  workflow_dispatch:
+    inputs:
+      package:
+        description: 'Which package to release'
+        type: choice
+        options:
+          - matrix-component-store
+          - matrix-design-system
+        required: true
+      increment:
+        description: 'Which release to cut ("initial" publishes the version already in package.json)'
+        type: choice
+        options: [initial, patch, minor, major, beta, major-beta]
+        default: patch
+      dry_run:
+        description: 'Dry run (no publish, tag or push)'
+        type: boolean
+        default: true
+
+permissions:
+  contents: write # push the bump/changelog commit + tag, create the GH release
+  id-token: write # OIDC token for trusted publishing (+ automatic provenance)
+
+jobs:
+  release:
+    name: Release ${{ inputs.package }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0 # full history so conventional-changelog can diff tags
+      - name: Setup Node
+        uses: actions/setup-node@v5
+        with:
+          node-version-file: 'package.json'
+          cache: 'npm'
+          registry-url: 'https://registry.npmjs.org'
+      - name: Use an npm that supports trusted publishing
+        run: npm install -g npm@latest # needs >= 11.5.1
+      - name: Install dependencies
+        run: npm ci
+      # matrix-design-system consumes matrix-component-store's dist, so build through turbo to pick
+      # up ^build rather than building the package alone.
+      - name: Build the package and its dependencies
+        run: npx turbo run build --filter=${{ inputs.package }}
+      # Never publish a tarball that has not been proven installable.
+      - name: Verify the published surface
+        run: node scripts/verify-packages.mjs
+      - name: Configure git identity
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+      - name: Map increment to release-it args
+        id: args
+        run: |
+          case "${{ inputs.increment }}" in
+            initial)     echo "args=--no-increment" >> "$GITHUB_OUTPUT" ;;
+            beta)        echo "args=--preRelease=beta" >> "$GITHUB_OUTPUT" ;;
+            major-beta)  echo "args=major --preRelease=beta" >> "$GITHUB_OUTPUT" ;;
+            *)           echo "args=${{ inputs.increment }}" >> "$GITHUB_OUTPUT" ;;
+          esac
+      - name: Release
+        working-directory: packages/${{ inputs.package }}
+        run: npx release-it ${{ steps.args.outputs.args }} ${{ inputs.dry_run && '--dry-run' || '' }} --ci
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # No NPM_TOKEN — OIDC trusted publishing authenticates the publish.

--- a/.release-it.json
+++ b/.release-it.json
@@ -13,7 +13,25 @@
   "plugins": {
     "@release-it/conventional-changelog": {
       "preset": "conventionalcommits",
-      "infile": "CHANGELOG.md"
+      "infile": "CHANGELOG.md",
+      "tagPrefix": "v",
+      "commitsOpts": {
+        "path": [
+          ".",
+          ":(exclude)packages"
+        ]
+      },
+      "gitRawCommitsOpts": {
+        "path": [
+          ".",
+          ":(exclude)packages"
+        ]
+      }
     }
+  },
+  "git": {
+    "tagName": "v${version}",
+    "tagMatch": "v[0-9]*",
+    "commitsPath": "."
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "knip": "turbo run knip",
     "typecheck": "turbo run typecheck",
     "validate-architecture": "turbo run validate-architecture",
+    "verify-packages": "turbo run build --filter=./packages/* && node scripts/verify-packages.mjs",
     "test": "turbo run test",
     "test:run": "turbo run test:run",
     "test:coverage": "turbo run test:coverage",

--- a/packages/matrix-component-store/.release-it.json
+++ b/packages/matrix-component-store/.release-it.json
@@ -1,0 +1,30 @@
+{
+    "$schema": "https://unpkg.com/release-it/schema/release-it.json",
+    "git": {
+        "tagName": "matrix-component-store@${version}",
+        "tagMatch": "matrix-component-store@*",
+        "tagAnnotation": "matrix-component-store ${version}",
+        "commitMessage": "chore(release): :bookmark: matrix-component-store ${version}",
+        "commitsPath": ".",
+        "requireCommits": true
+    },
+    "github": {
+        "release": true,
+        "releaseName": "matrix-component-store ${version}"
+    },
+    "npm": {
+        "publish": true
+    },
+    "hooks": {
+        "before:init": "npm run build"
+    },
+    "plugins": {
+        "@release-it/conventional-changelog": {
+            "preset": "conventionalcommits",
+            "infile": "CHANGELOG.md",
+            "tagPrefix": "matrix-component-store@",
+            "commitsOpts": { "path": "." },
+            "gitRawCommitsOpts": { "path": "." }
+        }
+    }
+}

--- a/packages/matrix-component-store/package.json
+++ b/packages/matrix-component-store/package.json
@@ -39,7 +39,8 @@
   "scripts": {
     "build": "tsdown",
     "dev": "tsdown --watch",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "release": "release-it"
   },
   "devDependencies": {
     "tsdown": "0.22.14",

--- a/packages/matrix-design-system/.release-it.json
+++ b/packages/matrix-design-system/.release-it.json
@@ -1,0 +1,30 @@
+{
+    "$schema": "https://unpkg.com/release-it/schema/release-it.json",
+    "git": {
+        "tagName": "matrix-design-system@${version}",
+        "tagMatch": "matrix-design-system@*",
+        "tagAnnotation": "matrix-design-system ${version}",
+        "commitMessage": "chore(release): :bookmark: matrix-design-system ${version}",
+        "commitsPath": ".",
+        "requireCommits": true
+    },
+    "github": {
+        "release": true,
+        "releaseName": "matrix-design-system ${version}"
+    },
+    "npm": {
+        "publish": true
+    },
+    "hooks": {
+        "before:init": "npm run build"
+    },
+    "plugins": {
+        "@release-it/conventional-changelog": {
+            "preset": "conventionalcommits",
+            "infile": "CHANGELOG.md",
+            "tagPrefix": "matrix-design-system@",
+            "commitsOpts": { "path": "." },
+            "gitRawCommitsOpts": { "path": "." }
+        }
+    }
+}

--- a/packages/matrix-design-system/package.json
+++ b/packages/matrix-design-system/package.json
@@ -63,7 +63,8 @@
     "test": "vitest",
     "test:run": "vitest run",
     "test:coverage": "vitest run --coverage",
-    "validate-architecture": "depcruise src --config .dependency-cruiser.cjs"
+    "validate-architecture": "depcruise src --config .dependency-cruiser.cjs",
+    "release": "release-it"
   },
   "peerDependencies": {
     "cmdk": ">=1",

--- a/scripts/verify-packages.mjs
+++ b/scripts/verify-packages.mjs
@@ -1,0 +1,192 @@
+/**
+ * Verifies what the registry would actually serve, which a workspace build never can.
+ *
+ * The website resolves these packages through the workspace, so it exercises the source tree and
+ * silently proves nothing about the published artifact. That gap is not theoretical: the design
+ * system once shipped a stylesheet whose `@source` glob pointed at `src/**`, which `files` does not
+ * publish — every component would have rendered with no colours, spacing or layout, behind a fully
+ * green build.
+ *
+ * So: pack each package, lint the published surface, then install the real tarballs into a throwaway
+ * app and import them. The tarballs are installed together, so this works before anything is on npm.
+ */
+
+import { execFileSync } from "node:child_process";
+import { globSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+const PACKAGES = ["matrix-component-store", "matrix-design-system"];
+
+// What a consumer must always supply. Deliberately excludes every optional peer: the root barrel
+// has to resolve with only these, which is the whole reason charts, markdown and the command
+// palette live behind their own entry points.
+const REQUIRED_PEERS = ["react@^19", "react-dom@^19", "framer-motion@^12"];
+
+// matrix-component-store is types-only — its built output is literally `export {}` — so it is
+// verified by type-checking an import, not by looking for a runtime value.
+const TYPE_ONLY_PROBE = {
+    entry: "matrix-component-store",
+    expect: ["ComponentStore", "StateStore", "EffectsStore"],
+};
+
+// Each optional-peer entry point, with the peers it is documented to need. Installed only after the
+// root barrel has been proven to import without them.
+const OPTIONAL_ENTRIES = [
+    // react-is is a peerDependency of recharts itself, not something this package needs. Listed
+    // explicitly so the run does not depend on npm's peer auto-install reaching a nested peer.
+    { entry: "matrix-design-system/chart", expect: ["DonutChart"], peers: ["recharts@^3", "react-is@^19"] },
+    { entry: "matrix-design-system/command-palette", expect: ["CommandPalette"], peers: ["cmdk@^1"] },
+    {
+        entry: "matrix-design-system/markdown",
+        expect: ["Markdown"],
+        peers: [
+            "react-markdown@^10", "unified@^11", "remark-parse@^11", "remark-gfm@^4",
+            "remark-math@^6", "remark-emoji@^5", "rehype-katex@^7", "rehype-highlight@^7",
+        ],
+    },
+];
+
+const run = (cmd, args, cwd) =>
+    execFileSync(cmd, args, { cwd, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
+
+const repoRoot = resolve(import.meta.dirname, "..");
+const workDir = mkdtempSync(join(tmpdir(), "verify-packages-"));
+let failed = false;
+
+const fail = (message) => {
+    console.error(`  FAIL  ${message}`);
+    failed = true;
+};
+
+try {
+    const tarballs = [];
+    for (const name of PACKAGES) {
+        const dir = join(repoRoot, "packages", name);
+        const file = JSON.parse(run("npm", ["pack", "--json", "--pack-destination", workDir], dir))[0].filename;
+        tarballs.push(join(workDir, file));
+        console.log(`  packed ${file}`);
+
+        try {
+            run("npx", ["--yes", "publint", "--strict"], dir);
+            console.log(`  publint clean: ${name}`);
+        } catch (error) {
+            fail(`publint: ${name}\n${error.stdout || error.message}`);
+        }
+
+        try {
+            // esm-only: these packages are ESM with an `exports` map and require React 19, so the
+            // node10 resolution algorithm (which predates `exports` entirely) is not a target.
+            // esm-only: these are ESM packages with an `exports` map requiring React 19, so the
+            // node10 algorithm (which predates `exports`) is not a target. The CSS entry points are
+            // excluded because attw looks for types or JS and a stylesheet is neither.
+            run(
+                "npx",
+                [
+                    "--yes", "@arethetypeswrong/cli", join(workDir, file),
+                    "--profile", "esm-only",
+                    "--exclude-entrypoints", "styles.css", "theme.css",
+                ],
+                repoRoot,
+            );
+            console.log(`  types resolve: ${name}`);
+        } catch (error) {
+            fail(`attw: ${name}\n${error.stdout || error.message}`);
+        }
+    }
+
+    const app = join(workDir, "consumer");
+    run("mkdir", ["-p", app]);
+    writeFileSync(join(app, "package.json"), JSON.stringify({ name: "consumer", private: true, type: "module" }));
+    run("npm", ["install", "--no-audit", "--no-fund", ...tarballs, ...REQUIRED_PEERS], app);
+    console.log("  installed the tarballs with only the REQUIRED peers");
+
+    const importProbe = (entry, expect) => {
+        writeFileSync(
+            join(app, "probe.mjs"),
+            `import * as m from "${entry}";\n` +
+                `const missing = ${JSON.stringify(expect)}.filter((n) => !(n in m));\n` +
+                `if (missing.length) { console.error("missing exports: " + missing.join(", ")); process.exit(1); }`,
+        );
+        run("node", ["probe.mjs"], app);
+    };
+
+    // The property the entry-point split exists to guarantee.
+    try {
+        importProbe("matrix-design-system", ["Button", "Accordion", "Menu"]);
+        console.log("  root barrel imports with no optional peer installed");
+    } catch (error) {
+        fail(`root barrel needs an optional peer: ${(error.stderr || error.message).trim().split("\n")[0]}`);
+    }
+
+    run("npm", ["install", "--no-audit", "--no-fund", "typescript@^5"], app);
+    writeFileSync(
+        join(app, "tsconfig.json"),
+        JSON.stringify({ compilerOptions: { module: "nodenext", moduleResolution: "nodenext", strict: true, noEmit: true, skipLibCheck: true } }),
+    );
+    writeFileSync(
+        join(app, "probe.ts"),
+        `import type { ${TYPE_ONLY_PROBE.expect.join(", ")} } from "${TYPE_ONLY_PROBE.entry}";\n` +
+            `type _Check = ${TYPE_ONLY_PROBE.expect.map((t) => `${t}<{ a: 1 }, { b: 2 }> | ${t}<{ a: 1 }>`).join(" | ")};\n` +
+            `export type { _Check };\n`,
+    );
+    try {
+        run("npx", ["tsc", "--noEmit", "probe.ts"], app);
+        console.log(`  types resolve from a consumer: ${TYPE_ONLY_PROBE.entry}`);
+    } catch (error) {
+        // The union above intentionally passes the wrong arity to some of them; only a resolution
+        // failure matters here, not an arity complaint.
+        const out = (error.stdout || "") + (error.stderr || "");
+        if (/Cannot find module|has no exported member/.test(out)) {
+            fail(`${TYPE_ONLY_PROBE.entry} types: ${out.trim().split("\n")[0]}`);
+        } else {
+            console.log(`  types resolve from a consumer: ${TYPE_ONLY_PROBE.entry}`);
+        }
+    }
+
+    // Tailwind ignores node_modules when scanning for class names, so the package opts its own
+    // classes back in with @source. Those globs are resolved inside the INSTALLED package, which is
+    // exactly where they once pointed at `src/**` — a path `files` does not publish, so they matched
+    // nothing and every component rendered with no colours, spacing or layout. A glob that matches
+    // no published file is that bug, so it is a failure here.
+    const stylesheet = join(app, "node_modules", "matrix-design-system", "src", "styles", "index.css");
+    const sources = [...readFileSync(stylesheet, "utf8").matchAll(/@source\s+"([^"]+)"/g)].map((m) => m[1]);
+    if (sources.length === 0) {
+        fail("the published stylesheet declares no @source globs — Tailwind would generate no utilities");
+    }
+    for (const glob of sources) {
+        const matches = globSync(glob, { cwd: join(stylesheet, "..") });
+        if (matches.length === 0) {
+            fail(`@source "${glob}" matches nothing in the published package`);
+        } else {
+            console.log(`  @source "${glob}" matches ${matches.length} published files`);
+        }
+    }
+
+    // Phase two: add every optional peer in a single install, then probe each entry point.
+    // They go in together on purpose — installing them one at a time leaves npm resolving partial
+    // trees, and a missing transitive of recharts then fails the run for reasons that have nothing
+    // to do with this package. The property worth testing (the root barrel needs none of them) is
+    // already established above.
+    const optionalPeers = OPTIONAL_ENTRIES.flatMap((e) => e.peers);
+    run("npm", ["install", "--no-audit", "--no-fund", ...optionalPeers], app);
+    console.log(`  installed the ${optionalPeers.length} optional peers`);
+
+    for (const { entry, expect } of OPTIONAL_ENTRIES) {
+        try {
+            importProbe(entry, expect);
+            console.log(`  imports cleanly with its peers present: ${entry}`);
+        } catch (error) {
+            fail(`${entry}\n${(error.stderr || error.stdout || error.message).trim()}`);
+        }
+    }
+
+} finally {
+    rmSync(workDir, { recursive: true, force: true });
+}
+
+if (failed) {
+    console.error("\nThe published packages would be broken. See failures above.");
+    process.exit(1);
+}
+console.log("\nPublished surface verified.");


### PR DESCRIPTION
First of three PRs for step 5. **Nothing is published by this PR** — it puts the machinery in place so the first release can be triggered deliberately afterwards.

## Per-package releases

Each publishable package gets its own `.release-it.json`, its own tag namespace (`matrix-design-system@1.1.0`) and a changelog scoped to commits touching its own directory.

Verified by dry run:
- `git describe --match=matrix-component-store@*` — the package's tags are resolved independently of the site's `vX.Y.Z`.
- Path scoping works: only 2 of the 22 commits since `v4.0.0` touch `packages/matrix-component-store`, and the changelog contained exactly the one releasable commit.
- The root config is scoped the other way (`:(exclude)packages`), dropping the packages-only commit from the site's changelog.

`increment: initial` maps to `--no-increment`, so a **first** release publishes the `1.0.0` already in `package.json` rather than bumping to `1.1.0` — there is no baseline tag to diff from yet.

## Releases

A manual `workflow_dispatch` mirroring matrix-rain-webgpu's: choose package + increment, npm **OIDC trusted publishing**, no `NPM_TOKEN`. Dry run defaults to `true`.

## Goal #7, replaced

The original plan wanted the website's dependency auto-bumped on publish. The monorepo made that moot — the website resolves the workspace, so it is always *ahead* of npm. What it cannot do is exercise the tarball.

`scripts/verify-packages.mjs` packs both packages, runs publint + attw, then installs the **real tarballs** into a throwaway app and imports every entry point. It asserts:

- the root barrel imports with **only the required peers** — the entire reason `/chart`, `/markdown` and `/command-palette` exist
- each optional entry imports once its peers are present
- `matrix-component-store`'s **types** resolve from a consumer tsconfig (it is types-only; its built output is literally `export {}`, so a runtime probe proves nothing)
- every `@source` glob in the published stylesheet matches published files

### Red-green on the last one

That check exists because the failure mode is silence. Reintroducing the original bug:

```
FAIL  @source "../**/*.{ts,tsx}" matches nothing in the published package
The published packages would be broken.
```

That glob pointed at `src/**`, which `files` does not publish — every component would have rendered with no colours, spacing or layout, behind a fully green build.

## Two third-party quirks, pinned in comments

- `attw` runs with `--profile esm-only` and the CSS entry points excluded — it looks for types or JS, and a stylesheet is neither. All four JS entry points are green for `node16 (from ESM)` and `bundler`.
- `react-is` is installed explicitly: it is a **peerDependency of recharts**, not of anything here, and npm's peer auto-install does not reliably reach it when adding to an existing tree.

## Verification

- All 13 turbo gates green; `verify-packages` added as a CI job gating `build`.
- Both workflow files parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Release Improvements**
  - Added a guided release workflow for publishing packages, supporting patch, minor, major, beta, and dry-run releases.
  - Standardized version tags, changelogs, GitHub releases, and npm publishing for each package.

- **Quality Improvements**
  - Added automated checks to confirm published packages install correctly, expose valid imports and types, and include required styles and optional integrations.
  - Builds now wait for package verification to complete successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->