### PR TITLE
fix: :bug: build every package inside the verification instead of trusting the caller

### DIFF
--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -48,13 +48,11 @@ jobs:
         run: npm install -g "npm@^11.5.1"
       - name: Install dependencies
         run: npm ci
-      # matrix-design-system consumes matrix-component-store's dist, so build through turbo to pick
-      # up ^build rather than building the package alone.
-      - name: Build the package and its dependencies
-        run: npx turbo run build --filter=${{ inputs.package }}
-      # Never publish a tarball that has not been proven installable.
+      # Never publish a tarball that has not been proven installable. This builds every package
+      # itself: verification packs them all, so a build scoped to the selected package would leave
+      # the other one without a dist and fail here for the wrong reason.
       - name: Verify the published surface
-        run: node scripts/verify-packages.mjs
+        run: npm run verify-packages
       - name: Configure git identity
         run: |
           git config user.name  "github-actions[bot]"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "knip": "turbo run knip",
     "typecheck": "turbo run typecheck",
     "validate-architecture": "turbo run validate-architecture",
-    "verify-packages": "turbo run build --filter=./packages/* && node scripts/verify-packages.mjs",
+    "verify-packages": "node scripts/verify-packages.mjs",
     "test": "turbo run test",
     "test:run": "turbo run test:run",
     "test:coverage": "turbo run test:coverage",

--- a/scripts/verify-packages.mjs
+++ b/scripts/verify-packages.mjs
@@ -51,6 +51,18 @@ const run = (cmd, args, cwd) =>
     execFileSync(cmd, args, { cwd, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
 
 const repoRoot = resolve(import.meta.dirname, "..");
+
+// Build every package before packing, rather than trusting the caller to have done it. dist/ is
+// gitignored, so on a fresh checkout it does not exist, and `npm pack` will happily produce a
+// tarball without it — which then fails here as a dozen confusing downstream errors instead of one
+// clear cause. Turbo makes this close to free when the build is already current.
+execFileSync("npx", ["turbo", "run", "build", "--filter=./packages/*"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+});
+console.log("  built every package");
+
 const workDir = mkdtempSync(join(tmpdir(), "verify-packages-"));
 let failed = false;
 


### PR DESCRIPTION
Second dry-run failure ([run 33307180731](https://github.com/chicio/chicio-blog/actions/runs/33307180731)), again in verification rather than near npm auth.

## Cause

matrix-design-system's `dist` was missing entirely, so everything about it went red at once:

```
FAIL  publint: matrix-design-system
FAIL  root barrel needs an optional peer
FAIL  @source "../../dist/**/*.mjs" matches nothing in the published package
FAIL  matrix-design-system/chart
FAIL  matrix-design-system/command-palette
FAIL  matrix-design-system/markdown
```

The workflow built only the package being released (`--filter=${{ inputs.package }}`), but the verification **packs both**. Releasing `matrix-component-store` therefore left the design system with no dist.

## The deeper problem

The script could be invoked in a state where it cannot possibly work, and then reported a dozen downstream symptoms instead of the one cause. `dist/` is gitignored, so on a fresh checkout it isn't there — and `npm pack` cheerfully produces a tarball without it rather than failing.

It now runs the package builds itself, so it behaves identically however it's invoked. Turbo makes that close to free when the build is already current.

## Verified red-green

Deleting the design system's `dist` and calling the script directly:

- **before**: four failures, no mention of a missing build
- **after**: `built every package` → `Published surface verified.`

This also collapses two workflow steps into one, and the root npm script no longer has to remember to build first.

All 13 turbo gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved package release verification by automatically building all packages before creating publication artifacts.
  * Streamlined the release workflow so verification uses the same build-and-check process consistently.
  * Ensured published packages include the latest generated output, reducing the risk of incomplete or outdated release artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->