### PR TITLE
fix: :bug: skip release-it's npm auth precondition under trusted publishing

### DIFF
--- a/packages/matrix-component-store/.release-it.json
+++ b/packages/matrix-component-store/.release-it.json
@@ -13,7 +13,8 @@
         "releaseName": "matrix-component-store ${version}"
     },
     "npm": {
-        "publish": true
+        "publish": true,
+        "skipChecks": true
     },
     "hooks": {
         "before:init": "npm run build"
@@ -23,8 +24,12 @@
             "preset": "conventionalcommits",
             "infile": "CHANGELOG.md",
             "tagPrefix": "matrix-component-store@",
-            "commitsOpts": { "path": "." },
-            "gitRawCommitsOpts": { "path": "." }
+            "commitsOpts": {
+                "path": "."
+            },
+            "gitRawCommitsOpts": {
+                "path": "."
+            }
         }
     }
 }

--- a/packages/matrix-design-system/.release-it.json
+++ b/packages/matrix-design-system/.release-it.json
@@ -13,7 +13,8 @@
         "releaseName": "matrix-design-system ${version}"
     },
     "npm": {
-        "publish": true
+        "publish": true,
+        "skipChecks": true
     },
     "hooks": {
         "before:init": "npm run build"
@@ -23,8 +24,12 @@
             "preset": "conventionalcommits",
             "infile": "CHANGELOG.md",
             "tagPrefix": "matrix-design-system@",
-            "commitsOpts": { "path": "." },
-            "gitRawCommitsOpts": { "path": "." }
+            "commitsOpts": {
+                "path": "."
+            },
+            "gitRawCommitsOpts": {
+                "path": "."
+            }
         }
     }
 }


### PR DESCRIPTION
Third dry run ([run 33307487594](https://github.com/chicio/chicio-blog/actions/runs/33307487594)) — and this one finally reached the **Release** step, past all the verification:

```
$ npm whoami
ERROR Not authenticated with npm. Please `npm login` and try again.
```

## Cause

release-it runs auth preconditions before publishing (`release-it/lib/plugin/npm/npm.js`):

```js
if (skipChecks) return;
const validations = Promise.all([this.isRegistryUp(), this.isAuthenticated(), …]);
```

`isAuthenticated()` shells out to `npm whoami`. Under **OIDC trusted publishing there is no long-lived token** — authentication happens during the publish itself, via token exchange — so `whoami` legitimately fails and release-it aborts before ever attempting it.

matrix-rain-webgpu's config already carries `"npm": { "publish": true, "skipChecks": true }` for exactly this reason. I mirrored its structure when writing these configs but dropped that field.

## Fix

`skipChecks: true` on both packages.

The site's root config is unaffected — it has `"publish": false`, and the plugin short-circuits on that before reaching any check.

## Verified

Simulated CI's tokenless state locally with an empty npmrc (I'm now logged in from the manual bootstrap publish, so a plain run wouldn't have been a faithful test):

- **before**: `$ npm whoami` → `ERROR Not authenticated with npm`
- **after**: straight to `$ npm publish . --tag latest --dry-run`

All 13 turbo gates green.

## What this leaves

The OIDC handshake itself is still unproven — a dry run never publishes. That needs a real release, which needs a commit touching a package; there are currently zero since the 1.0.0 tags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package release configuration to streamline npm publishing.
  * Reformatted changelog configuration for improved readability without changing its behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->