### PR TITLE
fix: :bug: stop a publish from shipping a package with no code in it

### DIFF
--- a/packages/matrix-component-store/package.json
+++ b/packages/matrix-component-store/package.json
@@ -38,6 +38,7 @@
   },
   "scripts": {
     "build": "tsdown",
+    "prepublishOnly": "npx turbo run build --filter=matrix-component-store",
     "dev": "tsdown --watch",
     "typecheck": "tsc --noEmit",
     "release": "release-it"

--- a/packages/matrix-design-system/package.json
+++ b/packages/matrix-design-system/package.json
@@ -57,6 +57,7 @@
   },
   "scripts": {
     "build": "tsdown",
+    "prepublishOnly": "npx turbo run build --filter=matrix-design-system",
     "dev": "tsdown --watch",
     "typecheck": "tsc --noEmit",
     "lint": "eslint .",


### PR DESCRIPTION
Found while writing the publishing guide, and worth landing **before** the first release.

## The problem

`dist/` is gitignored and neither package had a `prepublishOnly` guard. A publish from a clean checkout would have shipped a tarball containing `package.json` and nothing else — `files` lists `dist` and `src/styles`, and `dist` simply wouldn't be there.

Measured, not hypothetical:

```
$ rm -rf packages/matrix-component-store/dist && npm pack --dry-run
npm notice total files: 1
npm notice package size: 601 B
```

npm restricts unpublishing after 72 hours, so on a name that has never been published that mistake is close to permanent.

matrix-rain-webgpu already has this guard; these packages didn't.

## The fix

`prepublishOnly` on both packages, running **turbo** rather than `npm run build` — matrix-design-system needs matrix-component-store's `dist` to emit its declarations, which a package-local build would not produce.

Verified by deleting *both* dists and dry-running a publish from the design system:

```
matrix-component-store:build: ✔ Build complete in 530ms
matrix-design-system:build:   ✔ Build complete in 1836ms
npm notice total files: 316
npm notice package size: 74.9 kB
```

One subtlety worth recording: `prepublishOnly` does **not** run on `npm pack`, only on `npm publish`. That's why `verify-packages.mjs` builds through turbo before packing instead of relying on this hook.

## Verification

All 13 turbo gates green, and `npm run verify-packages` reports "Published surface verified."

🤖 Generated with [Claude Code](https://claude.com/claude-code)