### PR TITLE
docs: :memo: give the packages a README and a LICENSE before they are published

### DIFF
--- a/packages/matrix-component-store/LICENSE
+++ b/packages/matrix-component-store/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Fabrizio Duroni
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/matrix-component-store/README.md
+++ b/packages/matrix-component-store/README.md
@@ -1,0 +1,70 @@
+# matrix-component-store
+
+The return-type contract for the component-store pattern: a component stays a pure rendering
+function, and everything it needs comes from exactly one hook.
+
+This package is **types only** — it has no runtime code, and its built output is literally
+`export {}`. It exists so several packages can share one vocabulary for that boundary instead of
+each redeclaring it.
+
+```bash
+npm install --save-dev matrix-component-store
+```
+
+## The pattern
+
+A component calls exactly one hook, `use<ComponentName>Store()`, which returns its state and its
+effects. The component then does nothing but render them.
+
+```tsx
+import type { ComponentStore } from "matrix-component-store";
+
+interface AccordionState {
+    open: boolean;
+}
+
+interface AccordionEffects {
+    toggle: () => void;
+}
+
+export const useAccordionStore = (): ComponentStore<AccordionState, AccordionEffects> => {
+    const [open, setOpen] = useState(false);
+    const toggle = useCallback(() => setOpen((o) => !o), []);
+
+    return { state: { open }, effects: { toggle } };
+};
+```
+
+```tsx
+export const Accordion: FC<AccordionProps> = ({ title, children }) => {
+    const { state, effects } = useAccordionStore();
+
+    return (
+        <section>
+            <button onClick={effects.toggle}>{title}</button>
+            {state.open && <div>{children}</div>}
+        </section>
+    );
+};
+```
+
+## The three types
+
+| Type | Use when the component has |
+|---|---|
+| `ComponentStore<TState, TEffects>` | both state and behaviour |
+| `StateStore<TState>` | state only, no callbacks |
+| `EffectsStore<TEffects>` | behaviour only, no state |
+
+`StateStore` and `EffectsStore` exist so a store with only one half does not have to pad the other
+with `Record<string, never>` or `{}`. Reach for the narrowest one that fits.
+
+## Why bother
+
+Keeping state and effects behind a single hook per component means the rendering code has no
+branching logic to test around, and the hook can be exercised on its own. It also makes the seam
+obvious in review: if a component file calls a second hook, the boundary has leaked.
+
+## License
+
+MIT © Fabrizio Duroni

--- a/packages/matrix-design-system/LICENSE
+++ b/packages/matrix-design-system/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Fabrizio Duroni
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
Small but worth landing **before** the first publish, since a package's README and licence are what people see on npm and are awkward to change retroactively for a published version.

## matrix-component-store had no README

It packs three files, so its npm page would have been blank. It now explains the pattern it encodes — a component calls exactly one store hook and does nothing but render what it returns — with a worked example, and documents when to use `StateStore` / `EffectsStore` instead of padding the unused half with `Record<string, never>`.

## Neither package shipped a licence

Both declare `"license": "MIT"` while shipping no licence text — the one claim in a manifest that shouldn't be unbacked. Both now carry the MIT text.

Deliberately **not** adding one at the repository root: that would read as covering the blog's writing and photographs, which is a different decision.

## Verified

npm always includes README and LICENSE regardless of `files` — checked rather than assumed:

- `matrix-component-store`: 3 → **5 files**
- `matrix-design-system`: 316 → **317 files**

`npm run verify-packages` still reports "Published surface verified."

🤖 Generated with [Claude Code](https://claude.com/claude-code)