### PR TITLE
fix: :bug: read npm pack --json under npm 12, and stop the workflow jumping majors

### DIFF
--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -41,8 +41,11 @@ jobs:
           node-version-file: 'package.json'
           cache: 'npm'
           registry-url: 'https://registry.npmjs.org'
+      # Trusted publishing needs npm >= 11.5.1. Pinned to the 11.x line rather than @latest: the
+      # repo declares npm ^11.0.0 in devEngines, and npm 12 both contradicts that and changed the
+      # shape of `npm pack --json`, which broke the verification step on its release day.
       - name: Use an npm that supports trusted publishing
-        run: npm install -g npm@latest # needs >= 11.5.1
+        run: npm install -g "npm@^11.5.1"
       - name: Install dependencies
         run: npm ci
       # matrix-design-system consumes matrix-component-store's dist, so build through turbo to pick

--- a/scripts/verify-packages.mjs
+++ b/scripts/verify-packages.mjs
@@ -63,7 +63,10 @@ try {
     const tarballs = [];
     for (const name of PACKAGES) {
         const dir = join(repoRoot, "packages", name);
-        const file = JSON.parse(run("npm", ["pack", "--json", "--pack-destination", workDir], dir))[0].filename;
+        // npm 11 returns an array of packed entries; npm 12 returns an object keyed by package
+        // name. Accept either, so the script does not depend on which npm the caller happens to run.
+        const packed = JSON.parse(run("npm", ["pack", "--json", "--pack-destination", workDir], dir));
+        const [{ filename: file }] = Array.isArray(packed) ? packed : Object.values(packed);
         tarballs.push(join(workDir, file));
         console.log(`  packed ${file}`);
 


### PR DESCRIPTION
Caught by a dry run of the release workflow ([run 33306875173](https://github.com/chicio/chicio-blog/actions/runs/33306875173)). It failed in the **verification** step, not near npm auth:

```
TypeError: Cannot read properties of undefined (reading 'filename')
    at scripts/verify-packages.mjs:66
```

## Cause

npm 12 changed the shape of `npm pack --json`:

```
npm 11:  [ { "id": …, "filename": … } ]
npm 12:  { "matrix-component-store": { "id": …, "filename": … } }
```

So `[0].filename` is `undefined`. The script now accepts either shape, verified against genuine output from **both** versions:

```
npm 11 -> matrix-component-store-1.0.0.tgz (array)
npm 12 -> matrix-component-store-1.0.0.tgz (object)
```

## Why it only broke in CI

The workflow ran `npm install -g npm@latest` — now 12.x, while local is 11.17.0.

That upgrade also contradicted the repo's own declaration. `devEngines` pins npm to `^11.0.0`, and npm 12 says so itself when you run it here:

```
npm warn EBADDEVENGINES Invalid semver version "^11.0.0" does not match "12.0.2"
```

The step is now pinned to `npm@^11.5.1`, which satisfies trusted publishing's minimum **and** the declared range, and stops a future npm major landing mid-release.

## Note

This is the verification step doing exactly its job — failing loudly before anything reached npm. Nothing was published.

All 13 turbo gates green; `npm run verify-packages` reports "Published surface verified."

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved package verification across supported npm versions.
  - Prevented release checks from failing when npm returns package metadata in different formats.

- **Chores**
  - Updated the release process to use a compatible npm 11 version, improving publishing reliability and trusted-release support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->