### PR TITLE
feat(capabilities): :sparkles: publish the design system as a Storybook showcase

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,9 @@ turbo.json                        the task graph (build, lint, typecheck, test, 
 apps/website/                     the Next.js site, with its own tsconfig, eslint, knip,
                                   vitest, playwright and dependency-cruiser configs
 packages/matrix-design-system/    the published design system: framework-agnostic React
-                                  components, its own stylesheet, built with tsdown
+                                  components, its own stylesheet, built with tsdown. Stories live
+                                  beside their components as *.stories.tsx
+apps/matrix-design-system-showcase/  Storybook over those stories; deploys to GitHub Pages
 packages/matrix-component-store/  the published ComponentStore/StateStore/EffectsStore contract
 packages/eslint-plugin-chicio/    the component-store lint rules, shared by both workspaces
 ```
@@ -109,6 +111,7 @@ The workspace is indexed by CodeGraph (`.codegraph/`, MCP server in `.mcp.json`)
 AI agents and tools that send `Accept: text/markdown` receive a Markdown representation of the requested page instead of HTML.
 
 **Architecture**:
+
 - `apps/website/src/middleware.ts` — re-exports `proxy` from `apps/website/src/proxy.ts` as `middleware`, providing Next.js middleware wiring
 - `apps/website/src/proxy.ts` — generic proxy: if `Accept: text/markdown`, prepends `/markdown` to the path and rewrites; never needs updating for new pages
 - `apps/website/src/app/markdown/[[...path]]/route.ts` — single catch-all route handler; dispatches by path segments to per-section markdown generators; statically pre-rendered via `generateStaticParams`

--- a/apps/matrix-design-system-showcase/.gitignore
+++ b/apps/matrix-design-system-showcase/.gitignore
@@ -1,0 +1,2 @@
+dist/
+storybook-static/

--- a/apps/matrix-design-system-showcase/.storybook/main.ts
+++ b/apps/matrix-design-system-showcase/.storybook/main.ts
@@ -10,9 +10,9 @@ const config: StorybookConfig = {
         name: "@storybook/react-vite",
         options: {},
     },
+    // The TypeScript-aware docgen, so prop tables carry the real types rather than what can be
+    // inferred from JS. Slower than the default, which does not matter at this size.
     typescript: {
-        // The package ships its own declarations; re-deriving prop tables from source would make
-        // the showcase disagree with what consumers actually get.
         reactDocgen: "react-docgen-typescript",
     },
 };

--- a/apps/matrix-design-system-showcase/.storybook/main.ts
+++ b/apps/matrix-design-system-showcase/.storybook/main.ts
@@ -1,0 +1,20 @@
+import type { StorybookConfig } from "@storybook/react-vite";
+
+const config: StorybookConfig = {
+    // Stories live beside the components they document, inside the package. Storybook globs across
+    // the workspace to reach them: colocation is what keeps a story honest when its component
+    // changes, and it is also where .design-sync reads them from, so there is one source of truth.
+    stories: ["../../../packages/matrix-design-system/src/**/*.stories.@(ts|tsx)"],
+    addons: [],
+    framework: {
+        name: "@storybook/react-vite",
+        options: {},
+    },
+    typescript: {
+        // The package ships its own declarations; re-deriving prop tables from source would make
+        // the showcase disagree with what consumers actually get.
+        reactDocgen: "react-docgen-typescript",
+    },
+};
+
+export default config;

--- a/apps/matrix-design-system-showcase/.storybook/preview.ts
+++ b/apps/matrix-design-system-showcase/.storybook/preview.ts
@@ -1,0 +1,14 @@
+import type { Preview } from "@storybook/react-vite";
+import "../src/styles.css";
+
+const preview: Preview = {
+    parameters: {
+        controls: { matchers: { color: /(background|color)$/i, date: /Date$/i } },
+        // The design system assumes a dark surface: its stylesheet sets html/body to #001100 on
+        // #E8FFE8, and most components are near-invisible on white. Storybook's default light
+        // canvas would misrepresent every single one.
+        backgrounds: { disable: true },
+    },
+};
+
+export default preview;

--- a/apps/matrix-design-system-showcase/README.md
+++ b/apps/matrix-design-system-showcase/README.md
@@ -29,8 +29,9 @@ uses everywhere else: `packages/` publishes to npm, `apps/` deploys to a URL.
 A showcase that styles components in a way real consumers cannot reproduce is worth nothing, so
 resist adding anything else here.
 
-## Base path
+## Deploying under a subpath
 
-`STORYBOOK_BASE_PATH` is baked in at build time because Storybook emits absolute asset paths. It is
-`/` locally and `/chicio-blog/design-system/` on Pages, where this sits beside the matrix-rain
-showcase under one landing page.
+Nothing to configure. Storybook emits relative asset references, so the same build works at the
+root or under `/chicio-blog/design-system/`. An earlier version of this config threaded a
+`STORYBOOK_BASE_PATH` through vite's `base`; building with two different values produced identical
+output, so it was removed rather than left to look meaningful.

--- a/apps/matrix-design-system-showcase/README.md
+++ b/apps/matrix-design-system-showcase/README.md
@@ -28,10 +28,3 @@ uses everywhere else: `packages/` publishes to npm, `apps/` deploys to a URL.
 
 A showcase that styles components in a way real consumers cannot reproduce is worth nothing, so
 resist adding anything else here.
-
-## Deploying under a subpath
-
-Nothing to configure. Storybook emits relative asset references, so the same build works at the
-root or under `/chicio-blog/design-system/`. An earlier version of this config threaded a
-`STORYBOOK_BASE_PATH` through vite's `base`; building with two different values produced identical
-output, so it was removed rather than left to look meaningful.

--- a/apps/matrix-design-system-showcase/README.md
+++ b/apps/matrix-design-system-showcase/README.md
@@ -1,0 +1,36 @@
+# matrix-design-system-showcase
+
+Storybook for `matrix-design-system`, deployed to GitHub Pages.
+
+```bash
+npm run dev --workspace=matrix-design-system-showcase     # http://localhost:6006
+npm run build --workspace=matrix-design-system-showcase   # static build into dist/
+```
+
+## Where the stories live
+
+Not here. They sit beside the components they document, inside
+`packages/matrix-design-system/src/**/*.stories.tsx`, and this app globs across the workspace to
+collect them. Colocation is what keeps a story honest when its component changes, and it is the
+single source of truth the Claude Design sync reads from too.
+
+This app owns only the Storybook toolchain and the deployment. That keeps the split the monorepo
+uses everywhere else: `packages/` publishes to npm, `apps/` deploys to a URL.
+
+## Styling
+
+`src/styles.css` is exactly what the package's README tells a consumer to write:
+
+```css
+@import "tailwindcss";
+@import "matrix-design-system/styles.css";
+```
+
+A showcase that styles components in a way real consumers cannot reproduce is worth nothing, so
+resist adding anything else here.
+
+## Base path
+
+`STORYBOOK_BASE_PATH` is baked in at build time because Storybook emits absolute asset paths. It is
+`/` locally and `/chicio-blog/design-system/` on Pages, where this sits beside the matrix-rain
+showcase under one landing page.

--- a/apps/matrix-design-system-showcase/package.json
+++ b/apps/matrix-design-system-showcase/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "matrix-design-system-showcase",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "storybook dev -p 6006 --no-open",
+    "build": "storybook build --output-dir dist",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "matrix-design-system": "^1.0.0",
+    "react": "^19.2.6",
+    "react-dom": "^19.2.6"
+  },
+  "devDependencies": {
+    "@storybook/react-vite": "^10.0.0",
+    "@tailwindcss/vite": "^4.3.3",
+    "@types/react": "19.2.14",
+    "@types/react-dom": "19.2.3",
+    "@vitejs/plugin-react": "^6.0.0",
+    "cmdk": "^1.1.1",
+    "react-markdown": "^10.1.0",
+    "rehype-highlight": "^7.0.2",
+    "rehype-katex": "^7.0.1",
+    "remark-emoji": "^5.0.2",
+    "remark-gfm": "^4.0.1",
+    "remark-math": "^6.0.0",
+    "remark-parse": "^11.0.0",
+    "storybook": "^10.0.0",
+    "tailwindcss": "^4.3.3",
+    "typescript": "^5.9.3",
+    "unified": "^11.0.5",
+    "vite": "^8.1.0"
+  }
+}

--- a/apps/matrix-design-system-showcase/src/styles.css
+++ b/apps/matrix-design-system-showcase/src/styles.css
@@ -1,0 +1,6 @@
+/*
+ * Exactly what a consumer writes, and in the order the design system's README specifies. The
+ * showcase is worth nothing if it styles components in a way real consumers cannot reproduce.
+ */
+@import "tailwindcss";
+@import "matrix-design-system/styles.css";

--- a/apps/matrix-design-system-showcase/tsconfig.json
+++ b/apps/matrix-design-system-showcase/tsconfig.json
@@ -1,0 +1,14 @@
+{
+    "compilerOptions": {
+        "target": "ES2022",
+        "lib": ["ES2022", "DOM", "DOM.Iterable"],
+        "module": "ESNext",
+        "moduleResolution": "bundler",
+        "jsx": "react-jsx",
+        "strict": true,
+        "noEmit": true,
+        "skipLibCheck": true,
+        "types": ["vite/client"]
+    },
+    "include": [".storybook/**/*.ts", "src/**/*.ts", "vite.config.ts"]
+}

--- a/apps/matrix-design-system-showcase/vite.config.ts
+++ b/apps/matrix-design-system-showcase/vite.config.ts
@@ -2,10 +2,9 @@ import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 
+// Storybook's react-vite builder reads this for plugins. There is deliberately no `base` here:
+// Storybook emits relative asset paths, so the build already works unchanged under any subpath —
+// verified by building with two different bases and diffing the output, which was identical.
 export default defineConfig({
     plugins: [react(), tailwindcss()],
-    // GitHub Pages serves the monorepo's site from /chicio-blog/, and this showcase sits beneath it
-    // alongside the matrix-rain one. Storybook builds absolute asset paths, so the base has to be
-    // baked in at build time.
-    base: process.env.STORYBOOK_BASE_PATH ?? "/",
 });

--- a/apps/matrix-design-system-showcase/vite.config.ts
+++ b/apps/matrix-design-system-showcase/vite.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+import tailwindcss from "@tailwindcss/vite";
+
+export default defineConfig({
+    plugins: [react(), tailwindcss()],
+    // GitHub Pages serves the monorepo's site from /chicio-blog/, and this showcase sits beneath it
+    // alongside the matrix-rain one. Storybook builds absolute asset paths, so the base has to be
+    // baked in at build time.
+    base: process.env.STORYBOOK_BASE_PATH ?? "/",
+});

--- a/apps/matrix-design-system-showcase/vite.config.ts
+++ b/apps/matrix-design-system-showcase/vite.config.ts
@@ -2,9 +2,6 @@ import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 
-// Storybook's react-vite builder reads this for plugins. There is deliberately no `base` here:
-// Storybook emits relative asset paths, so the build already works unchanged under any subpath —
-// verified by building with two different bases and diffing the output, which was identical.
 export default defineConfig({
     plugins: [react(), tailwindcss()],
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,34 @@
         "node": "24.x"
       }
     },
+    "apps/matrix-design-system-showcase": {
+      "version": "0.0.0",
+      "dependencies": {
+        "matrix-design-system": "^1.0.0",
+        "react": "^19.2.6",
+        "react-dom": "^19.2.6"
+      },
+      "devDependencies": {
+        "@storybook/react-vite": "^10.0.0",
+        "@tailwindcss/vite": "^4.3.3",
+        "@types/react": "19.2.14",
+        "@types/react-dom": "19.2.3",
+        "@vitejs/plugin-react": "^6.0.0",
+        "cmdk": "^1.1.1",
+        "react-markdown": "^10.1.0",
+        "rehype-highlight": "^7.0.2",
+        "rehype-katex": "^7.0.1",
+        "remark-emoji": "^5.0.2",
+        "remark-gfm": "^4.0.1",
+        "remark-math": "^6.0.0",
+        "remark-parse": "^11.0.0",
+        "storybook": "^10.0.0",
+        "tailwindcss": "^4.3.3",
+        "typescript": "^5.9.3",
+        "unified": "^11.0.5",
+        "vite": "^8.1.0"
+      }
+    },
     "apps/website": {
       "version": "4.0.0",
       "dependencies": {
@@ -2488,6 +2516,26 @@
         }
       }
     },
+    "node_modules/@joshwooding/vite-plugin-react-docgen-typescript": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@joshwooding/vite-plugin-react-docgen-typescript/-/vite-plugin-react-docgen-typescript-0.7.0.tgz",
+      "integrity": "sha512-qvsTEwEFefhdirGOPnu9Wp6ChfIwy2dBCRuETU3uE+4cC+PFoxMSiiEhxk4lOluA34eARHA0OxqsEUYDqRMgeQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "glob": "^13.0.1",
+        "react-docgen-typescript": "^2.2.2"
+      },
+      "peerDependencies": {
+        "typescript": ">= 4.3.x",
+        "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -4830,9 +4878,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.3.tgz",
-      "integrity": "sha512-DT6Z3PhvioeHMvxo+xHc3KtqggrI7CCTXCmC2h/5zUlp5jVitv7XEy+9q5/7v8IolhlioawpMo8Kg0EEBy7J0g==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.6.tgz",
+      "integrity": "sha512-lkWU8ZJaRk9q3CIEY1Tc7vIFALp3Xw5NfGJo2hQg5oIqNgxWi1zI+IiDEK3r70BF5Dzol1tcXsnzsRc8NLhG+Q==",
       "cpu": [
         "arm64"
       ],
@@ -4847,9 +4895,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.3.tgz",
-      "integrity": "sha512-0NwgwsjM7LrsuVnXMK3koTpagBNOhloc/BNjKqZjv4V5zI5r13qx69uVhRx+o5Z0yy4Hzq+lpy7TAgUG/ocvrw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.6.tgz",
+      "integrity": "sha512-dgR56NYnvAszm7Ob1B2/Vn0e8bUQYZH2UjVaMMtMVOCKFSfjhfLmuA/9+O+F+ajUdG6B/bSssrKW6JJYASa8jA==",
       "cpu": [
         "arm64"
       ],
@@ -4864,9 +4912,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.3.tgz",
-      "integrity": "sha512-YtiBp4disu6V560loT6PjMdiRaWmVvDNrUunAalbiFx2ggeJwxdAsgZMcoGP17uyAsTwAj5V1niksxlHnVQ1Sw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.6.tgz",
+      "integrity": "sha512-vpVxFvUCFioJqug7OTvqptkc4yb8UX0AwfDmJpaR/0sWz+BUmqSVAf7c8JkUgnN8YLspb4a/N6NhTyMAmdyQ7Q==",
       "cpu": [
         "x64"
       ],
@@ -4881,9 +4929,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.3.tgz",
-      "integrity": "sha512-yD3EkEdXk2LypPxnf/kSZHirarsI8gcPzc62SukhR9VJTyvV+F9Q/GxWNuCojc7sXyuVC4DxRGhdDK4X8VSsbw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.6.tgz",
+      "integrity": "sha512-h1wG6Y6K3JlRswxsI64qQJqBAy4vrLuHgRbc8CZMGSWTOFRY6ghMApM1NKzB2I0n5xV1fjkE18SuVl2QpLeNpA==",
       "cpu": [
         "x64"
       ],
@@ -4898,9 +4946,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.3.tgz",
-      "integrity": "sha512-c+8vieQbsD7HNAHKIA34w0GJ9FedFFuJGD+7E6vz7Q3uqAIugL5p45fhlsj4UaAsHpcmlqugBWMhA0/j7o0sIg==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.6.tgz",
+      "integrity": "sha512-tbCiqub0q2MVWJKgF5PoAlNWCtQydiOYSLIkd8sByqK/6MMYLJRcSXSYodqYtd0O+Fw7QaVmKKlS4oL94YRZ0w==",
       "cpu": [
         "arm"
       ],
@@ -4915,13 +4963,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.3.tgz",
-      "integrity": "sha512-50jD0uUwLvur7Zz9LHz17kaAdTPjn5wN93hEgjvmYFRZwiR7ZJYovTd5ipyWJDAnXKvZ+wgc+/Ika6dwSF5OcA==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.6.tgz",
+      "integrity": "sha512-oxK9+baEBPhZG5HB4URY+uU04zJWeZlH6Tb9rB5DK4DF9XR1uXNLXt5Q5ZsugTKayNCNLhkcwz/ye74hRI98dg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4932,13 +4983,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.3.tgz",
-      "integrity": "sha512-BO9+oPL8K9poZJBfYPsXNtYjPE5uM3qeehT3aFcW4LITOl+iSqhp0abzjR2nWBUNjIZeKXjAEWBZ64WjNoHd6w==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.6.tgz",
+      "integrity": "sha512-muWCk27FVBEZtv0MsK8gnfSmgczA8KQ0uRVJbTABKhkRfQc38aUrcb7fhi3BNiyseFmgcRsoMfQsSNJ+DbZdSw==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4949,13 +5003,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.3.tgz",
-      "integrity": "sha512-f3VpLB1vQ0Eo6ecr/6cekLnvYMFF4YBFoVGkfkvPLq1bAkbAwHYQPZKoAmG6OJyTcxxoC+AvezGx/S1obNC0Mw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.6.tgz",
+      "integrity": "sha512-eWDoSfU7Co2qj3vgB3Dt4lj1mG6CoWbcJQkRMP3XJplyCMtuaq3LHvPFjS9QIPvMGWVadJC04Xiy0IdcVPtnwQ==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4966,13 +5023,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.3.tgz",
-      "integrity": "sha512-AmurZ26Pqx/RI9N1gzEOCklkKXl927yjfXWUUS0O7Puh8ARM/Ob8qfrD3qnWksScdw6cSrW5PSHE9DyLu7+PtA==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.6.tgz",
+      "integrity": "sha512-2bWNjRSIayvupRKxXUY2tWG9fYdoUlTqWywHRvE8Eq3GvuQ+f2HeIkve697fIt+IQs/PV8yFsdWuhp1aJ1PdnA==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4983,13 +5043,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.3.tgz",
-      "integrity": "sha512-JJpqs8bRGITDOdbkNKnlojzBabbOHrqjSvDr0IVsZObE1lBcPjxItUEY9eWIDbxaJ3cGrXPWGfGkIxFijg/URg==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.6.tgz",
+      "integrity": "sha512-KekI0gS0wLxe1UBSQSjenBVwou/JkcQPDzBPICGZjxUv9k3RteHDPBQaiOicZUFKRIH2wKEimGwVpnJsbPzu7w==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5000,13 +5063,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.3.tgz",
-      "integrity": "sha512-rSJcdjPxzA/by/6/rYs+v+bXU7UjvnbUWz8MJb6kh6+knqB1dCrtHg0uu7C/4haqJvqdkYHQ5IGn+tCH9GLW/g==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.6.tgz",
+      "integrity": "sha512-TvtPnfVr+HtyGiDmPK4VWmlNm7QhNNAcK5Q9A7aOXsI8545yCyaoMaicXrFZ72JzeYjaUVk7yT243zT0jzjFKQ==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5017,9 +5083,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.3.tgz",
-      "integrity": "sha512-hQ3/PYkDJICgevvyNcVrihVeqq7k1Pp3VZ9lY+dauAYUJKO+auqApvANhvR1An9BhmqYKvW2Mu1F9u4DXSMLxQ==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.6.tgz",
+      "integrity": "sha512-iOo0VEay2XFhaCcH0sps5XIimkSuOnNaZrf6+ZkoSOQBJPKNU48RkmJv0/lSpipexu5P+ouFgafe5IGr/DiQfg==",
       "cpu": [
         "arm64"
       ],
@@ -5033,48 +5099,10 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
-    "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.3.tgz",
-      "integrity": "sha512-Elcv/BtML9lXrV6JuKITc/grN2kYV9gjsQpW8Jfw4ioK0TOkjBjye0nnyqQNy9STNaI20lXNaQBRrD5gSgR0Yg==",
-      "cpu": [
-        "wasm32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/core": "1.11.1",
-        "@emnapi/runtime": "1.11.1",
-        "@napi-rs/wasm-runtime": "^1.1.6"
-      },
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
-      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@tybys/wasm-util": "^0.10.3"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Brooooooklyn"
-      },
-      "peerDependencies": {
-        "@emnapi/core": "^1.7.1",
-        "@emnapi/runtime": "^1.7.1"
-      }
-    },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.3.tgz",
-      "integrity": "sha512-2DrEfhluH9yhiaFApmsjsjwrSYbNcY1oFTzYSP1a535jDbV98zCFanA/96TBUd0iDFcxGmw9QRExwGCXz3U+/g==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.6.tgz",
+      "integrity": "sha512-y5NTmmasMS455JlOCO4ZM9krIchv3Mvm1crL1iUPGOPgEzSkves9n0SdC5Sjz6+qWDFhd8/JpfWMH8NSWNHe+A==",
       "cpu": [
         "arm64"
       ],
@@ -5089,9 +5117,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.3.tgz",
-      "integrity": "sha512-OL4OMk7UPXOeVGGd3qo5zJyPIljf4AFgk5QAkPPS+OoLuOOozhuaQGC18MxVTnw/06q93gShAJzlwnSCY9YtqA==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.6.tgz",
+      "integrity": "sha512-np8iZSLfXlAD4kWhiyq/u0Yt8oZDtRQ8lGhQaCXo2rl37KNjeU0GjJuwr4P3oeZ++ROfofsKNBqR5LTO8aXyWQ==",
       "cpu": [
         "x64"
       ],
@@ -5156,6 +5184,49 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@rollup/pluginutils": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.4.0.tgz",
+      "integrity": "sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-walker": "^2.0.2",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/pluginutils/node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/pluginutils/node_modules/picomatch": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+      "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -5201,90 +5272,6 @@
         "typescript": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@serwist/build/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/@serwist/build/node_modules/brace-expansion": {
-      "version": "5.0.9",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
-      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/@serwist/build/node_modules/glob": {
-      "version": "13.0.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
-      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "minimatch": "^10.2.2",
-        "minipass": "^7.1.3",
-        "path-scurry": "^2.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@serwist/build/node_modules/lru-cache": {
-      "version": "11.5.2",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
-      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/@serwist/build/node_modules/minimatch": {
-      "version": "10.2.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "brace-expansion": "^5.0.5"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@serwist/build/node_modules/path-scurry": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
-      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "lru-cache": "^11.0.0",
-        "minipass": "^7.1.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@serwist/build/node_modules/source-map": {
@@ -5362,57 +5349,6 @@
         }
       }
     },
-    "node_modules/@serwist/cli/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/@serwist/cli/node_modules/brace-expansion": {
-      "version": "5.0.9",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
-      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/@serwist/cli/node_modules/glob": {
-      "version": "13.0.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
-      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "minimatch": "^10.2.2",
-        "minipass": "^7.1.3",
-        "path-scurry": "^2.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@serwist/cli/node_modules/lru-cache": {
-      "version": "11.3.5",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
-      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
     "node_modules/@serwist/cli/node_modules/meow": {
       "version": "14.1.0",
       "resolved": "https://registry.npmjs.org/meow/-/meow-14.1.0.tgz",
@@ -5424,39 +5360,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@serwist/cli/node_modules/minimatch": {
-      "version": "10.2.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "brace-expansion": "^5.0.5"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@serwist/cli/node_modules/path-scurry": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
-      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "lru-cache": "^11.0.0",
-        "minipass": "^7.1.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@serwist/cli/node_modules/zod": {
@@ -5545,90 +5448,6 @@
         "browserslist": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@serwist/next/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/@serwist/next/node_modules/brace-expansion": {
-      "version": "5.0.9",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
-      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/@serwist/next/node_modules/glob": {
-      "version": "13.0.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
-      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "minimatch": "^10.2.2",
-        "minipass": "^7.1.3",
-        "path-scurry": "^2.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@serwist/next/node_modules/lru-cache": {
-      "version": "11.5.2",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
-      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/@serwist/next/node_modules/minimatch": {
-      "version": "10.2.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "brace-expansion": "^5.0.5"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@serwist/next/node_modules/path-scurry": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
-      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "lru-cache": "^11.0.0",
-        "minipass": "^7.1.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@serwist/next/node_modules/source-map": {
@@ -5740,90 +5559,6 @@
         "browserslist": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@serwist/webpack-plugin/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/@serwist/webpack-plugin/node_modules/brace-expansion": {
-      "version": "5.0.9",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
-      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/@serwist/webpack-plugin/node_modules/glob": {
-      "version": "13.0.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
-      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "minimatch": "^10.2.2",
-        "minipass": "^7.1.3",
-        "path-scurry": "^2.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@serwist/webpack-plugin/node_modules/lru-cache": {
-      "version": "11.5.2",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
-      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/@serwist/webpack-plugin/node_modules/minimatch": {
-      "version": "10.2.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
-      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "brace-expansion": "^5.0.8"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@serwist/webpack-plugin/node_modules/path-scurry": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
-      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "lru-cache": "^11.0.0",
-        "minipass": "^7.1.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@serwist/webpack-plugin/node_modules/source-map": {
@@ -5959,6 +5694,201 @@
       "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
       "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
+    },
+    "node_modules/@storybook/builder-vite": {
+      "version": "10.5.10",
+      "resolved": "https://registry.npmjs.org/@storybook/builder-vite/-/builder-vite-10.5.10.tgz",
+      "integrity": "sha512-O4GgIP0tKLRueom3EmU3OaBUHKjNYj+jkOvmTIkn3PYTiWVkCuHqSKEs4ADvRyaQuLH+peHhFe4JtkNC9KbtrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@storybook/csf-plugin": "10.5.10",
+        "ts-dedent": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "storybook": "^10.5.10",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/@storybook/csf-plugin": {
+      "version": "10.5.10",
+      "resolved": "https://registry.npmjs.org/@storybook/csf-plugin/-/csf-plugin-10.5.10.tgz",
+      "integrity": "sha512-TaCLBrqVEr767+w58QDotDUiCTuE5cyRJuRcDlsKQyUIyGBv+lYD3lu8wBiVCYxgIjB/gu9HmqiC+0yx1rHzaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "unplugin": "^2.3.5"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "esbuild": "*",
+        "rollup": "*",
+        "storybook": "^10.5.10",
+        "vite": "*",
+        "webpack": "*"
+      },
+      "peerDependenciesMeta": {
+        "esbuild": {
+          "optional": true
+        },
+        "rollup": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        },
+        "webpack": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@storybook/global": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@storybook/global/-/global-5.0.0.tgz",
+      "integrity": "sha512-FcOqPAXACP0I3oJ/ws6/rrPT9WGhu915Cg8D02a9YxLo0DE9zI+a9A5gRGvmQ09fiWPukqI8ZAEoQEdWUKMQdQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@storybook/icons": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@storybook/icons/-/icons-2.1.0.tgz",
+      "integrity": "sha512-Fxh9vYpX9bQqFeHRiY8h2ApeRGDzRSMLwJwNZ/AIRqnyOKHxRKL+yFe+ctEkVJmuptRE9u1Hrn8ZZNHyfDKKNg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@storybook/react": {
+      "version": "10.5.10",
+      "resolved": "https://registry.npmjs.org/@storybook/react/-/react-10.5.10.tgz",
+      "integrity": "sha512-4MBV5e1SXIMfPynLHzr+Mp0dwGv/FW1bklWAsS4ynBOAbC98W9p/I9vqBnUctsvE3BJkhzHQQyPwMHL5tTcHVA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@storybook/global": "^5.0.0",
+        "@storybook/react-dom-shim": "10.5.10",
+        "react-docgen": "^8.0.2",
+        "react-docgen-typescript": "^2.2.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "storybook": "^10.5.10",
+        "typescript": ">= 4.9.x"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@storybook/react-dom-shim": {
+      "version": "10.5.10",
+      "resolved": "https://registry.npmjs.org/@storybook/react-dom-shim/-/react-dom-shim-10.5.10.tgz",
+      "integrity": "sha512-rbu62ILo/VE3iXKmu+kWXFpD1H1Lwi0f19q/x7JnDsD2dxKS9w5znLEqPIq2qxpzi/wjjIb2iUP1cRG1d/9W5A==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "storybook": "^10.5.10"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@storybook/react-vite": {
+      "version": "10.5.10",
+      "resolved": "https://registry.npmjs.org/@storybook/react-vite/-/react-vite-10.5.10.tgz",
+      "integrity": "sha512-xOztxefUnqKeuyvcnjspqmlDnER4cExL+liltrpdXLPJVqfFNr9lgM49FyEPajzsUVG9W/vHJWjbaQGGu1UsYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@joshwooding/vite-plugin-react-docgen-typescript": "^0.7.0",
+        "@rollup/pluginutils": "^5.0.2",
+        "@storybook/builder-vite": "10.5.10",
+        "@storybook/react": "10.5.10",
+        "empathic": "^2.0.0",
+        "magic-string": "^0.30.0",
+        "react-docgen": "^8.0.2",
+        "resolve": "^1.22.8",
+        "tsconfig-paths": "^4.2.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "storybook": "^10.5.10",
+        "typescript": ">= 4.9.x",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@storybook/react-vite/node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@storybook/react-vite/node_modules/tsconfig-paths": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz",
+      "integrity": "sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json5": "^2.2.2",
+        "minimist": "^1.2.6",
+        "strip-bom": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
@@ -6295,6 +6225,290 @@
       "integrity": "sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==",
       "license": "MIT"
     },
+    "node_modules/@tailwindcss/vite": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.3.3.tgz",
+      "integrity": "sha512-yYU8cogLeSh/ms2jh8Fj7jaba/EWa7Ja6GoUqYZaraEuCI5YS6ms6ObZgjjedm+jm6XZjdNRWBpPP6Z86oOxcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tailwindcss/node": "4.3.3",
+        "@tailwindcss/oxide": "4.3.3",
+        "tailwindcss": "4.3.3"
+      },
+      "peerDependencies": {
+        "vite": "^5.2.0 || ^6 || ^7 || ^8"
+      }
+    },
+    "node_modules/@tailwindcss/vite/node_modules/@tailwindcss/node": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.3.tgz",
+      "integrity": "sha512-/T8IKEsf9VTU6tLjgC7+sv2mOPtQxzE2jMw7u4Tt40Tx+QSZxpzh95/H6cMKoja9XuW7iMdLJYBB0o9G1CaAgg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.5",
+        "enhanced-resolve": "^5.24.1",
+        "jiti": "^2.7.0",
+        "lightningcss": "1.32.0",
+        "magic-string": "^0.30.21",
+        "source-map-js": "^1.2.1",
+        "tailwindcss": "4.3.3"
+      }
+    },
+    "node_modules/@tailwindcss/vite/node_modules/@tailwindcss/oxide": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.3.tgz",
+      "integrity": "sha512-krXjAikiaFSPaK/FkAQT5UTx3VormQaiZ5hBFlJZ9UFQGB/rwg1MZIhHAG9smMQRTdyJxP6Qt5MwMtdyU5FWrA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      },
+      "optionalDependencies": {
+        "@tailwindcss/oxide-android-arm64": "4.3.3",
+        "@tailwindcss/oxide-darwin-arm64": "4.3.3",
+        "@tailwindcss/oxide-darwin-x64": "4.3.3",
+        "@tailwindcss/oxide-freebsd-x64": "4.3.3",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.3",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.3.3",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.3.3",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.3.3",
+        "@tailwindcss/oxide-linux-x64-musl": "4.3.3",
+        "@tailwindcss/oxide-wasm32-wasi": "4.3.3",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.3.3",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.3.3"
+      }
+    },
+    "node_modules/@tailwindcss/vite/node_modules/@tailwindcss/oxide-android-arm64": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.3.tgz",
+      "integrity": "sha512-Y85A2gmPSkl5Ve5qR86GL4HT509cFqQh1aes9p3sSkyTPwt0Pppf3GkwGe4JPACcRYjgJIEhQgM6dBClnr0NYw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/vite/node_modules/@tailwindcss/oxide-darwin-arm64": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.3.tgz",
+      "integrity": "sha512-BiaWatpBcERQFDlOjRDpIVXuFK5PJez5SA4JMg6VYZdBYU+qKfV/vqjcIs+IYmtitf1xYQZTwXvU/8y4lfZUGw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/vite/node_modules/@tailwindcss/oxide-darwin-x64": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.3.tgz",
+      "integrity": "sha512-fAeUqfV5ndhxRwai8cXGzdLvul9utWOmeTkv69unv4ZXixjn61Z+p9lCWdwOwA3TYboG3BwdVuN/RDjhBRl0mw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/vite/node_modules/@tailwindcss/oxide-freebsd-x64": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.3.tgz",
+      "integrity": "sha512-iyf5bV6+wnAlflVeEy7R25dupxTNECZN5QMI0qNT6eT+EgaGdZcKhGkr5SdoaWiLJ3spLqIY9VCeSGrwmtg4kw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/vite/node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.3.tgz",
+      "integrity": "sha512-aAYUprJAJQWWbRrPvtjdroZ56Md+JM8pMiopS6xGEwDfLhqj+2ver2p4nU4Mb3CRqcMmNBjo8KkUgcxhkzVQGQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/vite/node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.3.tgz",
+      "integrity": "sha512-nDxldcEENOxZRzC2uu9jrutZdAAQtb+8WWDCSnWL1zvBk1+FN+x6MtDViPB5AJMfttVCUhehGWus3XBPgatM/w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/vite/node_modules/@tailwindcss/oxide-linux-arm64-musl": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.3.tgz",
+      "integrity": "sha512-Md44bD6veX/PC5iyF8cDVnw4HBIANZepRZZ7a8DQOvkfo5WUBwcp6iAuCUz23u+4SUkhJlD3eL7hNdW8ezd/kA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/vite/node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.3.tgz",
+      "integrity": "sha512-tx7us1muwOKAKWao2v/GaafFeQboE6aj88vC6ziN2NCGcRm8gWUhwjzg+YdVB1e4boAtdtma4L43onunI6NS4w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/vite/node_modules/@tailwindcss/oxide-linux-x64-musl": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.3.tgz",
+      "integrity": "sha512-SJxX60smvHgasZoBy11dX6YRjXJFovwWBoedhbQPOBzgFWBHGB+TVPWB9BxzR7TTxU8FQZAI2AyiNCMzFm8Img==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/vite/node_modules/@tailwindcss/oxide-wasm32-wasi": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.3.tgz",
+      "integrity": "sha512-jx1+rPhY/5Ympkktd656HBWEBLxP7dH06losBLjjf5vgCODXvi9KhtftWcMIwTFIDqBr7cRnQkdLnAG+IOlGvQ==",
+      "bundleDependencies": [
+        "@napi-rs/wasm-runtime",
+        "@emnapi/core",
+        "@emnapi/runtime",
+        "@tybys/wasm-util",
+        "@emnapi/wasi-threads",
+        "tslib"
+      ],
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.11.1",
+        "@emnapi/runtime": "^1.11.1",
+        "@emnapi/wasi-threads": "^1.2.2",
+        "@napi-rs/wasm-runtime": "^1.1.4",
+        "@tybys/wasm-util": "^0.10.2",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@tailwindcss/vite/node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.3.tgz",
+      "integrity": "sha512-3rc292Ca2ceK6Ulcc/bAVnTs/3nDtoPhyEKlgPv+yQJQi/JS/AMJlqzxvlDacL1nekbrcf6bTqp/jV4qgnPxNQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/vite/node_modules/@tailwindcss/oxide-win32-x64-msvc": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.3.tgz",
+      "integrity": "sha512-yJ0pwIVc/nYeGoV02WtsN8KYyLQv7kyI2wDnkezyJlGGjkd4QLwDGAwl47YpPJeuI0M0ObaXGSPjvWDPeTPggw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/@testing-library/dom": {
       "version": "10.4.1",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
@@ -6526,6 +6740,51 @@
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -6807,6 +7066,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/doctrine": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/@types/doctrine/-/doctrine-0.0.9.tgz",
+      "integrity": "sha512-eOIHzCUSH7SMfonMG1LsC2f8vxBFtho6NGBznK41R84YzPuvSBzrhEps33IsQiOW9+VL6NQ9DbjQJznk/S4uRA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/dom-chromium-ai": {
       "version": "0.0.17",
       "resolved": "https://registry.npmjs.org/@types/dom-chromium-ai/-/dom-chromium-ai-0.0.17.tgz",
@@ -6822,9 +7088,9 @@
       "license": "MIT"
     },
     "node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "license": "MIT"
     },
     "node_modules/@types/estree-jsx": {
@@ -6927,6 +7193,13 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/resolve": {
+      "version": "1.20.6",
+      "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.6.tgz",
+      "integrity": "sha512-A4STmOXPhMUtHH+S6ymgE2GiBSMqf4oTvcQZMcHzokuTLVYzXTB8ttjcgxOVaAp2lGwEdzZ0J+cRbbeevQj1UQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/trusted-types": {
       "version": "2.0.7",
@@ -7876,6 +8149,13 @@
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
+    },
+    "node_modules/@webcontainer/env": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@webcontainer/env/-/env-1.1.1.tgz",
+      "integrity": "sha512-6aN99yL695Hi9SuIk1oC88l9o0gmxL1nGWWQ/kNy81HigJ0FoaoTXpytCj6ItzgyCEwA9kF1wixsTuv5cjsgng==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@workflow/serde": {
       "version": "4.1.0",
@@ -9373,6 +9653,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
     "node_modules/chokidar": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
@@ -10627,6 +10917,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/deep-extend": {
@@ -12900,6 +13200,24 @@
       "integrity": "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==",
       "license": "ISC"
     },
+    "node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -12911,6 +13229,45 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.8"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/global-directory": {
@@ -14740,6 +15097,13 @@
         "json5": "lib/cli.js"
       }
     },
+    "node_modules/jsonc-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/jsx-ast-utils": {
       "version": "3.3.5",
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
@@ -15380,6 +15744,13 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lowlight": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-3.3.0.tgz",
@@ -15520,6 +15891,10 @@
     },
     "node_modules/matrix-design-system": {
       "resolved": "packages/matrix-design-system",
+      "link": true
+    },
+    "node_modules/matrix-design-system-showcase": {
+      "resolved": "apps/matrix-design-system-showcase",
       "link": true
     },
     "node_modules/matrix-rain-webgpu": {
@@ -17690,6 +18065,33 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/path-to-regexp": {
       "version": "8.4.2",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
@@ -17705,6 +18107,16 @@
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
     },
     "node_modules/peberminta": {
       "version": "0.9.0",
@@ -18369,6 +18781,64 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-docgen": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/react-docgen/-/react-docgen-8.0.3.tgz",
+      "integrity": "sha512-aEZ9qP+/M+58x2qgfSFEWH1BxLyHe5+qkLNJOZQb5iGS017jpbRnoKhNRrXPeA6RfBrZO5wZrT9DMC1UqE1f1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.28.0",
+        "@babel/traverse": "^7.28.0",
+        "@babel/types": "^7.28.2",
+        "@types/babel__core": "^7.20.5",
+        "@types/babel__traverse": "^7.20.7",
+        "@types/doctrine": "^0.0.9",
+        "@types/resolve": "^1.20.2",
+        "doctrine": "^3.0.0",
+        "resolve": "^1.22.1",
+        "strip-indent": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.9.0 || >=22"
+      }
+    },
+    "node_modules/react-docgen-typescript": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/react-docgen-typescript/-/react-docgen-typescript-2.4.0.tgz",
+      "integrity": "sha512-ZtAp5XTO5HRzQctjPU0ybY0RRCQO19X/8fxn3w7y2VVTUbGHDKULPTL4ky3vB05euSgG5NpALhEhDPvQ56wvXg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "typescript": ">= 4.3.x"
+      }
+    },
+    "node_modules/react-docgen/node_modules/doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/react-docgen/node_modules/strip-indent": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-4.1.1.tgz",
+      "integrity": "sha512-SlyRoSkdh1dYP0PzclLE7r0M9sgbFKKMFXpFRUMNuKhQSbC6VQIGzq3E0qsfvGJaUFJPGv6Ws1NZ/haTAjfbMA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/react-dom": {
       "version": "19.2.6",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
@@ -18548,6 +19018,36 @@
       "resolved": "https://registry.npmjs.org/reading-time/-/reading-time-1.5.0.tgz",
       "integrity": "sha512-onYyVhBNr4CmAxFsKS7bz+uTLRakypIe4R+5A824vBSkQy/hB3fZepoVEf8OVAxzLvK+H/jm9TzpI3ETSm64Kg==",
       "license": "MIT"
+    },
+    "node_modules/recast": {
+      "version": "0.23.21",
+      "resolved": "https://registry.npmjs.org/recast/-/recast-0.23.21.tgz",
+      "integrity": "sha512-mFAyJq9vUbSTARLZUvAEf1z3YxlvAwswbmxMx2mPA/MSm4KmpwvwvhsH/NIrZhyOuwD60Lzyw2qh83uCbgTPYw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ast-types": "^0.16.1",
+        "esprima": "~4.0.0",
+        "source-map": "~0.6.1",
+        "tiny-invariant": "^1.3.3",
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/recast/node_modules/ast-types": {
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.16.1.tgz",
+      "integrity": "sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/recharts": {
       "version": "3.9.0",
@@ -19229,13 +19729,13 @@
       "license": "Unlicense"
     },
     "node_modules/rolldown": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.3.tgz",
-      "integrity": "sha512-1F1eEtUBtFvcGm1HQ9TiUIUHPQG7mSAODrhIzjxoUEFuo8OcbrGLiVLkevNgj84TE4lnHvnumwFjhJO5Eu135g==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.6.tgz",
+      "integrity": "sha512-vMM4q3aixf46GiF1Kok8jDPFsEpXgFWGjUHXNkNHNm+Y2adXAG2dbX91jkti3i0ZRsOlcmbuzAz1poObSHCmUA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.137.0",
+        "@oxc-project/types": "=0.147.0",
         "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
@@ -19245,21 +19745,21 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.1.3",
-        "@rolldown/binding-darwin-arm64": "1.1.3",
-        "@rolldown/binding-darwin-x64": "1.1.3",
-        "@rolldown/binding-freebsd-x64": "1.1.3",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.1.3",
-        "@rolldown/binding-linux-arm64-gnu": "1.1.3",
-        "@rolldown/binding-linux-arm64-musl": "1.1.3",
-        "@rolldown/binding-linux-ppc64-gnu": "1.1.3",
-        "@rolldown/binding-linux-s390x-gnu": "1.1.3",
-        "@rolldown/binding-linux-x64-gnu": "1.1.3",
-        "@rolldown/binding-linux-x64-musl": "1.1.3",
-        "@rolldown/binding-openharmony-arm64": "1.1.3",
-        "@rolldown/binding-wasm32-wasi": "1.1.3",
-        "@rolldown/binding-win32-arm64-msvc": "1.1.3",
-        "@rolldown/binding-win32-x64-msvc": "1.1.3"
+        "@rolldown/binding-android-arm-eabi": "1.2.6",
+        "@rolldown/binding-android-arm64": "1.2.6",
+        "@rolldown/binding-darwin-arm64": "1.2.6",
+        "@rolldown/binding-darwin-x64": "1.2.6",
+        "@rolldown/binding-freebsd-x64": "1.2.6",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.2.6",
+        "@rolldown/binding-linux-arm64-gnu": "1.2.6",
+        "@rolldown/binding-linux-arm64-musl": "1.2.6",
+        "@rolldown/binding-linux-ppc64-gnu": "1.2.6",
+        "@rolldown/binding-linux-s390x-gnu": "1.2.6",
+        "@rolldown/binding-linux-x64-gnu": "1.2.6",
+        "@rolldown/binding-linux-x64-musl": "1.2.6",
+        "@rolldown/binding-openharmony-arm64": "1.2.6",
+        "@rolldown/binding-win32-arm64-msvc": "1.2.6",
+        "@rolldown/binding-win32-x64-msvc": "1.2.6"
       }
     },
     "node_modules/rolldown-plugin-dts": {
@@ -19318,6 +19818,16 @@
       },
       "funding": {
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/rolldown/node_modules/@oxc-project/types": {
+      "version": "0.147.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.147.0.tgz",
+      "integrity": "sha512-IJ3s6ltHLp45S0bh7phkX+gJO7A1Wuz2EaqpAhb8WjqDwbzMiWKHhyyT42tskaWjEYXtHtVCPpnBJVT9+dcRLg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
       }
     },
     "node_modules/roughjs": {
@@ -19919,7 +20429,6 @@
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -20014,6 +20523,1005 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/storybook": {
+      "version": "10.5.10",
+      "resolved": "https://registry.npmjs.org/storybook/-/storybook-10.5.10.tgz",
+      "integrity": "sha512-Rz8k9ejFHsi7lbtJTaxZlhCUz4GkbJIKEoKDjXeLfr/ZhXip73E6keKxW0KH8iGeKiCqHAbJCV4YIQrxTOLiig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@storybook/global": "^5.0.0",
+        "@storybook/icons": "^2.0.2",
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/jest-dom": "6.9.1",
+        "@testing-library/user-event": "^14.6.1",
+        "@vitest/expect": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@webcontainer/env": "^1.1.1",
+        "esbuild": "^0.18.0 || ^0.19.0 || ^0.20.0 || ^0.21.0 || ^0.22.0 || ^0.23.0 || ^0.24.0 || ^0.25.0 || ^0.26.0 || ^0.27.0 || ^0.28.0",
+        "jsonc-parser": "^3.3.1",
+        "open": "^10.2.0",
+        "oxc-parser": "^0.127.0",
+        "oxc-resolver": "11.21.2",
+        "recast": "^0.23.5",
+        "semver": "^7.7.3",
+        "use-sync-external-store": "^1.5.0",
+        "ws": "^8.21.1"
+      },
+      "bin": {
+        "storybook": "dist/bin/dispatcher.js"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "prettier": "^2 || ^3",
+        "vite-plus": "^0.1.15 || ^0.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "prettier": {
+          "optional": true
+        },
+        "vite-plus": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/storybook/node_modules/@emnapi/core": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/storybook/node_modules/@emnapi/runtime": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/storybook/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/storybook/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.2.3.tgz",
+      "integrity": "sha512-UMduMbqO5s5zF2NkNacMT/yK5Y5QiKvWr2+50bzIIxFDwVJ2h49b+oyjaCGPhJxd2/gC2x39EHv/gHVuu36x2Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=23.5.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1 || ^2.0.0-alpha.4",
+        "@emnapi/runtime": "^1.7.1 || ^2.0.0-alpha.4"
+      }
+    },
+    "node_modules/storybook/node_modules/@oxc-parser/binding-android-arm-eabi": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm-eabi/-/binding-android-arm-eabi-0.127.0.tgz",
+      "integrity": "sha512-0LC7ye4hvqbIKxAzThzvswgHLFu2AURKzYLeSVvLdu2TBOYWQDmHnTqPLeA597BcUCxiLqLsS4CJ5uoI5WYWCQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/storybook/node_modules/@oxc-parser/binding-android-arm64": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm64/-/binding-android-arm64-0.127.0.tgz",
+      "integrity": "sha512-b5jtVTH6AU5CJXHNdj7Jj9IEiR9yVjjnwHzPJhGyHGPdcsZSzBCkS9GBbV33niRMvKthDwQRFRJfI4a+k4PvYg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/storybook/node_modules/@oxc-parser/binding-darwin-arm64": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.127.0.tgz",
+      "integrity": "sha512-obCE8B7ISKkJidjlhv9xRGJPOSDG2Yu6PRga9Ruaz35uintHxbp1Ki/Yc71wx4rj3Edrm0a1kzG1TAwit0wFpg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/storybook/node_modules/@oxc-parser/binding-darwin-x64": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.127.0.tgz",
+      "integrity": "sha512-JL6Xb5IwPQT8rUzlpsX7E+AgfcdNklXNPFp8pjCQQ5MQOQo5rtEB2ui+3Hgg9Sn7Y9Egj6YOLLiHhLpdAe12Aw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/storybook/node_modules/@oxc-parser/binding-freebsd-x64": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.127.0.tgz",
+      "integrity": "sha512-SDQ/3MQFw58fqQz3Z1PhSKFF3JoCF4gmlNjziDm8X02tTahCw0qJbd7FGPDKw1i4VTBZene9JPyC3mHtSvi+wA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/storybook/node_modules/@oxc-parser/binding-linux-arm-gnueabihf": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.127.0.tgz",
+      "integrity": "sha512-Av+D1MIqzV0YMGPT9we2SIZaMKD7Cxs4CvXSx/yxaWHewZjYEjScpOf5igc8IILASViw4WTnjlwUdI1KzVtDHQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/storybook/node_modules/@oxc-parser/binding-linux-arm-musleabihf": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.127.0.tgz",
+      "integrity": "sha512-Cs2fdJ8cPpFdeebj6p4dag8A4+56hPvZ0AhQQzlaLswGz1tz7bXt1nETLeorrM9+AMcWFFkqxcXwDGfTVidY8g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/storybook/node_modules/@oxc-parser/binding-linux-arm64-gnu": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.127.0.tgz",
+      "integrity": "sha512-qdOfTcT6SY8gsJrrV92uyEUyjqMGPpIB5JZUG6QN5dukYd+7/j0kX6MwK1DgQj39jtUYixxPiaRUiEN1+0CXgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/storybook/node_modules/@oxc-parser/binding-linux-arm64-musl": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.127.0.tgz",
+      "integrity": "sha512-EoTCZneNFU/P2qrpEM+RHmQwt+CvDkyGESG6qhr7KaegXLZwePfbrkCDfAk8/rhxbDUVGsZILX+2tqPzFtoFWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/storybook/node_modules/@oxc-parser/binding-linux-ppc64-gnu": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.127.0.tgz",
+      "integrity": "sha512-zALjmZYgxFLHjXeudcDF0xFGNydTAtkAeXAr2EuC17ywCyFxcmQra4w0BMde0Yi/re4Bi4iwEoEXtYN7l6eBLQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/storybook/node_modules/@oxc-parser/binding-linux-riscv64-gnu": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.127.0.tgz",
+      "integrity": "sha512-fPP8M6zQLS7Jz7o9d5ArUSuAuSK3e+WCYVrCpdzeCOejidtZExJ9tjhDrAd3HEPqARBCPmdpqxESPFqy44vkBQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/storybook/node_modules/@oxc-parser/binding-linux-riscv64-musl": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.127.0.tgz",
+      "integrity": "sha512-7IcC4Ao02oGpfnjt+X/oF4U2mllo2qoSkw5xxiXNKL9MCTsTiAC6616beOuehdxGcnz1bRoPC1RQ2f1GQDdN+g==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/storybook/node_modules/@oxc-parser/binding-linux-s390x-gnu": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.127.0.tgz",
+      "integrity": "sha512-pbXIhiNFHoqWeqDNLiJ9JkpHz1IM9k4DXa66x+1GTWMG7iLxtkXgE53iiuKSXwmk3zIYmaPVfBvgcAhS583K4Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/storybook/node_modules/@oxc-parser/binding-linux-x64-gnu": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.127.0.tgz",
+      "integrity": "sha512-MYCguB9RvBvlSd6gbuNI7QwiLoCCAlGnlRJFPrzLI6U1/9wkC/WK6LtBAUln55H1Ctqw45PWmqrobKoMhsYQzQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/storybook/node_modules/@oxc-parser/binding-linux-x64-musl": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.127.0.tgz",
+      "integrity": "sha512-5eY0B/bxf1xIUxb4NOTvOI3KWtBQfPWYyKAzgcrCt0mDibSZygVpO1Pz8bkeiSZ5Jj9+M09dkggG3H8I5d0Uyg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/storybook/node_modules/@oxc-parser/binding-openharmony-arm64": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-openharmony-arm64/-/binding-openharmony-arm64-0.127.0.tgz",
+      "integrity": "sha512-Gld0ajrFTUXNtdw20fVBuTQx66FA75nIVg+//pPfR3sXkuABB4mTBhl3r9JNzrJpgW//qiwxf0nWXUWGJSL3UQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/storybook/node_modules/@oxc-parser/binding-wasm32-wasi": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-wasm32-wasi/-/binding-wasm32-wasi-0.127.0.tgz",
+      "integrity": "sha512-T6KVD7rhLzFlwGRXMnxUFfkCZD8FHnb968wVXW1mXzgRFc5RNXOBY2mPPDZ77x5Ln76ltLMgtPg0cOkU1NSrEQ==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.9.2",
+        "@emnapi/runtime": "1.9.2",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/storybook/node_modules/@oxc-parser/binding-win32-arm64-msvc": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.127.0.tgz",
+      "integrity": "sha512-Ujvw4X+LD1CCGULcsQcvb4YNVoBGqt+JHgNNzGGaCImELiZLk477ifUH53gIbE7EKd933NdTi25JWEr9K2HwXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/storybook/node_modules/@oxc-parser/binding-win32-ia32-msvc": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.127.0.tgz",
+      "integrity": "sha512-0cwxKO7KHQQQfo4Uf4B2SQrhgm+cJaP9OvFFhx52Tkg4bezsacu83GB2/In5bC415Ueeym+kXdnge/57rbSfTw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/storybook/node_modules/@oxc-parser/binding-win32-x64-msvc": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.127.0.tgz",
+      "integrity": "sha512-rOrnSQSCbhI2kowr9XxE7m9a8oQXnBHjnS6j95LxxAnEZ0+Fz20WlRXG4ondQb+ejjt2KOsa65sE6++L6kUd+w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/storybook/node_modules/@oxc-project/types": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.127.0.tgz",
+      "integrity": "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/storybook/node_modules/@oxc-resolver/binding-android-arm-eabi": {
+      "version": "11.21.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-android-arm-eabi/-/binding-android-arm-eabi-11.21.2.tgz",
+      "integrity": "sha512-xQoCRv+gKax9KTdwdaQNnAFOai8neay7g3jExDIORzhbrejwGSJaZNTdOJHR5ziLg2joMxOCMOFMo4zuxza2uQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/storybook/node_modules/@oxc-resolver/binding-android-arm64": {
+      "version": "11.21.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-android-arm64/-/binding-android-arm64-11.21.2.tgz",
+      "integrity": "sha512-HF5oiE2L05yInPYCFD/4uxSrEZW4SuIfn99Y6L1xnJnzl066JR+MJs2rIdstw8A2MPlAKH+13dpFPNycjqzvGg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/storybook/node_modules/@oxc-resolver/binding-darwin-arm64": {
+      "version": "11.21.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-darwin-arm64/-/binding-darwin-arm64-11.21.2.tgz",
+      "integrity": "sha512-UX4u49CVCAD8QZNELaW8eMGgMAGwFWYEPbvNsh+3r/gs4NX3KfpiACMVwRQT0EuH3uat9hM5Zl+Ppm9pJD8tgg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/storybook/node_modules/@oxc-resolver/binding-darwin-x64": {
+      "version": "11.21.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-darwin-x64/-/binding-darwin-x64-11.21.2.tgz",
+      "integrity": "sha512-J9xPx7YBkrRmJ+xl561ztnMWEc1aOyjEIxBiGX1dVb3u7bGSnfObfcZk+Pd+uM0HZAPNsQ1xvD8j52A/uOSqNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/storybook/node_modules/@oxc-resolver/binding-freebsd-x64": {
+      "version": "11.21.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-freebsd-x64/-/binding-freebsd-x64-11.21.2.tgz",
+      "integrity": "sha512-fRlt7OvSaQkWj6+EDTVxawVxOlqJB2QSnBfkeCyK4RTvsGctbw3BiH2Tb7DzMs7bikc4BRBpvWP5zF9K8b54Zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/storybook/node_modules/@oxc-resolver/binding-linux-arm-gnueabihf": {
+      "version": "11.21.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-11.21.2.tgz",
+      "integrity": "sha512-gK+vPUcPQITkGwBKpZGrcDHSlU6eDGl7AQacxS2CEKAZIBHWkOVFeJwLZ4tYnA1acJqRM5lt7yYwPCVqGHIJ7A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/storybook/node_modules/@oxc-resolver/binding-linux-arm-musleabihf": {
+      "version": "11.21.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-11.21.2.tgz",
+      "integrity": "sha512-L/Rgas7SrOKy/z7IH+HxSFRqVO4PuLDKLEGKvnhoCBBq3UJ0YzGBou3qMzaAGgkJwsIvX2pBF+7ojzfUhLiZxQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/storybook/node_modules/@oxc-resolver/binding-linux-arm64-gnu": {
+      "version": "11.21.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-11.21.2.tgz",
+      "integrity": "sha512-CUEYvlX1Fk7E9kUMzuswru1J9HLxMwnpDeQGjQuI4ZH+iNCoa2X9T+pvyzrbsgl7WnIeTFTlNlHsRfVdf5g9/g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/storybook/node_modules/@oxc-resolver/binding-linux-arm64-musl": {
+      "version": "11.21.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm64-musl/-/binding-linux-arm64-musl-11.21.2.tgz",
+      "integrity": "sha512-ViN1ZibQyxwC67GpoP33oo+S9UyUnkog13vzQb9+v9bCNvrVzJuk0MRdacjtv/9xfRMVF/eqHFyl8YOeykI10Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/storybook/node_modules/@oxc-resolver/binding-linux-ppc64-gnu": {
+      "version": "11.21.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-11.21.2.tgz",
+      "integrity": "sha512-CU1sCqWnhGqYD5I1HedHk5pujrn7ssDkNB/AEQd/pd3D/EojVSgJUlpbafwIbyhia3PgIfkvdFpRPWSALzVumA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/storybook/node_modules/@oxc-resolver/binding-linux-riscv64-gnu": {
+      "version": "11.21.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-11.21.2.tgz",
+      "integrity": "sha512-jWVyZtIHca4Gb96x7dag+y69vlei7ffjrsveLkmf2ZhqEAz6ZSBnY1GWvgZUaZlwZP62A3xD092BW97Q5VGc+g==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/storybook/node_modules/@oxc-resolver/binding-linux-riscv64-musl": {
+      "version": "11.21.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-11.21.2.tgz",
+      "integrity": "sha512-LF29obFqNgBUgDX7rmUK7M4D0JQG5LxhYzn3xXmECcHU9aQAdWG7NiY052qybtesEdwHQXKNTWYQ7mTsybNvWg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/storybook/node_modules/@oxc-resolver/binding-linux-s390x-gnu": {
+      "version": "11.21.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-11.21.2.tgz",
+      "integrity": "sha512-+NYcm+cCHBbtdQQ3A4phQTSuVRYnNHz7wrl9XRAPEovcdoqi0mb1K5ZOl+jN54ZD+q1zz3V0vltbFJmzecJKmw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/storybook/node_modules/@oxc-resolver/binding-linux-x64-gnu": {
+      "version": "11.21.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-x64-gnu/-/binding-linux-x64-gnu-11.21.2.tgz",
+      "integrity": "sha512-UQqZDdG2r2HhAOsZEgufkIWHPQ886IUyuJQkoZByvzhW8j51R4UNzGBJFkTiTnLhQnggwJRdJgFWK4uY6ZVIMw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/storybook/node_modules/@oxc-resolver/binding-linux-x64-musl": {
+      "version": "11.21.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-x64-musl/-/binding-linux-x64-musl-11.21.2.tgz",
+      "integrity": "sha512-3Q9PMRjalWkT6NZ4jfujuqTCFwoWErg3y3BnOgb544B8IMw4PktiwWOigMfOHNRLMghZeJ7hpfpZf4CP7rV7Og==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/storybook/node_modules/@oxc-resolver/binding-openharmony-arm64": {
+      "version": "11.21.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-openharmony-arm64/-/binding-openharmony-arm64-11.21.2.tgz",
+      "integrity": "sha512-Eljeq3ndtyKhM+Es8LITi4Zl2htzuRZcrPMF3kMCsrILztvU6AjZ3FuEhHHKobPUB9rMpzLpJP5bDqXI7r+iog==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/storybook/node_modules/@oxc-resolver/binding-wasm32-wasi": {
+      "version": "11.21.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-wasm32-wasi/-/binding-wasm32-wasi-11.21.2.tgz",
+      "integrity": "sha512-HGDbNsIywqc4LxU38+CTJNnB/6BF7rheWOJ259b4eE0aEnelYblC8x+1tEd63bp31fYne63RQz9Jb4yVnC7Yig==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.0",
+        "@emnapi/runtime": "1.11.0",
+        "@napi-rs/wasm-runtime": "^1.1.5"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/storybook/node_modules/@oxc-resolver/binding-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.0.tgz",
+      "integrity": "sha512-l9Oo58x0HOP5znGzVhYW9U3e5wVuA4LAZU2AGezTmkhO1CgQRFDhDg4nneHsu/t3WniXg9QrG2nIXL/ZS8ln8Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/storybook/node_modules/@oxc-resolver/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.0.tgz",
+      "integrity": "sha512-55coeOFKHv1ywEcUXJtWU5f+Jr/W5tZDvZig8DLKSwUN1JpROQ4rk/SNOQiFWmaR/VKF4zuFyW1B8JduOSv6Pg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/storybook/node_modules/@oxc-resolver/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/storybook/node_modules/@oxc-resolver/binding-win32-arm64-msvc": {
+      "version": "11.21.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-11.21.2.tgz",
+      "integrity": "sha512-iWx25CBEgH49iE9q5coEGI/jb1jl5kkCY9z6U5Og67xCkQ/WFMDc2J5U78+AE91SUxM2NqSLhJC8/PLfWnImww==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/storybook/node_modules/@oxc-resolver/binding-win32-x64-msvc": {
+      "version": "11.21.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-win32-x64-msvc/-/binding-win32-x64-msvc-11.21.2.tgz",
+      "integrity": "sha512-VPoCAhKvCQTlG7vxqaBXcmuvbh77BfnGXj8g0pbvVXpm1F/R8rDVwqIWcEbMzrI1JvJlm8v7T9uMVQb6UctMRg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/storybook/node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/storybook/node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/storybook/node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/storybook/node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/storybook/node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/storybook/node_modules/open": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
+      "integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "default-browser": "^5.2.1",
+        "define-lazy-prop": "^3.0.0",
+        "is-inside-container": "^1.0.0",
+        "wsl-utils": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/storybook/node_modules/oxc-parser": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.127.0.tgz",
+      "integrity": "sha512-bkgD4qHlN7WxLdX8bLXdaU54TtQtAIg/ZBAfm0aje/mo3MRDo3P0hZSgr4U7O3xfX+fQmR5AP04JS/TGcZLcFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "^0.127.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      },
+      "optionalDependencies": {
+        "@oxc-parser/binding-android-arm-eabi": "0.127.0",
+        "@oxc-parser/binding-android-arm64": "0.127.0",
+        "@oxc-parser/binding-darwin-arm64": "0.127.0",
+        "@oxc-parser/binding-darwin-x64": "0.127.0",
+        "@oxc-parser/binding-freebsd-x64": "0.127.0",
+        "@oxc-parser/binding-linux-arm-gnueabihf": "0.127.0",
+        "@oxc-parser/binding-linux-arm-musleabihf": "0.127.0",
+        "@oxc-parser/binding-linux-arm64-gnu": "0.127.0",
+        "@oxc-parser/binding-linux-arm64-musl": "0.127.0",
+        "@oxc-parser/binding-linux-ppc64-gnu": "0.127.0",
+        "@oxc-parser/binding-linux-riscv64-gnu": "0.127.0",
+        "@oxc-parser/binding-linux-riscv64-musl": "0.127.0",
+        "@oxc-parser/binding-linux-s390x-gnu": "0.127.0",
+        "@oxc-parser/binding-linux-x64-gnu": "0.127.0",
+        "@oxc-parser/binding-linux-x64-musl": "0.127.0",
+        "@oxc-parser/binding-openharmony-arm64": "0.127.0",
+        "@oxc-parser/binding-wasm32-wasi": "0.127.0",
+        "@oxc-parser/binding-win32-arm64-msvc": "0.127.0",
+        "@oxc-parser/binding-win32-ia32-msvc": "0.127.0",
+        "@oxc-parser/binding-win32-x64-msvc": "0.127.0"
+      }
+    },
+    "node_modules/storybook/node_modules/oxc-resolver": {
+      "version": "11.21.2",
+      "resolved": "https://registry.npmjs.org/oxc-resolver/-/oxc-resolver-11.21.2.tgz",
+      "integrity": "sha512-w5tLwYN3Zo24w5EeWJjJWZOwhYqTtC8PS2B1tIt7BZUuqTIcU07sQValbDw+rq7+AuAGzOHklgK+ifsy4lpXfw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      },
+      "optionalDependencies": {
+        "@oxc-resolver/binding-android-arm-eabi": "11.21.2",
+        "@oxc-resolver/binding-android-arm64": "11.21.2",
+        "@oxc-resolver/binding-darwin-arm64": "11.21.2",
+        "@oxc-resolver/binding-darwin-x64": "11.21.2",
+        "@oxc-resolver/binding-freebsd-x64": "11.21.2",
+        "@oxc-resolver/binding-linux-arm-gnueabihf": "11.21.2",
+        "@oxc-resolver/binding-linux-arm-musleabihf": "11.21.2",
+        "@oxc-resolver/binding-linux-arm64-gnu": "11.21.2",
+        "@oxc-resolver/binding-linux-arm64-musl": "11.21.2",
+        "@oxc-resolver/binding-linux-ppc64-gnu": "11.21.2",
+        "@oxc-resolver/binding-linux-riscv64-gnu": "11.21.2",
+        "@oxc-resolver/binding-linux-riscv64-musl": "11.21.2",
+        "@oxc-resolver/binding-linux-s390x-gnu": "11.21.2",
+        "@oxc-resolver/binding-linux-x64-gnu": "11.21.2",
+        "@oxc-resolver/binding-linux-x64-musl": "11.21.2",
+        "@oxc-resolver/binding-openharmony-arm64": "11.21.2",
+        "@oxc-resolver/binding-wasm32-wasi": "11.21.2",
+        "@oxc-resolver/binding-win32-arm64-msvc": "11.21.2",
+        "@oxc-resolver/binding-win32-x64-msvc": "11.21.2"
+      }
+    },
+    "node_modules/storybook/node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/storybook/node_modules/wsl-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
+      "integrity": "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-wsl": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/stream-events": {
@@ -20598,6 +22106,16 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/tldts": {
       "version": "7.4.9",
       "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.9.tgz",
@@ -20862,272 +22380,6 @@
         }
       }
     },
-    "node_modules/tsdown/node_modules/@oxc-project/types": {
-      "version": "0.147.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.147.0.tgz",
-      "integrity": "sha512-IJ3s6ltHLp45S0bh7phkX+gJO7A1Wuz2EaqpAhb8WjqDwbzMiWKHhyyT42tskaWjEYXtHtVCPpnBJVT9+dcRLg==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/Boshen"
-      }
-    },
-    "node_modules/tsdown/node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.6.tgz",
-      "integrity": "sha512-lkWU8ZJaRk9q3CIEY1Tc7vIFALp3Xw5NfGJo2hQg5oIqNgxWi1zI+IiDEK3r70BF5Dzol1tcXsnzsRc8NLhG+Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/tsdown/node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.6.tgz",
-      "integrity": "sha512-dgR56NYnvAszm7Ob1B2/Vn0e8bUQYZH2UjVaMMtMVOCKFSfjhfLmuA/9+O+F+ajUdG6B/bSssrKW6JJYASa8jA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/tsdown/node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.6.tgz",
-      "integrity": "sha512-vpVxFvUCFioJqug7OTvqptkc4yb8UX0AwfDmJpaR/0sWz+BUmqSVAf7c8JkUgnN8YLspb4a/N6NhTyMAmdyQ7Q==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/tsdown/node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.6.tgz",
-      "integrity": "sha512-h1wG6Y6K3JlRswxsI64qQJqBAy4vrLuHgRbc8CZMGSWTOFRY6ghMApM1NKzB2I0n5xV1fjkE18SuVl2QpLeNpA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/tsdown/node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.6.tgz",
-      "integrity": "sha512-tbCiqub0q2MVWJKgF5PoAlNWCtQydiOYSLIkd8sByqK/6MMYLJRcSXSYodqYtd0O+Fw7QaVmKKlS4oL94YRZ0w==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/tsdown/node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.6.tgz",
-      "integrity": "sha512-oxK9+baEBPhZG5HB4URY+uU04zJWeZlH6Tb9rB5DK4DF9XR1uXNLXt5Q5ZsugTKayNCNLhkcwz/ye74hRI98dg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/tsdown/node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.6.tgz",
-      "integrity": "sha512-muWCk27FVBEZtv0MsK8gnfSmgczA8KQ0uRVJbTABKhkRfQc38aUrcb7fhi3BNiyseFmgcRsoMfQsSNJ+DbZdSw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "libc": [
-        "musl"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/tsdown/node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.6.tgz",
-      "integrity": "sha512-eWDoSfU7Co2qj3vgB3Dt4lj1mG6CoWbcJQkRMP3XJplyCMtuaq3LHvPFjS9QIPvMGWVadJC04Xiy0IdcVPtnwQ==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/tsdown/node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.6.tgz",
-      "integrity": "sha512-2bWNjRSIayvupRKxXUY2tWG9fYdoUlTqWywHRvE8Eq3GvuQ+f2HeIkve697fIt+IQs/PV8yFsdWuhp1aJ1PdnA==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/tsdown/node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.6.tgz",
-      "integrity": "sha512-KekI0gS0wLxe1UBSQSjenBVwou/JkcQPDzBPICGZjxUv9k3RteHDPBQaiOicZUFKRIH2wKEimGwVpnJsbPzu7w==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/tsdown/node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.6.tgz",
-      "integrity": "sha512-TvtPnfVr+HtyGiDmPK4VWmlNm7QhNNAcK5Q9A7aOXsI8545yCyaoMaicXrFZ72JzeYjaUVk7yT243zT0jzjFKQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "libc": [
-        "musl"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/tsdown/node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.6.tgz",
-      "integrity": "sha512-iOo0VEay2XFhaCcH0sps5XIimkSuOnNaZrf6+ZkoSOQBJPKNU48RkmJv0/lSpipexu5P+ouFgafe5IGr/DiQfg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/tsdown/node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.6.tgz",
-      "integrity": "sha512-y5NTmmasMS455JlOCO4ZM9krIchv3Mvm1crL1iUPGOPgEzSkves9n0SdC5Sjz6+qWDFhd8/JpfWMH8NSWNHe+A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/tsdown/node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.6.tgz",
-      "integrity": "sha512-np8iZSLfXlAD4kWhiyq/u0Yt8oZDtRQ8lGhQaCXo2rl37KNjeU0GjJuwr4P3oeZ++ROfofsKNBqR5LTO8aXyWQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
     "node_modules/tsdown/node_modules/picomatch": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
@@ -21139,40 +22391,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/tsdown/node_modules/rolldown": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.6.tgz",
-      "integrity": "sha512-vMM4q3aixf46GiF1Kok8jDPFsEpXgFWGjUHXNkNHNm+Y2adXAG2dbX91jkti3i0ZRsOlcmbuzAz1poObSHCmUA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@oxc-project/types": "=0.147.0",
-        "@rolldown/pluginutils": "^1.0.0"
-      },
-      "bin": {
-        "rolldown": "bin/cli.mjs"
-      },
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      },
-      "optionalDependencies": {
-        "@rolldown/binding-android-arm-eabi": "1.2.6",
-        "@rolldown/binding-android-arm64": "1.2.6",
-        "@rolldown/binding-darwin-arm64": "1.2.6",
-        "@rolldown/binding-darwin-x64": "1.2.6",
-        "@rolldown/binding-freebsd-x64": "1.2.6",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.2.6",
-        "@rolldown/binding-linux-arm64-gnu": "1.2.6",
-        "@rolldown/binding-linux-arm64-musl": "1.2.6",
-        "@rolldown/binding-linux-ppc64-gnu": "1.2.6",
-        "@rolldown/binding-linux-s390x-gnu": "1.2.6",
-        "@rolldown/binding-linux-x64-gnu": "1.2.6",
-        "@rolldown/binding-linux-x64-musl": "1.2.6",
-        "@rolldown/binding-openharmony-arm64": "1.2.6",
-        "@rolldown/binding-win32-arm64-msvc": "1.2.6",
-        "@rolldown/binding-win32-x64-msvc": "1.2.6"
       }
     },
     "node_modules/tslib": {
@@ -21665,6 +22883,35 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/unplugin": {
+      "version": "2.3.11",
+      "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-2.3.11.tgz",
+      "integrity": "sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.5",
+        "acorn": "^8.15.0",
+        "picomatch": "^4.0.3",
+        "webpack-virtual-modules": "^0.6.2"
+      },
+      "engines": {
+        "node": ">=18.12.0"
+      }
+    },
+    "node_modules/unplugin/node_modules/picomatch": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+      "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/unrs-resolver": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.11.1.tgz",
@@ -21934,16 +23181,16 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.0.tgz",
-      "integrity": "sha512-BuJcQK/56NQTWDGn4ABea3q4SSBdNPWwNZKTkkUpcMPnLoquSYH8llRtSUIgoL1KSCpHt5eghLShn50mH36y7Q==",
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.2.tgz",
+      "integrity": "sha512-cFKLV/PRgAUlIRm5WjMjJ86jrftzpqcgH+Us+DS8mI3CDNiH30Whrz8uHL3+MOLPAgqbMBAqWdAHAphOAM+z/Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "lightningcss": "^1.32.0",
-        "picomatch": "^4.0.4",
-        "postcss": "^8.5.15",
-        "rolldown": "~1.1.2",
+        "lightningcss": "^1.33.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.26",
+        "rolldown": "~1.2.4",
         "tinyglobby": "^0.2.17"
       },
       "bin": {
@@ -21960,7 +23207,7 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
-        "@vitejs/devtools": "^0.3.0",
+        "@vitejs/devtools": "^0.4.0 || ^0.5.0",
         "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",
@@ -22011,10 +23258,283 @@
         }
       }
     },
+    "node_modules/vite/node_modules/lightningcss": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-android-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-darwin-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-darwin-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-freebsd-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/vite/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+      "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -22022,6 +23542,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vite/node_modules/postcss": {
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.17",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/vitest": {
@@ -22223,6 +23772,13 @@
       "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
       "dev": true,
       "license": "BSD-2-Clause"
+    },
+    "node_modules/webpack-virtual-modules": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.6.2.tgz",
+      "integrity": "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/website": {
       "resolved": "apps/website",
@@ -22528,6 +24084,28 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/wsl-utils": {
       "version": "0.3.1",
@@ -22836,6 +24414,7 @@
         "@babel/core": "^7.28.5",
         "@eslint/js": "^9",
         "@rolldown/plugin-babel": "^0.2.3",
+        "@storybook/react-vite": "^10.5.10",
         "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",

--- a/packages/matrix-design-system/.dependency-cruiser.cjs
+++ b/packages/matrix-design-system/.dependency-cruiser.cjs
@@ -55,7 +55,10 @@ const config = {
     ],
     options: {
         doNotFollow: { path: "node_modules" },
-        exclude: { path: "(\\.(test|spec)\\.(ts|tsx)$|src/test-utils/)" },
+        // Stories are documentation, not shipped code: they are excluded from `files`, and they
+        // compose across layers on purpose — an atom's story may show it inside a realistic
+        // molecule. Same reasoning as tests, which were already excluded.
+        exclude: { path: "(\\.(test|spec|stories)\\.(ts|tsx)$|src/(test-utils|stories)/)" },
         tsPreCompilationDeps: true,
         tsConfig: { fileName: "tsconfig.json" },
         moduleSystems: ["es6", "cjs"],

--- a/packages/matrix-design-system/eslint.config.mjs
+++ b/packages/matrix-design-system/eslint.config.mjs
@@ -38,7 +38,17 @@ export default [
     },
     {
         files: ["src/**/*.tsx"],
-        ignores: ["src/**/use-*.tsx", "src/**/*.test.tsx", "src/test-utils/**"],
+        // Stories document the components; they are not components. folder-composition would
+        // reject every *.stories.tsx for not matching its folder, and jsx-no-bind would reject the
+        // inline handlers a story uses to stand in for real behaviour. Tests are ignored here for
+        // the same reason.
+        ignores: [
+            "src/**/use-*.tsx",
+            "src/**/*.test.tsx",
+            "src/**/*.stories.tsx",
+            "src/test-utils/**",
+            "src/stories/**",
+        ],
         plugins: { chicio },
         rules: {
             "react/jsx-no-bind": ["error", { allowArrowFunctions: false, allowFunctions: false, allowBind: false }],

--- a/packages/matrix-design-system/package.json
+++ b/packages/matrix-design-system/package.json
@@ -123,6 +123,7 @@
     "@babel/core": "^7.28.5",
     "@eslint/js": "^9",
     "@rolldown/plugin-babel": "^0.2.3",
+    "@storybook/react-vite": "^10.5.10",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",

--- a/packages/matrix-design-system/src/atoms/animation/motion-div/motion-div.stories.tsx
+++ b/packages/matrix-design-system/src/atoms/animation/motion-div/motion-div.stories.tsx
@@ -1,0 +1,86 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { MotionDiv } from ".";
+
+// Typed as plain Meta/StoryObj rather than Meta<typeof Component>. These stories render
+// explicitly instead of being driven by args — several compose more than one component —
+// so binding the story type to a single component's props would demand an `args` object
+// that nothing reads.
+const meta: Meta = {
+    title: "Atoms/Animation/Motion Div",
+    component: MotionDiv,
+};
+
+export default meta;
+
+type Story = StoryObj;
+
+// initial={false} renders the element straight at its `animate` state. Mount transitions cannot be
+// captured in a still frame anyway, and under the screenshot harness they are frozen mid-flight, so
+// an `initial={{ opacity: 0 }}` entrance photographs as an empty card.
+
+const DefaultStory = () => (
+    <div className="flex">
+        <MotionDiv
+            className="glow-container max-w-md p-5"
+            initial={false}
+            animate={{ opacity: 1, y: 0 }}
+            whileHover={{ scale: 1.05 }}
+            transition={{ type: "spring", stiffness: 300, damping: 20 }}
+        >
+            <h3 className="text-accent mt-0 mb-2">Matrix Rain WebGPU</h3>
+            <p className="text-primary-text m-0">
+                GPU-accelerated Matrix-style digital rain for React, built with WebGPU and TypeGPU.
+            </p>
+        </MotionDiv>
+    </div>
+);
+
+const StaggeredStackStory = () => (
+    <div className="flex max-w-md flex-col gap-3">
+        <MotionDiv
+            className="glow-container p-4"
+            initial={false}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ type: "spring", stiffness: 100, damping: 12 }}
+        >
+            <span className="text-primary-text font-mono">React Native Skia Skeleton</span>
+        </MotionDiv>
+        <MotionDiv
+            className="glow-container p-4"
+            initial={false}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ type: "spring", stiffness: 100, damping: 12, delay: 0.1 }}
+        >
+            <span className="text-primary-text font-mono">Matrix Rain WebGPU</span>
+        </MotionDiv>
+        <MotionDiv
+            className="glow-container p-4"
+            initial={false}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ type: "spring", stiffness: 100, damping: 12, delay: 0.2 }}
+        >
+            <span className="text-primary-text font-mono">Chicio Coding blog</span>
+        </MotionDiv>
+    </div>
+);
+
+const AnimatedBarStory = () => (
+    <div className="flex w-full max-w-md flex-col gap-2">
+        <div className="flex items-center justify-between">
+            <span className="text-primary-text font-mono text-sm">Reading progress</span>
+            <span className="text-accent font-mono text-sm">72%</span>
+        </div>
+        <div className="bg-general-background-light border-accent-alpha-25 h-8 w-full overflow-hidden rounded-full border">
+            <MotionDiv
+                className="bg-accent h-full rounded-full"
+                initial={false}
+                animate={{ width: "72%" }}
+                transition={{ duration: 0.6, ease: "easeOut" }}
+            />
+        </div>
+    </div>
+);
+
+export const Default: Story = { render: () => <DefaultStory /> };
+export const StaggeredStack: Story = { render: () => <StaggeredStackStory /> };
+export const AnimatedBar: Story = { render: () => <AnimatedBarStory /> };

--- a/packages/matrix-design-system/src/atoms/buttons/button/button.stories.tsx
+++ b/packages/matrix-design-system/src/atoms/buttons/button/button.stories.tsx
@@ -1,0 +1,47 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Button } from ".";
+
+// Typed as plain Meta/StoryObj rather than Meta<typeof Component>. These stories render
+// explicitly instead of being driven by args — several compose more than one component —
+// so binding the story type to a single component's props would demand an `args` object
+// that nothing reads.
+const meta: Meta = {
+    title: "Atoms/Buttons/Button",
+    component: Button,
+};
+
+export default meta;
+
+type Story = StoryObj;
+
+const DefaultStory = () => (
+    <div className="flex">
+        <Button onClick={() => {}}>Read the full article</Button>
+    </div>
+);
+
+const WithIconStory = () => (
+    <div className="flex">
+        <Button className="my-2 flex items-center gap-4" onClick={() => {}} type="button">
+            <div className="flex-shrink-0">💬</div>
+            <span className="text-primary-text flex-1 text-sm leading-normal">
+                What did you work on at lastminute.com?
+            </span>
+        </Button>
+    </div>
+);
+
+const ActionRowStory = () => (
+    <div className="flex flex-wrap gap-3">
+        <Button onClick={() => {}}>
+            <p>TL;DR</p>
+        </Button>
+        <Button onClick={() => {}}>
+            <p>Key Points</p>
+        </Button>
+    </div>
+);
+
+export const Default: Story = { render: () => <DefaultStory /> };
+export const WithIcon: Story = { render: () => <WithIconStory /> };
+export const ActionRow: Story = { render: () => <ActionRowStory /> };

--- a/packages/matrix-design-system/src/atoms/call-to-actions/call-to-action-external-with-tracking/call-to-action-external-with-tracking.stories.tsx
+++ b/packages/matrix-design-system/src/atoms/call-to-actions/call-to-action-external-with-tracking/call-to-action-external-with-tracking.stories.tsx
@@ -1,0 +1,64 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { CallToActionExternalWithTracking } from ".";
+
+// Typed as plain Meta/StoryObj rather than Meta<typeof Component>. These stories render
+// explicitly instead of being driven by args — several compose more than one component —
+// so binding the story type to a single component's props would demand an `args` object
+// that nothing reads.
+const meta: Meta = {
+    title: "Atoms/Call To Actions/Call To Action External With Tracking",
+    component: CallToActionExternalWithTracking,
+};
+
+export default meta;
+
+type Story = StoryObj;
+
+const DefaultStory = () => (
+    <div className="flex">
+        <CallToActionExternalWithTracking
+            href="https://github.com/chicio/matrix-rain-webgpu"
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={() => {}}
+        >
+            Github
+        </CallToActionExternalWithTracking>
+    </div>
+);
+
+const LongLabelStory = () => (
+    <div className="flex">
+        <CallToActionExternalWithTracking
+            href="https://www.npmjs.com/package/react-native-skia-skeleton"
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={() => {}}
+        >
+            Read the documentation
+        </CallToActionExternalWithTracking>
+    </div>
+);
+
+const ProjectActionsStory = () => (
+    <div className="flex flex-wrap gap-4">
+        <CallToActionExternalWithTracking
+            href="https://github.com/chicio/react-native-skia-skeleton"
+            target="_blank"
+            rel="noopener noreferrer"
+        >
+            Github
+        </CallToActionExternalWithTracking>
+        <CallToActionExternalWithTracking
+            href="https://www.npmjs.com/package/react-native-skia-skeleton"
+            target="_blank"
+            rel="noopener noreferrer"
+        >
+            NPM
+        </CallToActionExternalWithTracking>
+    </div>
+);
+
+export const Default: Story = { render: () => <DefaultStory /> };
+export const LongLabel: Story = { render: () => <LongLabelStory /> };
+export const ProjectActions: Story = { render: () => <ProjectActionsStory /> };

--- a/packages/matrix-design-system/src/atoms/call-to-actions/call-to-action-internal-with-tracking/call-to-action-internal-with-tracking.stories.tsx
+++ b/packages/matrix-design-system/src/atoms/call-to-actions/call-to-action-internal-with-tracking/call-to-action-internal-with-tracking.stories.tsx
@@ -1,0 +1,45 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { CallToActionInternalWithTracking } from ".";
+import { BiEnvelope } from "react-icons/bi";
+
+// Typed as plain Meta/StoryObj rather than Meta<typeof Component>. These stories render
+// explicitly instead of being driven by args — several compose more than one component —
+// so binding the story type to a single component's props would demand an `args` object
+// that nothing reads.
+const meta: Meta = {
+    title: "Atoms/Call To Actions/Call To Action Internal With Tracking",
+    component: CallToActionInternalWithTracking,
+};
+
+export default meta;
+
+type Story = StoryObj;
+
+const DefaultStory = () => (
+    <div className="flex">
+        <CallToActionInternalWithTracking to="/blog" onClick={() => {}}>
+            Go to the blog
+        </CallToActionInternalWithTracking>
+    </div>
+);
+
+const IconOnlyStory = () => (
+    <div className="flex">
+        <CallToActionInternalWithTracking to="/contact" onClick={() => {}} className="min-w-auto!">
+            <BiEnvelope size={30} />
+        </CallToActionInternalWithTracking>
+    </div>
+);
+
+const NavigationRowStory = () => (
+    <div className="flex flex-wrap gap-4">
+        <CallToActionInternalWithTracking to="/data-structures-and-algorithms/roadmap">
+            DSA roadmap
+        </CallToActionInternalWithTracking>
+        <CallToActionInternalWithTracking to="/chat">Chat with my AI</CallToActionInternalWithTracking>
+    </div>
+);
+
+export const Default: Story = { render: () => <DefaultStory /> };
+export const IconOnly: Story = { render: () => <IconOnlyStory /> };
+export const NavigationRow: Story = { render: () => <NavigationRowStory /> };

--- a/packages/matrix-design-system/src/atoms/chip/chip.stories.tsx
+++ b/packages/matrix-design-system/src/atoms/chip/chip.stories.tsx
@@ -1,0 +1,43 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Chip } from ".";
+
+// Typed as plain Meta/StoryObj rather than Meta<typeof Component>. These stories render
+// explicitly instead of being driven by args — several compose more than one component —
+// so binding the story type to a single component's props would demand an `args` object
+// that nothing reads.
+const meta: Meta = {
+    title: "Atoms/Chip",
+    component: Chip,
+};
+
+export default meta;
+
+type Story = StoryObj;
+
+// Single instances are wrapped in a flex row: in a plain block context the chip stretches to the
+// full card width and reads as a bar rather than a chip.
+const DefaultStory = () => (
+    <div className="flex">
+        <Chip>TypeScript</Chip>
+    </div>
+);
+
+const BigStory = () => (
+    <div className="flex">
+        <Chip big>Data structures and algorithms</Chip>
+    </div>
+);
+
+const TagRowStory = () => (
+    <div className="flex flex-wrap gap-2">
+        <Chip>Next.js</Chip>
+        <Chip>React</Chip>
+        <Chip>TailwindCSS</Chip>
+        <Chip>Swift</Chip>
+        <Chip>Kotlin</Chip>
+    </div>
+);
+
+export const Default: Story = { render: () => <DefaultStory /> };
+export const Big: Story = { render: () => <BigStory /> };
+export const TagRow: Story = { render: () => <TagRowStory /> };

--- a/packages/matrix-design-system/src/atoms/effects/image-glow/image-glow.stories.tsx
+++ b/packages/matrix-design-system/src/atoms/effects/image-glow/image-glow.stories.tsx
@@ -1,0 +1,64 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { ImageGlow } from ".";
+import { landscapeImage, squarePortrait } from "../../../stories/sample-media";
+
+// Typed as plain Meta/StoryObj rather than Meta<typeof Component>. These stories render
+// explicitly instead of being driven by args — several compose more than one component —
+// so binding the story type to a single component's props would demand an `args` object
+// that nothing reads.
+const meta: Meta = {
+    title: "Atoms/Effects/Image Glow",
+    component: ImageGlow,
+};
+
+export default meta;
+
+type Story = StoryObj;
+
+const DefaultStory = () => (
+    <div className="flex">
+        <ImageGlow
+            className="h-[150px] w-[150px] rounded-full"
+            src={squarePortrait}
+            alt="Fabrizio Duroni"
+            width={150}
+            height={150}
+        />
+    </div>
+);
+
+const NoGlowStory = () => (
+    <div className="flex">
+        <ImageGlow src={squarePortrait} alt="Fabrizio Duroni" width={150} height={150} />
+    </div>
+);
+
+const AuthorBylineStory = () => (
+    <div className="flex items-center gap-2">
+        <ImageGlow
+            className="rounded-full"
+            src={squarePortrait}
+            alt="Antonino Gitto"
+            width={30}
+            height={30}
+            noPlaceholder={true}
+        />
+        <p className="text-primary-text">Antonino Gitto</p>
+    </div>
+);
+
+const FillCoverStory = () => (
+    <div className="relative h-64 w-full overflow-hidden">
+        <ImageGlow
+            fill={true}
+            className="relative! h-full! w-full! object-cover"
+            src={landscapeImage}
+            alt="Digital painting from the art gallery"
+        />
+    </div>
+);
+
+export const Default: Story = { render: () => <DefaultStory /> };
+export const NoGlow: Story = { render: () => <NoGlowStory /> };
+export const AuthorByline: Story = { render: () => <AuthorBylineStory /> };
+export const FillCover: Story = { render: () => <FillCoverStory /> };

--- a/packages/matrix-design-system/src/atoms/effects/matrix-rain/matrix-rain/matrix-rain.stories.tsx
+++ b/packages/matrix-design-system/src/atoms/effects/matrix-rain/matrix-rain/matrix-rain.stories.tsx
@@ -1,0 +1,60 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { MatrixRain } from ".";
+import { Cursor, TerminalLine } from "../../../typography/terminal-blocks";
+
+// Typed as plain Meta/StoryObj rather than Meta<typeof Component>. These stories render
+// explicitly instead of being driven by args — several compose more than one component —
+// so binding the story type to a single component's props would demand an `args` object
+// that nothing reads.
+const meta: Meta = {
+    title: "Atoms/Effects/Matrix Rain/Matrix Rain",
+    component: MatrixRain,
+};
+
+export default meta;
+
+type Story = StoryObj;
+
+// The Cursor blink is a CSS keyframe animation and the capture freezes the page clock, so an
+// unpaused cursor photographs at whatever frame it happens to be in (often the transparent half).
+// Pausing it pins it to the 0% keyframe, where it is visible.
+const freeze = `.ds-still, .ds-still * { animation-play-state: paused !important; }`;
+
+// MatrixRain paints into the nearest positioned ancestor and contributes no layout of its own, so
+// every cell gives it a sized box. WebGPU is unavailable in headless Chromium, so what is captured
+// here is the 2D canvas fallback the component ships with.
+const DefaultStory = () => (
+    <div className="border-accent relative h-64 w-full overflow-hidden border">
+        <MatrixRain />
+    </div>
+);
+
+const BehindContentStory = () => (
+    <div className="border-accent ds-still relative flex h-64 w-full items-center justify-center overflow-hidden border">
+        <style>{freeze}</style>
+        <MatrixRain />
+        <span className="text-accent z-10 font-mono text-2xl font-bold uppercase text-shadow-lg">
+            Wake up, Neo
+            <Cursor />
+        </span>
+    </div>
+);
+
+const TerminalBackdropStory = () => (
+    <div className="border-accent ds-still relative h-64 w-full overflow-hidden border">
+        <style>{freeze}</style>
+        <MatrixRain />
+        <div className="glassmorphism-lite-no-scale relative z-10 m-4 p-4">
+            <TerminalLine>{"> "}npm run dev</TerminalLine>
+            <TerminalLine>{"> "}search index generated — 514 documents</TerminalLine>
+            <TerminalLine>
+                {"> "}ready on http://localhost:3000
+                <Cursor />
+            </TerminalLine>
+        </div>
+    </div>
+);
+
+export const Default: Story = { render: () => <DefaultStory /> };
+export const BehindContent: Story = { render: () => <BehindContentStory /> };
+export const TerminalBackdrop: Story = { render: () => <TerminalBackdropStory /> };

--- a/packages/matrix-design-system/src/atoms/effects/overlay/overlay.stories.tsx
+++ b/packages/matrix-design-system/src/atoms/effects/overlay/overlay.stories.tsx
@@ -1,0 +1,89 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Chip } from "../../chip";
+import { Overlay } from ".";
+import { Cursor, TerminalLine } from "../../typography/terminal-blocks";
+import { PageTitle } from "../../../molecules/typography/page-title";
+
+// Typed as plain Meta/StoryObj rather than Meta<typeof Component>. These stories render
+// explicitly instead of being driven by args — several compose more than one component —
+// so binding the story type to a single component's props would demand an `args` object
+// that nothing reads.
+const meta: Meta = {
+    title: "Atoms/Effects/Overlay",
+    component: Overlay,
+};
+
+export default meta;
+
+type Story = StoryObj;
+
+// Capture-stability shim, not styling. The capture screenshots after networkidle with the page clock
+// frozen, so framer-motion's fade-in (initial opacity 0 -> 1) never advances and the whole overlay
+// photographs as if it were not mounted. An !important author rule outranks both the inline
+// `opacity: 0` framer writes and the WAAPI animation, pinning the overlay to its settled state; the
+// paused rule does the same for the Cursor blink keyframes.
+const freeze = `
+.ds-overlay-still { opacity: 1 !important; }
+.ds-overlay-still * { animation-play-state: paused !important; }
+`;
+
+const DimmedContentStory = () => (
+    <>
+        <style>{freeze}</style>
+        <div className="flex h-72 flex-col gap-2">
+            <PageTitle>Data structures and algorithms</PageTitle>
+            <p className="text-primary-text">
+                A complete course, from arrays and hash maps up to graphs and dynamic programming.
+            </p>
+            <div className="flex flex-wrap gap-2">
+                <Chip>Graph</Chip>
+                <Chip>Binary search</Chip>
+            </div>
+        </div>
+        <Overlay delay={0} className="ds-overlay-still" />
+    </>
+);
+
+const WithDialogStory = () => (
+    <>
+        <style>{freeze}</style>
+        <div className="flex h-72 flex-col gap-2">
+            <PageTitle>Blog</PageTitle>
+            <p className="text-primary-text">Pixels. Code. Unplugged.</p>
+        </div>
+        <Overlay delay={0} className="ds-overlay-still">
+            <div className="flex h-full w-full items-center justify-center p-4">
+                <div className="glassmorphism-lite-no-scale w-full max-w-md p-4">
+                    <TerminalLine>{"> "}Open the command palette?</TerminalLine>
+                    <TerminalLine>{"> "}Press ⌘K to search 514 pages.</TerminalLine>
+                </div>
+            </div>
+        </Overlay>
+    </>
+);
+
+const WithTerminalStory = () => (
+    <>
+        <style>{freeze}</style>
+        <div className="flex h-72 flex-col gap-2">
+            <PageTitle>Terminal</PageTitle>
+            <p className="text-primary-text">A Unix-like shell over the whole site.</p>
+        </div>
+        <Overlay delay={0} className="ds-overlay-still">
+            <div className="flex h-full w-full items-center justify-center p-4">
+                <div className="glow-border w-full max-w-md p-4">
+                    <TerminalLine>{"> "}cd /blog</TerminalLine>
+                    <TerminalLine>{"> "}ls</TerminalLine>
+                    <TerminalLine>
+                        {"> "}open swiftui-path-and-shape.mdx
+                        <Cursor />
+                    </TerminalLine>
+                </div>
+            </div>
+        </Overlay>
+    </>
+);
+
+export const DimmedContent: Story = { render: () => <DimmedContentStory /> };
+export const WithDialog: Story = { render: () => <WithDialogStory /> };
+export const WithTerminal: Story = { render: () => <WithTerminalStory /> };

--- a/packages/matrix-design-system/src/atoms/icons/copy-icon/copy-icon.stories.tsx
+++ b/packages/matrix-design-system/src/atoms/icons/copy-icon/copy-icon.stories.tsx
@@ -1,0 +1,80 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Button } from "../../buttons/button";
+import { CopiedIcon, CopyIcon } from ".";
+
+// Typed as plain Meta/StoryObj rather than Meta<typeof Component>. These stories render
+// explicitly instead of being driven by args — several compose more than one component —
+// so binding the story type to a single component's props would demand an `args` object
+// that nothing reads.
+const meta: Meta = {
+    title: "Atoms/Icons/Copy Icon",
+    component: CopiedIcon,
+};
+
+export default meta;
+
+type Story = StoryObj;
+
+// CopiedIcon is a fixed size-4 checkmark — the confirmed state of the code-block copy button. On its
+// own it is a 16px mark, so each cell gives it the label or button chrome it ships with.
+const CopiedIconDefaultStory = () => (
+    <div className="text-accent flex items-center gap-2">
+        <CopiedIcon />
+        <span className="font-mono text-sm">Copied!</span>
+    </div>
+);
+
+const CopiedIconCopyButtonStory = () => (
+    <div className="flex">
+        <span className="border-accent bg-general-background-light text-accent flex items-center gap-2 rounded border px-3 py-2">
+            <CopiedIcon />
+            <span className="font-mono text-xs tracking-wider uppercase">Copied</span>
+        </span>
+    </div>
+);
+
+const CopiedIconCodeBlockHeaderStory = () => (
+    <div className="border-accent bg-general-background-light flex w-full items-center justify-between rounded border px-3 py-2">
+        <span className="text-primary-text font-mono text-xs">use-reading-progress.ts</span>
+        <span className="text-accent flex items-center gap-2">
+            <CopiedIcon />
+            <span className="font-mono text-xs">Copied!</span>
+        </span>
+    </div>
+);
+
+// CopyIcon is a fixed 16px glyph that inherits its colour, so on its own it needs a coloured flex
+// row to be legible; the other cells show it where it actually lives, inside a code-block button.
+const CopyIconDefaultStory = () => (
+    <div className="text-accent flex items-center gap-2 font-mono text-sm">
+        <CopyIcon />
+        <span>Copy code</span>
+    </div>
+);
+
+const CopyIconInCopyButtonStory = () => (
+    <div className="flex">
+        <Button className="text-primary!" aria-label="Copy code">
+            <CopyIcon />
+        </Button>
+    </div>
+);
+
+const CopyIconOnCodeBlockStory = () => (
+    <div className="glow-container bg-general-background-light relative max-w-[500px] p-4">
+        <Button className="text-primary! absolute top-2 right-2 p-2!" aria-label="Copy code">
+            <CopyIcon />
+        </Button>
+        <div className="text-primary-text font-mono text-sm leading-relaxed">
+            <div>const posts = await getAllPosts();</div>
+            <div>return posts.slice(0, 5);</div>
+        </div>
+    </div>
+);
+
+export const CopiedIconDefault: Story = { render: () => <CopiedIconDefaultStory /> };
+export const CopiedIconCopyButton: Story = { render: () => <CopiedIconCopyButtonStory /> };
+export const CopiedIconCodeBlockHeader: Story = { render: () => <CopiedIconCodeBlockHeaderStory /> };
+export const CopyIconDefault: Story = { render: () => <CopyIconDefaultStory /> };
+export const CopyIconInCopyButton: Story = { render: () => <CopyIconInCopyButtonStory /> };
+export const CopyIconOnCodeBlock: Story = { render: () => <CopyIconOnCodeBlockStory /> };

--- a/packages/matrix-design-system/src/atoms/icons/rounded-icon/rounded-icon.stories.tsx
+++ b/packages/matrix-design-system/src/atoms/icons/rounded-icon/rounded-icon.stories.tsx
@@ -1,0 +1,73 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { RoundedIcon } from ".";
+
+// Typed as plain Meta/StoryObj rather than Meta<typeof Component>. These stories render
+// explicitly instead of being driven by args — several compose more than one component —
+// so binding the story type to a single component's props would demand an `args` object
+// that nothing reads.
+const meta: Meta = {
+    title: "Atoms/Icons/Rounded Icon",
+    component: RoundedIcon,
+};
+
+export default meta;
+
+type Story = StoryObj;
+
+// RoundedIcon is the accent-filled circle behind the site's floating actions (the chat launcher, the
+// back-to-top control). Its children are inline SVG glyphs drawn in currentColor, exactly like the
+// react-icons glyphs the real ChatIcon passes in.
+const chatGlyph = (
+    <svg viewBox="0 0 24 24" fill="currentColor" className="size-5" aria-hidden="true">
+        <path d="M20 2H4a2 2 0 0 0-2 2v18l4-4h14a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2zm0 14H5.17L4 17.17V4h16v12z" />
+        <circle cx="8" cy="10" r="1.4" />
+        <circle cx="12" cy="10" r="1.4" />
+        <circle cx="16" cy="10" r="1.4" />
+    </svg>
+);
+
+const arrowUpGlyph = (
+    <svg viewBox="0 0 24 24" fill="currentColor" className="size-5" aria-hidden="true">
+        <path d="M12 4l-8 8h5v8h6v-8h5z" />
+    </svg>
+);
+
+const terminalGlyph = (
+    <svg viewBox="0 0 24 24" fill="currentColor" className="size-5" aria-hidden="true">
+        <path d="M3 4h18v16H3V4zm2 2v12h14V6H5zm2 2.5L10.5 12 7 15.5 8.2 16.7 12.9 12 8.2 7.3 7 8.5zM13 15h5v1.6h-5V15z" />
+    </svg>
+);
+
+const DefaultStory = () => (
+    <div className="flex">
+        <RoundedIcon className="text-text-above-primary">{chatGlyph}</RoundedIcon>
+    </div>
+);
+
+// The real ChatIcon pulses and is used as the icon of the chat page's "Ask the Oracle" heading, so
+// this cell reproduces that pairing rather than the bare circle. package-capture screenshots with no
+// animation control, so the frame it catches is arbitrary — freezing the animation pins the cell to
+// the 0% keyframe (full opacity) and makes the shot deterministic.
+const ChatLauncherStory = () => (
+    <>
+        <style>{`.ds-anim-still, .ds-anim-still * { animation-play-state: paused !important; }`}</style>
+        <div className="ds-anim-still flex items-center gap-3">
+            <RoundedIcon className="text-text-above-primary flex animate-pulse items-center justify-center">
+                {chatGlyph}
+            </RoundedIcon>
+            <span className="text-accent text-2xl font-bold text-shadow-md">Ask the Oracle</span>
+        </div>
+    </>
+);
+
+const ActionRowStory = () => (
+    <div className="flex flex-wrap gap-2">
+        <RoundedIcon className="text-text-above-primary">{chatGlyph}</RoundedIcon>
+        <RoundedIcon className="text-text-above-primary">{terminalGlyph}</RoundedIcon>
+        <RoundedIcon className="text-text-above-primary">{arrowUpGlyph}</RoundedIcon>
+    </div>
+);
+
+export const Default: Story = { render: () => <DefaultStory /> };
+export const ChatLauncher: Story = { render: () => <ChatLauncherStory /> };
+export const ActionRow: Story = { render: () => <ActionRowStory /> };

--- a/packages/matrix-design-system/src/atoms/links/external-link/external-link.stories.tsx
+++ b/packages/matrix-design-system/src/atoms/links/external-link/external-link.stories.tsx
@@ -1,0 +1,73 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { ExternalLink } from ".";
+
+// Typed as plain Meta/StoryObj rather than Meta<typeof Component>. These stories render
+// explicitly instead of being driven by args — several compose more than one component —
+// so binding the story type to a single component's props would demand an `args` object
+// that nothing reads.
+const meta: Meta = {
+    title: "Atoms/Links/External Link",
+    component: ExternalLink,
+};
+
+export default meta;
+
+type Story = StoryObj;
+
+// ExternalLink is an unstyled anchor: the accent colour and glow come from the base `a` rule in the
+// theme. Single instances go in a flex row so the anchor shrinks to its text instead of reading as a
+// full-width bar.
+const DefaultStory = () => (
+    <div className="flex">
+        <ExternalLink href="https://github.com/chicio" target="_blank" rel="noopener noreferrer">
+            See the source on GitHub
+        </ExternalLink>
+    </div>
+);
+
+const SocialButtonsStory = () => (
+    <div className="flex flex-wrap items-center gap-3">
+        <ExternalLink
+            className="glow-container inline-flex items-center gap-2 px-4 py-2 no-underline"
+            href="https://www.linkedin.com/in/fabrizioduroni/"
+            target="_blank"
+            rel="noopener noreferrer"
+        >
+            LinkedIn
+        </ExternalLink>
+        <ExternalLink
+            className="glow-container inline-flex items-center gap-2 px-4 py-2 no-underline"
+            href="https://github.com/chicio"
+            target="_blank"
+            rel="noopener noreferrer"
+        >
+            GitHub
+        </ExternalLink>
+        <ExternalLink
+            className="glow-container inline-flex items-center gap-2 px-4 py-2 no-underline"
+            href="https://www.fabrizioduroni.it"
+            target="_blank"
+            rel="noopener noreferrer"
+        >
+            Website
+        </ExternalLink>
+    </div>
+);
+
+const InlineInProseStory = () => (
+    <p className="text-primary-text max-w-[500px]">
+        The whole design system is open source: read the components in the{" "}
+        <ExternalLink href="https://github.com/chicio/chicio-blog" target="_blank" rel="noopener noreferrer">
+            chicio-blog repository
+        </ExternalLink>{" "}
+        and the write-up on{" "}
+        <ExternalLink href="https://www.fabrizioduroni.it" target="_blank" rel="noopener noreferrer">
+            fabrizioduroni.it
+        </ExternalLink>
+        .
+    </p>
+);
+
+export const Default: Story = { render: () => <DefaultStory /> };
+export const SocialButtons: Story = { render: () => <SocialButtonsStory /> };
+export const InlineInProse: Story = { render: () => <InlineInProseStory /> };

--- a/packages/matrix-design-system/src/atoms/links/internal-link/internal-link.stories.tsx
+++ b/packages/matrix-design-system/src/atoms/links/internal-link/internal-link.stories.tsx
@@ -1,0 +1,49 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { InternalLink } from ".";
+
+// Typed as plain Meta/StoryObj rather than Meta<typeof Component>. These stories render
+// explicitly instead of being driven by args — several compose more than one component —
+// so binding the story type to a single component's props would demand an `args` object
+// that nothing reads.
+const meta: Meta = {
+    title: "Atoms/Links/Internal Link",
+    component: InternalLink,
+};
+
+export default meta;
+
+type Story = StoryObj;
+
+// InternalLink wraps next/link and is unstyled: the accent colour and glow come from the base `a`
+// rule in the theme. Single instances go in a flex row so the anchor shrinks to its text instead of
+// reading as a full-width bar.
+const DefaultStory = () => (
+    <div className="flex">
+        <InternalLink to="/blog">Read the blog</InternalLink>
+    </div>
+);
+
+const PostCardTitleStory = () => (
+    <div className="glow-container bg-general-background-light max-w-[500px] p-4">
+        <InternalLink to="/blog/2026/05/01/build-mcp-server-typescript">
+            <h3>Build an MCP server in TypeScript</h3>
+        </InternalLink>
+        <p className="text-secondary-text mt-2 text-sm">
+            How the portfolio exposes its content to AI agents through the Model Context Protocol.
+        </p>
+    </div>
+);
+
+const NavigationRowStory = () => (
+    <div className="flex flex-wrap gap-4">
+        <InternalLink to="/blog">Blog</InternalLink>
+        <InternalLink to="/data-structures-and-algorithms/roadmap">DSA roadmap</InternalLink>
+        <InternalLink to="/videogames">Videogames</InternalLink>
+        <InternalLink to="/about-me">About me</InternalLink>
+        <InternalLink to="/contact">Contact</InternalLink>
+    </div>
+);
+
+export const Default: Story = { render: () => <DefaultStory /> };
+export const PostCardTitle: Story = { render: () => <PostCardTitleStory /> };
+export const NavigationRow: Story = { render: () => <NavigationRowStory /> };

--- a/packages/matrix-design-system/src/atoms/typography/input-field/input-field.stories.tsx
+++ b/packages/matrix-design-system/src/atoms/typography/input-field/input-field.stories.tsx
@@ -1,0 +1,58 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { InputField } from ".";
+
+// Typed as plain Meta/StoryObj rather than Meta<typeof Component>. These stories render
+// explicitly instead of being driven by args — several compose more than one component —
+// so binding the story type to a single component's props would demand an `args` object
+// that nothing reads.
+const meta: Meta = {
+    title: "Atoms/Typography/Input Field",
+    component: InputField,
+};
+
+export default meta;
+
+type Story = StoryObj;
+
+const DefaultStory = () => (
+    <div className="flex">
+        <InputField id="name" type="text" aria-label="Name" placeholder="Your name" className="w-80 px-4 py-3" />
+    </div>
+);
+
+const NumericOperandStory = () => (
+    <div className="flex items-center gap-2">
+        <span className="text-primary-text font-mono">A:</span>
+        <InputField type="number" aria-label="Operand A" defaultValue={12} className="w-20 rounded border px-2 py-1" />
+        <span className="text-primary-text font-mono">B:</span>
+        <InputField type="number" aria-label="Operand B" defaultValue={10} className="w-20 rounded border px-2 py-1" />
+    </div>
+);
+
+const ChatPromptStory = () => (
+    <div className="flex max-w-150">
+        <InputField
+            aria-label="Ask me anything"
+            defaultValue="Which articles have you written about SwiftUI?"
+            className="w-full pt-3 pr-9 pb-3 pl-4 backdrop-blur-2xl"
+        />
+    </div>
+);
+
+const ContactFormStackStory = () => (
+    <div className="flex w-80 flex-col gap-4">
+        <InputField id="contact-name" type="text" aria-label="Name" placeholder="Your name" className="px-4 py-3" />
+        <InputField
+            id="contact-email"
+            type="email"
+            aria-label="Email"
+            placeholder="your@email.com"
+            className="px-4 py-3"
+        />
+    </div>
+);
+
+export const Default: Story = { render: () => <DefaultStory /> };
+export const NumericOperand: Story = { render: () => <NumericOperandStory /> };
+export const ChatPrompt: Story = { render: () => <ChatPromptStory /> };
+export const ContactFormStack: Story = { render: () => <ContactFormStackStory /> };

--- a/packages/matrix-design-system/src/atoms/typography/label/label.stories.tsx
+++ b/packages/matrix-design-system/src/atoms/typography/label/label.stories.tsx
@@ -1,0 +1,40 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Label } from ".";
+import { BiEnvelope, BiMessageDetail, BiUser } from "react-icons/bi";
+
+// Typed as plain Meta/StoryObj rather than Meta<typeof Component>. These stories render
+// explicitly instead of being driven by args — several compose more than one component —
+// so binding the story type to a single component's props would demand an `args` object
+// that nothing reads.
+const meta: Meta = {
+    title: "Atoms/Typography/Label",
+    component: Label,
+};
+
+export default meta;
+
+type Story = StoryObj;
+
+const DefaultStory = () => (
+    <div className="flex">
+        <Label id="name" value="Name" icon={<BiUser size={20} />} />
+    </div>
+);
+
+const WithoutIconStory = () => (
+    <div className="flex">
+        <Label id="reading-time" value="Reading time" />
+    </div>
+);
+
+const ContactFormLabelsStory = () => (
+    <div className="flex flex-col gap-6">
+        <Label id="name" value="Name" icon={<BiUser size={20} />} />
+        <Label id="email" value="Email" icon={<BiEnvelope size={20} />} />
+        <Label id="message" value="Message" icon={<BiMessageDetail size={20} />} />
+    </div>
+);
+
+export const Default: Story = { render: () => <DefaultStory /> };
+export const WithoutIcon: Story = { render: () => <WithoutIconStory /> };
+export const ContactFormLabels: Story = { render: () => <ContactFormLabelsStory /> };

--- a/packages/matrix-design-system/src/atoms/typography/markdown/markdown.stories.tsx
+++ b/packages/matrix-design-system/src/atoms/typography/markdown/markdown.stories.tsx
@@ -1,0 +1,72 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Markdown } from ".";
+
+// Typed as plain Meta/StoryObj rather than Meta<typeof Component>. These stories render
+// explicitly instead of being driven by args — several compose more than one component —
+// so binding the story type to a single component's props would demand an `args` object
+// that nothing reads.
+const meta: Meta = {
+    title: "Atoms/Typography/Markdown",
+    component: Markdown,
+};
+
+export default meta;
+
+type Story = StoryObj;
+
+const graphTraversalArticle = `## Graph traversal
+
+Two traversals cover most of the graph problems you will meet in an interview. Both of them visit
+every vertex once, so with an adjacency list the cost is \`O(V + E)\`.
+
+- **BFS** explores the graph level by level using a queue, so it is the traversal that gives you the
+  shortest path in an unweighted graph.
+- **DFS** goes as deep as it can before backtracking, using an explicit stack or the call stack, and
+  it is the natural fit for cycle detection and topological sort.
+
+> Pick the traversal from the question, not from habit: "shortest" almost always means BFS.
+`;
+
+const chatAnswer = `I have written a few articles about **SwiftUI** on the blog:
+
+- [Use SwiftUI Path and Shape to render your svg files](/blog) walks through drawing vector paths by
+  hand.
+- The Metal series covers the rendering pipeline underneath, from shaders to the depth buffer.
+
+If you want the code, every example lives in a repository linked at the end of the post.
+`;
+
+const exerciseDescription = `### Number of Islands
+
+Given an \`m x n\` binary grid where \`1\` is land and \`0\` is water, count the number of islands.
+
+| Approach | Time | Space |
+| --- | --- | --- |
+| DFS flood fill | O(m · n) | O(m · n) |
+| BFS flood fill | O(m · n) | O(min(m, n)) |
+| Union find | O(m · n · α) | O(m · n) |
+
+Flood fill every unvisited land cell and count how many times you had to start a new fill.
+`;
+
+const DefaultStory = () => (
+    <div className="max-w-2xl">
+        <Markdown content={graphTraversalArticle} id="graph-traversal" />
+    </div>
+);
+
+const ChatAnswerStory = () => (
+    <div className="max-w-2xl">
+        <Markdown content={chatAnswer} id="chat-answer" />
+    </div>
+);
+
+const ExerciseDescriptionStory = () => (
+    <div className="max-w-2xl">
+        <Markdown content={exerciseDescription} id="number-of-islands" />
+    </div>
+);
+
+export const Default: Story = { render: () => <DefaultStory /> };
+export const ChatAnswer: Story = { render: () => <ChatAnswerStory /> };
+export const ExerciseDescription: Story = { render: () => <ExerciseDescriptionStory /> };

--- a/packages/matrix-design-system/src/atoms/typography/terminal-blocks/terminal-blocks.stories.tsx
+++ b/packages/matrix-design-system/src/atoms/typography/terminal-blocks/terminal-blocks.stories.tsx
@@ -1,0 +1,201 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Cursor, ErrorText, QuoteText, SuccessText, TerminalLine, TerminalQuoteLine } from ".";
+
+// Typed as plain Meta/StoryObj rather than Meta<typeof Component>. These stories render
+// explicitly instead of being driven by args — several compose more than one component —
+// so binding the story type to a single component's props would demand an `args` object
+// that nothing reads.
+const meta: Meta = {
+    title: "Atoms/Typography/Terminal Blocks",
+    component: Cursor,
+};
+
+export default meta;
+
+type Story = StoryObj;
+
+// Cursor is a single underscore driven by the `blink` keyframes (opacity 1 for the first half of a
+// 1s cycle, 0 for the second). The capture consistently lands in the invisible half, so every cell
+// freezes the animation at frame 0 — the glyph is unchanged, only the blink is held still for the
+// static shot.
+const FreezeBlink = () => <style>{".ds-blink-still .animate-blink{animation-play-state:paused}"}</style>;
+
+const CursorDefaultStory = () => (
+    <div className="ds-blink-still text-accent flex gap-2 font-mono text-sm">
+        <FreezeBlink />
+        <span>$ npm run build</span>
+        <Cursor />
+    </div>
+);
+
+const CursorTerminalPromptStory = () => (
+    <div className="ds-blink-still text-accent flex flex-col gap-2 font-mono text-sm">
+        <FreezeBlink />
+        <div className="flex gap-2">
+            <span>visitor@fabrizioduroni.it:~$</span>
+            <span>ls /blog</span>
+        </div>
+        <div className="flex gap-2">
+            <span>visitor@fabrizioduroni.it:~$</span>
+            <Cursor />
+        </div>
+    </div>
+);
+
+const CursorLoadingLineStory = () => (
+    <div className="ds-blink-still text-accent flex gap-2 font-mono text-sm">
+        <FreezeBlink />
+        <span>&gt; Uploading knowledge...</span>
+        <Cursor />
+    </div>
+);
+
+// A bare <ErrorText> is a couple of words of red monospace: on its own in a tall card it reads as
+// near-blank. Every cell pairs it with the terminal/form context it actually ships in.
+const ErrorTextDefaultStory = () => (
+    <div className="flex">
+        <ErrorText>Invalid email address</ErrorText>
+    </div>
+);
+
+const ErrorTextTerminalCommandFailureStory = () => (
+    <div className="flex flex-col gap-2 font-mono text-sm">
+        <div className="flex gap-2">
+            <span className="text-accent">$</span>
+            <span className="text-primary-text">sudo rm -rf /</span>
+        </div>
+        <div className="flex">
+            <ErrorText>command not found: sudo. Type &quot;help&quot; for a list of commands.</ErrorText>
+        </div>
+    </div>
+);
+
+const ErrorTextOfflineDiagnosticsStory = () => (
+    <div className="flex flex-col gap-2 font-mono text-sm">
+        <div className="flex">
+            <ErrorText>PING 8.8.8.8 ... Request timeout</ErrorText>
+        </div>
+        <div className="flex">
+            <ErrorText>PING fabrizioduroni.it ... Unreachable</ErrorText>
+        </div>
+        <div className="flex">
+            <ErrorText>ERROR 404: Page not found</ErrorText>
+        </div>
+    </div>
+);
+
+const QuoteTextDefaultStory = () => (
+    <div className="flex">
+        <QuoteText>This is your last chance...</QuoteText>
+    </div>
+);
+
+const QuoteTextOfflineQuoteStory = () => (
+    <div className="flex">
+        <QuoteText>You are disconnected from the Matrix.</QuoteText>
+    </div>
+);
+
+const QuoteTextShortQuoteStory = () => (
+    <div className="flex">
+        <QuoteText>Déjà vu</QuoteText>
+    </div>
+);
+
+const SuccessTextDefaultStory = () => (
+    <div className="flex">
+        <SuccessText>&gt; Transfer complete.</SuccessText>
+    </div>
+);
+
+const SuccessTextReadingProgressLinesStory = () => (
+    <div className="flex flex-col gap-2 font-mono text-sm">
+        <div className="flex">
+            <SuccessText>&gt; Uploading knowledge...</SuccessText>
+        </div>
+        <div className="flex">
+            <SuccessText>[████████████████░░░░░░░░]&nbsp;&nbsp;65%</SuccessText>
+        </div>
+    </div>
+);
+
+const SuccessTextTerminalSessionStory = () => (
+    <div className="flex flex-col gap-2 font-mono text-sm">
+        <div className="flex gap-2">
+            <span className="text-accent">$</span>
+            <span className="text-primary-text">cd /blog</span>
+        </div>
+        <div className="flex">
+            <SuccessText>Wake up, Neo... you are now in /blog</SuccessText>
+        </div>
+        <div className="flex">
+            <SuccessText>96 posts indexed. Type &quot;ls&quot; to list them.</SuccessText>
+        </div>
+    </div>
+);
+
+// TerminalLine is a block-level div. A single line is wrapped in a flex row so it shrinks to its
+// content instead of stretching across the whole card and reading as an empty bar.
+const TerminalLineDefaultStory = () => (
+    <div className="flex">
+        <TerminalLine>$ npm run build</TerminalLine>
+    </div>
+);
+
+const TerminalLineBuildOutputStory = () => (
+    <div className="glow-container bg-general-background-light p-4">
+        <TerminalLine>$ npm run build</TerminalLine>
+        <TerminalLine>▲ Next.js 16.0.1</TerminalLine>
+        <TerminalLine>✓ Compiled successfully in 12.4s</TerminalLine>
+        <TerminalLine>✓ Generating static pages (514/514)</TerminalLine>
+        <TerminalLine>✓ Search index written to public/search-index.json</TerminalLine>
+    </div>
+);
+
+const TerminalLineWrappedCommandStory = () => (
+    <div className="max-w-[500px]">
+        <TerminalLine>
+            $ curl -H &apos;Accept: text/markdown&apos;
+            https://www.fabrizioduroni.it/blog/2026/05/01/build-mcp-server-typescript
+        </TerminalLine>
+    </div>
+);
+
+// TerminalQuoteLine centres its own text, so it is deliberately NOT wrapped in a shrink-to-fit flex
+// row: it needs the full width of its container for the centring to be visible.
+const TerminalQuoteLineDefaultStory = () => <TerminalQuoteLine>There is no spoon.</TerminalQuoteLine>;
+
+const TerminalQuoteLineTerminalIntroStory = () => (
+    <div className="glow-container bg-general-background-light px-4 py-6">
+        <TerminalQuoteLine>Wake up, Neo...</TerminalQuoteLine>
+        <TerminalQuoteLine>The Matrix has you...</TerminalQuoteLine>
+        <TerminalQuoteLine>Follow the white rabbit.</TerminalQuoteLine>
+    </div>
+);
+
+const TerminalQuoteLineLongQuoteStory = () => (
+    <div className="mx-auto max-w-md">
+        <TerminalQuoteLine>
+            I know you are out there. I can feel you now. I know that you are afraid of us.
+        </TerminalQuoteLine>
+    </div>
+);
+
+export const CursorDefault: Story = { render: () => <CursorDefaultStory /> };
+export const CursorTerminalPrompt: Story = { render: () => <CursorTerminalPromptStory /> };
+export const CursorLoadingLine: Story = { render: () => <CursorLoadingLineStory /> };
+export const ErrorTextDefault: Story = { render: () => <ErrorTextDefaultStory /> };
+export const ErrorTextTerminalCommandFailure: Story = { render: () => <ErrorTextTerminalCommandFailureStory /> };
+export const ErrorTextOfflineDiagnostics: Story = { render: () => <ErrorTextOfflineDiagnosticsStory /> };
+export const QuoteTextDefault: Story = { render: () => <QuoteTextDefaultStory /> };
+export const QuoteTextOfflineQuote: Story = { render: () => <QuoteTextOfflineQuoteStory /> };
+export const QuoteTextShortQuote: Story = { render: () => <QuoteTextShortQuoteStory /> };
+export const SuccessTextDefault: Story = { render: () => <SuccessTextDefaultStory /> };
+export const SuccessTextReadingProgressLines: Story = { render: () => <SuccessTextReadingProgressLinesStory /> };
+export const SuccessTextTerminalSession: Story = { render: () => <SuccessTextTerminalSessionStory /> };
+export const TerminalLineDefault: Story = { render: () => <TerminalLineDefaultStory /> };
+export const TerminalLineBuildOutput: Story = { render: () => <TerminalLineBuildOutputStory /> };
+export const TerminalLineWrappedCommand: Story = { render: () => <TerminalLineWrappedCommandStory /> };
+export const TerminalQuoteLineDefault: Story = { render: () => <TerminalQuoteLineDefaultStory /> };
+export const TerminalQuoteLineTerminalIntro: Story = { render: () => <TerminalQuoteLineTerminalIntroStory /> };
+export const TerminalQuoteLineLongQuote: Story = { render: () => <TerminalQuoteLineLongQuoteStory /> };

--- a/packages/matrix-design-system/src/molecules/breadcrumbs/breadcrumb/breadcrumb.stories.tsx
+++ b/packages/matrix-design-system/src/molecules/breadcrumbs/breadcrumb/breadcrumb.stories.tsx
@@ -1,0 +1,44 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Breadcrumb } from ".";
+
+// Typed as plain Meta/StoryObj rather than Meta<typeof Component>. These stories render
+// explicitly instead of being driven by args — several compose more than one component —
+// so binding the story type to a single component's props would demand an `args` object
+// that nothing reads.
+const meta: Meta = {
+    title: "Molecules/Breadcrumbs/Breadcrumb",
+    component: Breadcrumb,
+};
+
+export default meta;
+
+type Story = StoryObj;
+
+const DefaultStory = () => (
+    <Breadcrumb
+        items={[
+            { label: "DSA", href: "/data-structures-and-algorithms/roadmap", isCurrent: false },
+            { label: "Graph", href: "/data-structures-and-algorithms/topic/graph", isCurrent: true },
+        ]}
+    />
+);
+
+const DeepTrailStory = () => (
+    <Breadcrumb
+        items={[
+            { label: "DSA", href: "/data-structures-and-algorithms/roadmap", isCurrent: false },
+            { label: "Graph", href: "/data-structures-and-algorithms/topic/graph", isCurrent: false },
+            {
+                label: "Number of Islands",
+                href: "/data-structures-and-algorithms/topic/graph/exercise/number-of-islands",
+                isCurrent: true,
+            },
+        ]}
+    />
+);
+
+const SingleLevelStory = () => <Breadcrumb items={[{ label: "Blog", href: "/blog", isCurrent: true }]} />;
+
+export const Default: Story = { render: () => <DefaultStory /> };
+export const DeepTrail: Story = { render: () => <DeepTrailStory /> };
+export const SingleLevel: Story = { render: () => <SingleLevelStory /> };

--- a/packages/matrix-design-system/src/molecules/buttons/pagination-navigation/pagination-navigation.stories.tsx
+++ b/packages/matrix-design-system/src/molecules/buttons/pagination-navigation/pagination-navigation.stories.tsx
@@ -1,0 +1,36 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { PaginationNavigation } from ".";
+
+// Typed as plain Meta/StoryObj rather than Meta<typeof Component>. These stories render
+// explicitly instead of being driven by args — several compose more than one component —
+// so binding the story type to a single component's props would demand an `args` object
+// that nothing reads.
+const meta: Meta = {
+    title: "Molecules/Buttons/Pagination Navigation",
+    component: PaginationNavigation,
+};
+
+export default meta;
+
+type Story = StoryObj;
+
+const DefaultStory = () => (
+    <PaginationNavigation
+        previousPageUrl="/blog/posts/2"
+        nextPageUrl="/blog/posts/4"
+        onPreviousClick={() => {}}
+        onNextClick={() => {}}
+    />
+);
+
+const FirstPageStory = () => (
+    <PaginationNavigation previousPageUrl={undefined} nextPageUrl="/blog/posts/2" onNextClick={() => {}} />
+);
+
+const LastPageStory = () => (
+    <PaginationNavigation previousPageUrl="/blog/posts/11" nextPageUrl={undefined} onPreviousClick={() => {}} />
+);
+
+export const Default: Story = { render: () => <DefaultStory /> };
+export const FirstPage: Story = { render: () => <FirstPageStory /> };
+export const LastPage: Story = { render: () => <LastPageStory /> };

--- a/packages/matrix-design-system/src/molecules/buttons/tag/tag.stories.tsx
+++ b/packages/matrix-design-system/src/molecules/buttons/tag/tag.stories.tsx
@@ -1,0 +1,50 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Tag } from ".";
+
+// Typed as plain Meta/StoryObj rather than Meta<typeof Component>. These stories render
+// explicitly instead of being driven by args — several compose more than one component —
+// so binding the story type to a single component's props would demand an `args` object
+// that nothing reads.
+const meta: Meta = {
+    title: "Molecules/Buttons/Tag",
+    component: Tag,
+};
+
+export default meta;
+
+type Story = StoryObj;
+
+const DefaultStory = () => (
+    <div className="flex">
+        <Tag tag="typescript" link="/blog/tag/typescript/" big={false} onClick={() => {}} />
+    </div>
+);
+
+const BigStory = () => (
+    <div className="flex">
+        <Tag tag="web development" link="/blog/tag/web-development/" big={true} onClick={() => {}} />
+    </div>
+);
+
+const PostTagRowStory = () => (
+    <div className="flex flex-wrap">
+        <Tag tag="ai" link="/blog/tag/ai/" big={false} />
+        <Tag tag="mcp" link="/blog/tag/mcp/" big={false} />
+        <Tag tag="typescript" link="/blog/tag/typescript/" big={false} />
+        <Tag tag="web development" link="/blog/tag/web-development/" big={false} />
+        <Tag tag="nextjs" link="/blog/tag/nextjs/" big={false} />
+    </div>
+);
+
+const BigTagCloudStory = () => (
+    <div className="flex flex-wrap">
+        <Tag tag="swift" link="/blog/tag/swift/" big={true} />
+        <Tag tag="kotlin" link="/blog/tag/kotlin/" big={true} />
+        <Tag tag="react native" link="/blog/tag/react-native/" big={true} />
+    </div>
+);
+
+export const Default: Story = { render: () => <DefaultStory /> };
+export const Big: Story = { render: () => <BigStory /> };
+export const PostTagRow: Story = { render: () => <PostTagRowStory /> };
+export const BigTagCloud: Story = { render: () => <BigTagCloudStory /> };

--- a/packages/matrix-design-system/src/molecules/containers/content-container/content-container.stories.tsx
+++ b/packages/matrix-design-system/src/molecules/containers/content-container/content-container.stories.tsx
@@ -1,0 +1,58 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Chip } from "../../../atoms/chip";
+import { ContentContainer } from ".";
+import { StatCard } from "../../stat-card";
+import { PageTitle } from "../../typography/page-title";
+import { SectionHeading } from "../../typography/section-heading";
+
+// Typed as plain Meta/StoryObj rather than Meta<typeof Component>. These stories render
+// explicitly instead of being driven by args — several compose more than one component —
+// so binding the story type to a single component's props would demand an `args` object
+// that nothing reads.
+const meta: Meta = {
+    title: "Molecules/Containers/Content Container",
+    component: ContentContainer,
+};
+
+export default meta;
+
+type Story = StoryObj;
+
+// ContentContainer is the page column itself (container-fixed + vertical rhythm), so it is never
+// rendered empty here: each cell fills it with the kind of content the real routes put inside it.
+const ArticleColumnStory = () => (
+    <ContentContainer>
+        <PageTitle>Data structures and algorithms</PageTitle>
+        <p className="text-primary-text">
+            A complete course on data structures and algorithms, from arrays and hash maps up to graphs and dynamic
+            programming, with a visualizer and a code template for every topic.
+        </p>
+        <div className="mt-4 flex flex-wrap gap-2">
+            <Chip>Graph</Chip>
+            <Chip>Binary search</Chip>
+            <Chip>Dynamic programming</Chip>
+            <Chip>Backtracking</Chip>
+        </div>
+    </ContentContainer>
+);
+
+const StatsSectionStory = () => (
+    <ContentContainer>
+        <SectionHeading title="Blog in numbers" description="Everything published on fabrizioduroni.it so far." />
+        <div className="mt-4 flex flex-wrap gap-4">
+            <StatCard value={96} label="Articles" />
+            <StatCard value={287} label="DSA lessons" />
+        </div>
+    </ContentContainer>
+);
+
+const ChatIntroStory = () => (
+    <ContentContainer>
+        <PageTitle>Ask the Oracle</PageTitle>
+        <p className="text-primary-text">Ask anything about my work, projects and code.</p>
+    </ContentContainer>
+);
+
+export const ArticleColumn: Story = { render: () => <ArticleColumnStory /> };
+export const StatsSection: Story = { render: () => <StatsSectionStory /> };
+export const ChatIntro: Story = { render: () => <ChatIntroStory /> };

--- a/packages/matrix-design-system/src/molecules/effects/matrix-header-background/matrix-header-background.stories.tsx
+++ b/packages/matrix-design-system/src/molecules/effects/matrix-header-background/matrix-header-background.stories.tsx
@@ -1,0 +1,78 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Cursor } from "../../../atoms/typography/terminal-blocks";
+import { MatrixHeaderBackground } from ".";
+
+// Typed as plain Meta/StoryObj rather than Meta<typeof Component>. These stories render
+// explicitly instead of being driven by args — several compose more than one component —
+// so binding the story type to a single component's props would demand an `args` object
+// that nothing reads.
+const meta: Meta = {
+    title: "Molecules/Effects/Matrix Header Background",
+    component: MatrixHeaderBackground,
+};
+
+export default meta;
+
+type Story = StoryObj;
+
+// The Cursor blink is a CSS keyframe animation and the capture freezes the page clock, so an
+// unpaused cursor photographs at whatever frame it happens to be in (often the transparent half).
+// Pausing it pins it to the 0% keyframe, where it is visible.
+const freeze = `.ds-still, .ds-still * { animation-play-state: paused !important; }`;
+
+// The component is an absolutely positioned, -z-10 backdrop: on its own it paints nothing you can
+// frame. Each cell gives it a sized positioned box and puts real header content on top of it, the
+// way BrandHeader does on every page of the site.
+const CompactStory = () => (
+    <div className="ds-still relative h-64 w-full overflow-hidden">
+        <style>{freeze}</style>
+        <MatrixHeaderBackground big={false} />
+        <div className="flex items-center pt-6">
+            <div className="glassmorphism-lite-no-scale z-30 w-full p-5">
+                <span className="text-accent m-0 block font-mono text-2xl font-bold uppercase text-shadow-lg">
+                    <span className="text-shadow-md">{"> "}</span>CHICIO CODING
+                    <Cursor />
+                </span>
+                <span className="text-primary-text font-mono text-xs font-normal text-shadow-md">
+                    Pixels. Code. Unplugged.
+                </span>
+            </div>
+        </div>
+    </div>
+);
+
+const BigStory = () => (
+    <div className="ds-still relative h-96 w-full overflow-hidden">
+        <style>{freeze}</style>
+        <MatrixHeaderBackground big={true} />
+        <div className="flex items-center pt-8">
+            <div className="glassmorphism-lite-no-scale z-30 w-full p-5">
+                <span className="text-accent m-0 block font-mono text-2xl font-bold uppercase text-shadow-lg">
+                    <span className="text-shadow-md">{"> "}</span>CHICIO CODING
+                    <Cursor />
+                </span>
+                <span className="text-primary-text font-mono text-xs font-normal text-shadow-md">
+                    Pixels. Code. Unplugged.
+                </span>
+            </div>
+        </div>
+    </div>
+);
+
+const BehindAPageTitleStory = () => (
+    <div className="ds-still relative h-64 w-full overflow-hidden">
+        <style>{freeze}</style>
+        <MatrixHeaderBackground big={false} />
+        <div className="flex flex-col gap-3 pt-8">
+            <span className="text-accent font-mono text-2xl font-bold uppercase text-shadow-lg">Data structures</span>
+            <span className="text-primary-text font-mono text-sm font-bold text-shadow-md">
+                {"> "}96 articles · 287 lessons
+                <Cursor />
+            </span>
+        </div>
+    </div>
+);
+
+export const Compact: Story = { render: () => <CompactStory /> };
+export const Big: Story = { render: () => <BigStory /> };
+export const BehindAPageTitle: Story = { render: () => <BehindAPageTitleStory /> };

--- a/packages/matrix-design-system/src/molecules/form/form-field/form-field.stories.tsx
+++ b/packages/matrix-design-system/src/molecules/form/form-field/form-field.stories.tsx
@@ -1,0 +1,67 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { FormField } from ".";
+import { BiEnvelope, BiSearch, BiUser } from "react-icons/bi";
+
+// Typed as plain Meta/StoryObj rather than Meta<typeof Component>. These stories render
+// explicitly instead of being driven by args — several compose more than one component —
+// so binding the story type to a single component's props would demand an `args` object
+// that nothing reads.
+const meta: Meta = {
+    title: "Molecules/Form/Form Field",
+    component: FormField,
+};
+
+export default meta;
+
+type Story = StoryObj;
+
+const DefaultStory = () => (
+    <FormField label="Name" icon={<BiUser size={20} />} id="preview-name" type="text" placeholder="Your name" />
+);
+
+const FilledStory = () => (
+    <FormField
+        label="Name"
+        icon={<BiUser size={20} />}
+        id="preview-name-filled"
+        type="text"
+        defaultValue="Fabrizio Duroni"
+    />
+);
+
+const WithErrorStory = () => (
+    <FormField
+        label="Email"
+        icon={<BiEnvelope size={20} />}
+        id="preview-email-error"
+        type="email"
+        defaultValue="fabrizio(at)example"
+        hasError
+    />
+);
+
+const ContactFormFieldsStory = () => (
+    <div className="flex flex-col gap-8">
+        <FormField label="Name" icon={<BiUser size={20} />} id="contact-name" type="text" placeholder="Your name" />
+        <FormField
+            label="Email"
+            icon={<BiEnvelope size={20} />}
+            id="contact-email"
+            type="email"
+            placeholder="your@email.com"
+        />
+        <FormField
+            label="Search the blog"
+            icon={<BiSearch size={20} />}
+            id="contact-search"
+            type="search"
+            placeholder="SwiftUI, Kotlin, Next.js..."
+            disabled
+        />
+    </div>
+);
+
+export const Default: Story = { render: () => <DefaultStory /> };
+export const Filled: Story = { render: () => <FilledStory /> };
+export const WithError: Story = { render: () => <WithErrorStory /> };
+export const ContactFormFields: Story = { render: () => <ContactFormFieldsStory /> };

--- a/packages/matrix-design-system/src/molecules/form/form-success-message/form-success-message.stories.tsx
+++ b/packages/matrix-design-system/src/molecules/form/form-success-message/form-success-message.stories.tsx
@@ -1,0 +1,29 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { FormSuccessMessage } from ".";
+
+// Typed as plain Meta/StoryObj rather than Meta<typeof Component>. These stories render
+// explicitly instead of being driven by args — several compose more than one component —
+// so binding the story type to a single component's props would demand an `args` object
+// that nothing reads.
+const meta: Meta = {
+    title: "Molecules/Form/Form Success Message",
+    component: FormSuccessMessage,
+};
+
+export default meta;
+
+type Story = StoryObj;
+
+const DefaultStory = () => (
+    <FormSuccessMessage message="Message sent! You should receive a confirmation email in your inbox shortly. I'll get back to you as soon as possible." />
+);
+
+const OfflineQueuedStory = () => (
+    <FormSuccessMessage message="You're offline — your message has been saved and will be sent automatically when you reconnect to the internet." />
+);
+
+const ShortMessageStory = () => <FormSuccessMessage message="Message sent!" />;
+
+export const Default: Story = { render: () => <DefaultStory /> };
+export const OfflineQueued: Story = { render: () => <OfflineQueuedStory /> };
+export const ShortMessage: Story = { render: () => <ShortMessageStory /> };

--- a/packages/matrix-design-system/src/molecules/lightbox-image/lightbox-image.stories.tsx
+++ b/packages/matrix-design-system/src/molecules/lightbox-image/lightbox-image.stories.tsx
@@ -1,0 +1,71 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { LightboxImage } from ".";
+import { landscapeImage, portraitImage } from "../../stories/sample-media";
+
+// Typed as plain Meta/StoryObj rather than Meta<typeof Component>. These stories render
+// explicitly instead of being driven by args — several compose more than one component —
+// so binding the story type to a single component's props would demand an `args` object
+// that nothing reads.
+const meta: Meta = {
+    title: "Molecules/Lightbox Image",
+    component: LightboxImage,
+};
+
+export default meta;
+
+type Story = StoryObj;
+
+// LightboxImage takes the full <img> prop surface (ComponentPropsWithoutRef<"img">)
+// and renders the image inside a zoom-in button that dispatches the lightbox-open
+// event. It stretches to its container, so every cell constrains the container.
+// The srcs here are the real featured images of two published posts, inlined at
+// build time because the preview card has no network.
+const DefaultStory = () => (
+    <div className="flex max-w-2xl">
+        <LightboxImage
+            src={landscapeImage}
+            alt="Chrome Built-in AI: adding on-device summarization to my blog with the Summarizer API"
+            className="w-full rounded-xl"
+        />
+    </div>
+);
+
+// How it appears in a post: prose, the click-to-zoom image, then prose again.
+const InArticleStory = () => (
+    <div className="container-fixed flex flex-col gap-4">
+        <p className="text-primary-text leading-relaxed">
+            How I integrated Chrome&apos;s Built-in AI Summarizer API to add TL;DR and Key Points features to my blog
+            posts, with progressive enhancement, streaming responses, and on-device privacy.
+        </p>
+        <LightboxImage
+            src={landscapeImage}
+            alt="The Summarizer API running on-device inside a blog post"
+            className="w-full rounded-xl"
+        />
+        <p className="text-primary-text leading-relaxed">
+            Every image in an article is wrapped in this component, so any of them can be opened full screen without
+            leaving the page.
+        </p>
+    </div>
+);
+
+// The art gallery: every drawing on /art is a LightboxImage, so the page reads as
+// a grid of thumbnails that each open full screen.
+const ArtGalleryStory = () => (
+    <div className="flex flex-wrap gap-4">
+        <div className="flex w-80">
+            <LightboxImage src={portraitImage} alt="Jellyfish 🪼" className="w-full rounded-xl" />
+        </div>
+        <div className="flex w-80">
+            <LightboxImage
+                src={portraitImage}
+                alt="Bowser from Super Mario Wonder 🧑‍🔧😈👾"
+                className="w-full rounded-xl"
+            />
+        </div>
+    </div>
+);
+
+export const Default: Story = { render: () => <DefaultStory /> };
+export const InArticle: Story = { render: () => <InArticleStory /> };
+export const ArtGallery: Story = { render: () => <ArtGalleryStory /> };

--- a/packages/matrix-design-system/src/molecules/links/pills-links/pills-links.stories.tsx
+++ b/packages/matrix-design-system/src/molecules/links/pills-links/pills-links.stories.tsx
@@ -1,0 +1,66 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { BluePillLink, RedPillLink } from ".";
+
+// Typed as plain Meta/StoryObj rather than Meta<typeof Component>. These stories render
+// explicitly instead of being driven by args — several compose more than one component —
+// so binding the story type to a single component's props would demand an `args` object
+// that nothing reads.
+const meta: Meta = {
+    title: "Molecules/Links/Pills Links",
+    component: BluePillLink,
+};
+
+export default meta;
+
+type Story = StoryObj;
+
+// The blue pill is always the "stay where you are" / previous direction in this design system:
+// previous DSA topic, previous blog page, previous videogame.
+const BluePillLinkDefaultStory = () => (
+    <div className="flex">
+        <BluePillLink to="/data-structures-and-algorithms/topic/binary-search">Binary Search</BluePillLink>
+    </div>
+);
+
+const BluePillLinkPaginationStory = () => (
+    <div className="flex">
+        <BluePillLink to="/blog/page/2">Previous</BluePillLink>
+    </div>
+);
+
+const BluePillLinkLongTopicTitleStory = () => (
+    <div className="flex">
+        <BluePillLink to="/data-structures-and-algorithms/topic/binary-search-tree">
+            Binary Search Tree and Ordered Set
+        </BluePillLink>
+    </div>
+);
+
+// The red pill is always the "go deeper" / next direction: next DSA topic, next blog page, next
+// videogame in the collection.
+const RedPillLinkDefaultStory = () => (
+    <div className="flex">
+        <RedPillLink to="/data-structures-and-algorithms/topic/graph">Graph</RedPillLink>
+    </div>
+);
+
+const RedPillLinkPaginationStory = () => (
+    <div className="flex">
+        <RedPillLink to="/blog/page/4">Next</RedPillLink>
+    </div>
+);
+
+const RedPillLinkLongTopicTitleStory = () => (
+    <div className="flex">
+        <RedPillLink to="/data-structures-and-algorithms/topic/longest-increasing-subsequence-dp">
+            Longest Increasing Subsequence DP
+        </RedPillLink>
+    </div>
+);
+
+export const BluePillLinkDefault: Story = { render: () => <BluePillLinkDefaultStory /> };
+export const BluePillLinkPagination: Story = { render: () => <BluePillLinkPaginationStory /> };
+export const BluePillLinkLongTopicTitle: Story = { render: () => <BluePillLinkLongTopicTitleStory /> };
+export const RedPillLinkDefault: Story = { render: () => <RedPillLinkDefaultStory /> };
+export const RedPillLinkPagination: Story = { render: () => <RedPillLinkPaginationStory /> };
+export const RedPillLinkLongTopicTitle: Story = { render: () => <RedPillLinkLongTopicTitleStory /> };

--- a/packages/matrix-design-system/src/molecules/menu/dropdown-menu/dropdown-menu.stories.tsx
+++ b/packages/matrix-design-system/src/molecules/menu/dropdown-menu/dropdown-menu.stories.tsx
@@ -1,0 +1,138 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { DropdownMenu } from ".";
+import { useEffect, useRef } from "react";
+
+// Typed as plain Meta/StoryObj rather than Meta<typeof Component>. These stories render
+// explicitly instead of being driven by args — several compose more than one component —
+// so binding the story type to a single component's props would demand an `args` object
+// that nothing reads.
+const meta: Meta = {
+    title: "Molecules/Menu/Dropdown Menu",
+    component: DropdownMenu,
+};
+
+export default meta;
+
+type Story = StoryObj;
+
+// A closed DropdownMenu is just its trigger button, so the interesting cells open
+// themselves on mount: the panel only exists after the trigger is clicked, and a
+// preview has no interaction. Programmatic .click() does not move focus, so the
+// component's own blur-to-close handler never fires and the panel stays open.
+const useOpenedOnMount = () => {
+    const ref = useRef<HTMLDivElement>(null);
+
+    useEffect(() => {
+        ref.current?.querySelector<HTMLButtonElement>('button[aria-haspopup="menu"]')?.click();
+    }, []);
+
+    return ref;
+};
+
+// Grouped to match what Menu actually passes: Posts / Discovery / Insights. The preview this was
+// converted from still used the flat item list from before sections were introduced, which is why
+// it rendered in Claude Design but would no longer compile.
+const blogItems = [
+    {
+        label: "Posts",
+        items: [
+            { label: "Latest posts", to: "/blog", selected: false },
+            { label: "Archive", to: "/blog/archive", selected: false },
+        ],
+    },
+    {
+        label: "Discovery",
+        items: [
+            { label: "Authors", to: "/blog/authors", selected: false },
+            { label: "Tags", to: "/blog/tags", selected: false },
+            { label: "Easter Eggs", to: "/easter-egg-hunt", selected: false },
+        ],
+    },
+    {
+        label: "Insights",
+        items: [{ label: "Stats", to: "/blog/stats", selected: false }],
+    },
+];
+
+const exploreItems = [
+    {
+        label: "DSA",
+        items: [
+            { label: "Roadmap", to: "/data-structures-and-algorithms/roadmap", selected: false },
+            { label: "Exercises", to: "/data-structures-and-algorithms/exercises", selected: false },
+        ],
+    },
+    {
+        label: "Artificial Intelligence",
+        items: [
+            { label: "Chat", to: "/chat", selected: false },
+            { label: "MCP", to: "/mcp", selected: false },
+        ],
+    },
+    {
+        label: "Computer Graphics",
+        items: [{ label: "Matrix Rain", to: "https://chicio.github.io/matrix-rain-webgpu/", external: true }],
+    },
+];
+
+const authorItems = [
+    {
+        label: "Me",
+        items: [
+            { label: "About me", to: "/about-me", selected: false },
+            { label: "Contact me", to: "/contact", selected: false },
+        ],
+    },
+    {
+        label: "Things I make",
+        items: [
+            { label: "Art", to: "/art", selected: true },
+            { label: "Videogames", to: "/videogames", selected: false },
+        ],
+    },
+];
+
+const ClosedStory = () => (
+    <div className="text-primary-text flex">
+        <DropdownMenu label="Blog" items={blogItems} />
+    </div>
+);
+
+const OpenStory = () => {
+    const ref = useOpenedOnMount();
+
+    return (
+        <div ref={ref} className="text-primary-text flex">
+            <DropdownMenu label="Blog" items={blogItems} />
+        </div>
+    );
+};
+
+// Grouped entries: every entry carrying an `items` array renders as a labelled
+// section with a divider between sections. This is the site's "Explore" menu.
+const GroupedStory = () => {
+    const ref = useOpenedOnMount();
+
+    return (
+        <div ref={ref} className="text-primary-text flex">
+            <DropdownMenu label="Explore" items={exploreItems} />
+        </div>
+    );
+};
+
+// When any entry is selected the trigger itself picks up the accent border and
+// background, so the nav shows which section you are in even while closed.
+const WithSelectedEntryStory = () => {
+    const ref = useOpenedOnMount();
+
+    return (
+        <div ref={ref} className="text-primary-text flex">
+            <DropdownMenu label="The Author" items={authorItems} />
+        </div>
+    );
+};
+
+export const Closed: Story = { render: () => <ClosedStory /> };
+export const Open: Story = { render: () => <OpenStory /> };
+export const Grouped: Story = { render: () => <GroupedStory /> };
+export const WithSelectedEntry: Story = { render: () => <WithSelectedEntryStory /> };

--- a/packages/matrix-design-system/src/molecules/menu/hamburger-menu/hamburger-menu.stories.tsx
+++ b/packages/matrix-design-system/src/molecules/menu/hamburger-menu/hamburger-menu.stories.tsx
@@ -1,0 +1,46 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { HamburgerMenu } from ".";
+
+// Typed as plain Meta/StoryObj rather than Meta<typeof Component>. These stories render
+// explicitly instead of being driven by args — several compose more than one component —
+// so binding the story type to a single component's props would demand an `args` object
+// that nothing reads.
+const meta: Meta = {
+    title: "Molecules/Menu/Hamburger Menu",
+    component: HamburgerMenu,
+};
+
+export default meta;
+
+type Story = StoryObj;
+
+// HamburgerMenu is a bare icon that paints in currentColor, so the colour comes
+// from whatever bar it is dropped into — the previews below supply both.
+const openMobileMenu = () => {};
+
+const DefaultStory = () => (
+    <div className="text-primary-text flex">
+        <HamburgerMenu onClick={openMobileMenu} />
+    </div>
+);
+
+const AccentStory = () => (
+    <div className="text-accent flex">
+        <HamburgerMenu onClick={openMobileMenu} />
+    </div>
+);
+
+// How it actually sits on the site: the trailing control of the mobile menu bar,
+// beside the command-palette search trigger.
+const InMenuBarStory = () => (
+    <div className="glassmorphism-lite-no-scale flex min-h-16 items-center gap-4 px-4">
+        <span className="text-accent font-mono text-sm">chicio coding</span>
+        <div className="text-primary-text flex">
+            <HamburgerMenu onClick={openMobileMenu} />
+        </div>
+    </div>
+);
+
+export const Default: Story = { render: () => <DefaultStory /> };
+export const Accent: Story = { render: () => <AccentStory /> };
+export const InMenuBar: Story = { render: () => <InMenuBarStory /> };

--- a/packages/matrix-design-system/src/molecules/menu/menu-item/menu-item.stories.tsx
+++ b/packages/matrix-design-system/src/molecules/menu/menu-item/menu-item.stories.tsx
@@ -1,0 +1,69 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { MenuItem } from ".";
+
+// Typed as plain Meta/StoryObj rather than Meta<typeof Component>. These stories render
+// explicitly instead of being driven by args — several compose more than one component —
+// so binding the story type to a single component's props would demand an `args` object
+// that nothing reads.
+const meta: Meta = {
+    title: "Molecules/Menu/Menu Item",
+    component: MenuItem,
+};
+
+export default meta;
+
+type Story = StoryObj;
+
+// Single instances are wrapped in a flex row: MenuItem is a block-level link and
+// stretches to the full card width otherwise, which hides its pill shape.
+const DefaultStory = () => (
+    <div className="flex">
+        <MenuItem to="/blog" selected={false}>
+            Blog
+        </MenuItem>
+    </div>
+);
+
+const SelectedStory = () => (
+    <div className="flex">
+        <MenuItem to="/data-structures-and-algorithms/roadmap" selected>
+            Roadmap
+        </MenuItem>
+    </div>
+);
+
+const ExternalStory = () => (
+    <div className="flex">
+        <MenuItem to="https://chicio.github.io/matrix-rain-webgpu/" selected={false} external>
+            Matrix Rain
+        </MenuItem>
+    </div>
+);
+
+const NavigationRowStory = () => (
+    <div className="flex flex-wrap gap-2">
+        <MenuItem to="/" selected={false}>
+            Home
+        </MenuItem>
+        <MenuItem to="/blog" selected>
+            Blog
+        </MenuItem>
+        <MenuItem to="/about-me" selected={false}>
+            About me
+        </MenuItem>
+        <MenuItem to="/videogames" selected={false}>
+            Videogames
+        </MenuItem>
+        <MenuItem to="/art" selected={false}>
+            Art
+        </MenuItem>
+        <MenuItem to="/contact" selected={false}>
+            Contact me
+        </MenuItem>
+    </div>
+);
+
+export const Default: Story = { render: () => <DefaultStory /> };
+export const Selected: Story = { render: () => <SelectedStory /> };
+export const External: Story = { render: () => <ExternalStory /> };
+export const NavigationRow: Story = { render: () => <NavigationRowStory /> };

--- a/packages/matrix-design-system/src/molecules/typography/page-title/page-title.stories.tsx
+++ b/packages/matrix-design-system/src/molecules/typography/page-title/page-title.stories.tsx
@@ -1,0 +1,27 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { PageTitle } from ".";
+
+// Typed as plain Meta/StoryObj rather than Meta<typeof Component>. These stories render
+// explicitly instead of being driven by args — several compose more than one component —
+// so binding the story type to a single component's props would demand an `args` object
+// that nothing reads.
+const meta: Meta = {
+    title: "Molecules/Typography/Page Title",
+    component: PageTitle,
+};
+
+export default meta;
+
+type Story = StoryObj;
+
+const DefaultStory = () => <PageTitle>Data structures and algorithms</PageTitle>;
+
+const ShortTitleStory = () => <PageTitle>Blog</PageTitle>;
+
+const LongTitleStory = () => (
+    <PageTitle>Use SwiftUI Path and Shape to render your svg files: a practical example</PageTitle>
+);
+
+export const Default: Story = { render: () => <DefaultStory /> };
+export const ShortTitle: Story = { render: () => <ShortTitleStory /> };
+export const LongTitle: Story = { render: () => <LongTitleStory /> };

--- a/packages/matrix-design-system/src/molecules/typography/paragraph-title-with-icon/paragraph-title-with-icon.stories.tsx
+++ b/packages/matrix-design-system/src/molecules/typography/paragraph-title-with-icon/paragraph-title-with-icon.stories.tsx
@@ -1,0 +1,63 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { ParagraphTitleWithIcon } from ".";
+import { BiPlug, BiTerminal, BiWrench } from "react-icons/bi";
+import { FaGamepad, FaLightbulb } from "react-icons/fa";
+import { FiCpu } from "react-icons/fi";
+
+// Typed as plain Meta/StoryObj rather than Meta<typeof Component>. These stories render
+// explicitly instead of being driven by args — several compose more than one component —
+// so binding the story type to a single component's props would demand an `args` object
+// that nothing reads.
+const meta: Meta = {
+    title: "Molecules/Typography/Paragraph Title With Icon",
+    component: ParagraphTitleWithIcon,
+};
+
+export default meta;
+
+type Story = StoryObj;
+
+const DefaultStory = () => (
+    <h2>
+        <ParagraphTitleWithIcon icon={<FaGamepad className="text-shadow-lg" />}>Gameplay</ParagraphTitleWithIcon>
+    </h2>
+);
+
+const SubSectionTitleStory = () => (
+    <h3>
+        <ParagraphTitleWithIcon icon={<BiTerminal className="text-accent text-xl" />}>
+            Claude Code
+        </ParagraphTitleWithIcon>
+    </h3>
+);
+
+const VideogamesSectionTitlesStory = () => (
+    <div className="flex flex-col">
+        <h2>
+            <ParagraphTitleWithIcon icon={<FiCpu className="text-shadow-lg" />}>Hardware specs</ParagraphTitleWithIcon>
+        </h2>
+        <h2>
+            <ParagraphTitleWithIcon icon={<FaLightbulb className="text-shadow-lg" />}>
+                Trivia & Fun Facts
+            </ParagraphTitleWithIcon>
+        </h2>
+    </div>
+);
+
+const McpSectionTitlesStory = () => (
+    <div className="flex flex-col">
+        <h2>
+            <ParagraphTitleWithIcon icon={<BiWrench className="text-accent" />}>Available Tools</ParagraphTitleWithIcon>
+        </h2>
+        <h2>
+            <ParagraphTitleWithIcon icon={<BiPlug className="text-accent text-2xl" />}>
+                Connect Your AI Assistant
+            </ParagraphTitleWithIcon>
+        </h2>
+    </div>
+);
+
+export const Default: Story = { render: () => <DefaultStory /> };
+export const SubSectionTitle: Story = { render: () => <SubSectionTitleStory /> };
+export const VideogamesSectionTitles: Story = { render: () => <VideogamesSectionTitlesStory /> };
+export const McpSectionTitles: Story = { render: () => <McpSectionTitlesStory /> };

--- a/packages/matrix-design-system/src/molecules/video/self-hosted-video/self-hosted-video.stories.tsx
+++ b/packages/matrix-design-system/src/molecules/video/self-hosted-video/self-hosted-video.stories.tsx
@@ -1,0 +1,44 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { SelfHostedVideo } from ".";
+
+// Typed as plain Meta/StoryObj rather than Meta<typeof Component>. These stories render
+// explicitly instead of being driven by args — several compose more than one component —
+// so binding the story type to a single component's props would demand an `args` object
+// that nothing reads.
+const meta: Meta = {
+    title: "Molecules/Video/Self Hosted Video",
+    component: SelfHostedVideo,
+};
+
+export default meta;
+
+type Story = StoryObj;
+
+const appJsConfTalk = "/media/content/blog/post/2026/06/01/app-js-conf-2026/app-js-conf-2026-william-1.mp4";
+const kungFu = "/media/video/i-know-kung-fu.mp4";
+
+const DefaultStory = () => (
+    <div className="max-w-2xl">
+        <SelfHostedVideo src={appJsConfTalk} />
+    </div>
+);
+
+const WithCaptionStory = () => (
+    <div className="max-w-2xl">
+        <SelfHostedVideo src={appJsConfTalk} caption="William Candillon on stage at App.js Conf 2026" />
+    </div>
+);
+
+const CustomSizingStory = () => (
+    <div className="max-w-md">
+        <SelfHostedVideo
+            src={kungFu}
+            ariaLabel="I know kung fu"
+            className="border-accent-alpha-40 aspect-video w-full overflow-hidden rounded-xl border border-solid shadow-lg"
+        />
+    </div>
+);
+
+export const Default: Story = { render: () => <DefaultStory /> };
+export const WithCaption: Story = { render: () => <WithCaptionStory /> };
+export const CustomSizing: Story = { render: () => <CustomSizingStory /> };

--- a/packages/matrix-design-system/src/organism/command-palette/command-palette.stories.tsx
+++ b/packages/matrix-design-system/src/organism/command-palette/command-palette.stories.tsx
@@ -1,0 +1,79 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { CommandPalette, CommandPaletteGroup, CommandPaletteItem, ToggleMotionItem } from ".";
+import { openCommandPalette } from "../../state/command-palette/command-palette-events";
+import { useEffect, useRef } from "react";
+
+// Typed as plain Meta/StoryObj rather than Meta<typeof Component>. These stories render
+// explicitly instead of being driven by args — several compose more than one component —
+// so binding the story type to a single component's props would demand an `args` object
+// that nothing reads.
+const meta: Meta = {
+    title: "Organism/Command Palette",
+    component: CommandPalette,
+};
+
+export default meta;
+
+type Story = StoryObj;
+
+// CommandPalette has no `open` prop: it opens on Cmd/Ctrl+K, or on the `command-palette-open`
+// event that the menu's search button fires. Each story dispatches that event on mount so the
+// palette appears the way a reader actually meets it.
+const useOpenedOnMount = () => {
+    const ref = useRef<HTMLDivElement>(null);
+
+    useEffect(() => {
+        openCommandPalette();
+    }, []);
+
+    return ref;
+};
+
+const ClosedStory = () => (
+    <div className="text-primary-text flex min-h-40 items-center justify-center">
+        <p className="font-mono">Press ⌘K — the palette is closed until it is opened.</p>
+        <CommandPalette>
+            <CommandPaletteGroup label="Navigation">
+                <CommandPaletteItem value="blog">Blog</CommandPaletteItem>
+            </CommandPaletteGroup>
+        </CommandPalette>
+    </div>
+);
+
+const OpenStory = () => {
+    const ref = useOpenedOnMount();
+
+    return (
+        <div ref={ref} className="min-h-96">
+            <CommandPalette>
+                <CommandPaletteGroup label="Navigation">
+                    <CommandPaletteItem value="blog">Blog</CommandPaletteItem>
+                    <CommandPaletteItem value="about me">About me</CommandPaletteItem>
+                    <CommandPaletteItem value="contact">Contact</CommandPaletteItem>
+                </CommandPaletteGroup>
+                <CommandPaletteGroup label="Actions">
+                    <ToggleMotionItem />
+                </CommandPaletteGroup>
+            </CommandPalette>
+        </div>
+    );
+};
+
+const CustomPlaceholderStory = () => {
+    const ref = useOpenedOnMount();
+
+    return (
+        <div ref={ref} className="min-h-96">
+            <CommandPalette placeholder="search the archive_">
+                <CommandPaletteGroup label="Archive">
+                    <CommandPaletteItem value="2026">2026 posts</CommandPaletteItem>
+                    <CommandPaletteItem value="2025">2025 posts</CommandPaletteItem>
+                </CommandPaletteGroup>
+            </CommandPalette>
+        </div>
+    );
+};
+
+export const Closed: Story = { render: () => <ClosedStory /> };
+export const Open: Story = { render: () => <OpenStory /> };
+export const CustomPlaceholder: Story = { render: () => <CustomPlaceholderStory /> };

--- a/packages/matrix-design-system/src/organism/cookie-consent-banner/cookie-consent-banner.stories.tsx
+++ b/packages/matrix-design-system/src/organism/cookie-consent-banner/cookie-consent-banner.stories.tsx
@@ -1,0 +1,56 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { CookieConsentBanner } from ".";
+
+// Typed as plain Meta/StoryObj rather than Meta<typeof Component>. These stories render
+// explicitly instead of being driven by args — several compose more than one component —
+// so binding the story type to a single component's props would demand an `args` object
+// that nothing reads.
+const meta: Meta = {
+    title: "Organism/Cookie Consent Banner",
+    component: CookieConsentBanner,
+};
+
+export default meta;
+
+type Story = StoryObj;
+
+// The banner is position:fixed and anchored to the bottom of its containing block,
+// so each cell supplies a full-card-height root for it to sit in. Passing
+// decided={true} renders nothing at all, so there is no "dismissed" cell.
+const cardHeight = { height: "calc(100vh - 48px)" };
+
+const acceptCookies = () => {};
+const rejectCookies = () => {};
+
+const DefaultStory = () => (
+    <div className="relative" style={cardHeight}>
+        <CookieConsentBanner decided={false} onAccept={acceptCookies} onReject={rejectCookies} />
+    </div>
+);
+
+// Over real page content: the glassmorphism panel blurs whatever it covers, which
+// is the whole point of the variant the banner asks for.
+const OverPageContentStory = () => (
+    <div className="relative flex flex-col gap-4 py-8" style={cardHeight}>
+        <div className="container-fixed flex flex-col gap-4">
+            <h1 className="text-accent text-2xl">Blog</h1>
+            <h2 className="text-primary-text text-xl">
+                Building an MCP server for my Next.js blog: how I gave AI assistants direct access to my content
+            </h2>
+            <p className="text-primary-text leading-relaxed">
+                How I built a Model Context Protocol server on top of my Next.js blog, covering the MCP protocol
+                architecture, JSON-RPC transport, capability negotiation, Streamable HTTP, OAuth discovery, and a full
+                TypeScript implementation deployed on Vercel.
+            </p>
+            <p className="text-primary-text leading-relaxed">
+                The Model Context Protocol is an open standard that lets an AI assistant discover and call the tools a
+                server exposes, so the assistant can read my posts, my DSA exercises and my videogame collection without
+                scraping a single HTML page.
+            </p>
+        </div>
+        <CookieConsentBanner decided={false} onAccept={acceptCookies} onReject={rejectCookies} />
+    </div>
+);
+
+export const Default: Story = { render: () => <DefaultStory /> };
+export const OverPageContent: Story = { render: () => <OverPageContentStory /> };

--- a/packages/matrix-design-system/src/organism/footer/footer.stories.tsx
+++ b/packages/matrix-design-system/src/organism/footer/footer.stories.tsx
@@ -1,0 +1,73 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Footer } from ".";
+
+// Typed as plain Meta/StoryObj rather than Meta<typeof Component>. These stories render
+// explicitly instead of being driven by args — several compose more than one component —
+// so binding the story type to a single component's props would demand an `args` object
+// that nothing reads.
+const meta: Meta = {
+    title: "Organism/Footer",
+    component: Footer,
+};
+
+export default meta;
+
+type Story = StoryObj;
+
+// The footer signs off with a blinking Cursor (animate-blink: opacity 1 for 0-50%,
+// 0 for 51-100%). package-capture screenshots after networkidle with no animation
+// control, so the caret is captured in whatever half of the cycle it happens to be
+// in — half the runs lose it. A paused animation sits at its 0% keyframe, which is
+// the visible one.
+const stillCaret = `
+.ds-caret-still, .ds-caret-still * {
+    animation-play-state: paused !important;
+}
+`;
+
+// The real footer nav and social contacts (src/components/features/content/nav-config.ts
+// and src/types/configuration/site-metadata.ts).
+const navHrefs = {
+    blog: "/blog",
+    art: "/art",
+    aboutMe: "/about-me",
+    archive: "/blog/archive",
+    tags: "/blog/tags",
+    contact: "/contact",
+};
+
+const socialLinks = {
+    github: "https://github.com/chicio",
+    linkedin: "https://www.linkedin.com/in/fabrizio-duroni/",
+    medium: "https://medium.com/@chicio",
+    devto: "https://dev.to/chicio",
+    twitter: "https://twitter.com/chicio86",
+    facebook: "https://www.facebook.com/fabrizio.duroni",
+    instagram: "https://www.instagram.com/__chicio__/",
+};
+
+const DefaultStory = () => (
+    <div className="ds-caret-still">
+        <style>{stillCaret}</style>
+        <Footer author="Fabrizio Duroni" navHrefs={navHrefs} socialLinks={socialLinks} />
+    </div>
+);
+
+// How it reads in place: the accent top border separates it from the page column
+// above it, and the whole block is the last snap point of the scroll container.
+const AtPageBottomStory = () => (
+    <div className="ds-caret-still flex flex-col gap-6">
+        <style>{stillCaret}</style>
+        <div className="container-fixed flex flex-col gap-2">
+            <h2 className="text-accent text-2xl">Memories and failures: 18 years of a software engineering career</h2>
+            <p className="text-primary-text leading-relaxed">
+                A personal essay looking back at my first 18 years as a software engineer, and the life, and the losses,
+                that ran alongside them.
+            </p>
+        </div>
+        <Footer author="Fabrizio Duroni" navHrefs={navHrefs} socialLinks={socialLinks} />
+    </div>
+);
+
+export const Default: Story = { render: () => <DefaultStory /> };
+export const AtPageBottom: Story = { render: () => <AtPageBottomStory /> };

--- a/packages/matrix-design-system/src/organism/lightbox/lightbox.stories.tsx
+++ b/packages/matrix-design-system/src/organism/lightbox/lightbox.stories.tsx
@@ -1,0 +1,71 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Lightbox } from ".";
+import { openLightbox } from "../../state/lightbox/lightbox-events";
+import { landscapeImage, portraitImage } from "../../stories/sample-media";
+import { useEffect } from "react";
+
+// Typed as plain Meta/StoryObj rather than Meta<typeof Component>. These stories render
+// explicitly instead of being driven by args — several compose more than one component —
+// so binding the story type to a single component's props would demand an `args` object
+// that nothing reads.
+const meta: Meta = {
+    title: "Organism/Lightbox",
+    component: Lightbox,
+};
+
+export default meta;
+
+type Story = StoryObj;
+
+// package-capture screenshots with the page clock frozen (playwright
+// clock.setFixedTime), so framer-motion's enter transitions never advance and the
+// overlay stays at its initial opacity: 0 — the card came back empty. This pins
+// anything still sitting at the initial frame to its settled value. It is a
+// capture-harness workaround, not a style decision: nothing else is touched
+// because only un-advanced elements carry an inline `opacity: 0;`.
+const settledEnterAnimations = `
+.ds-motion-settled [style*="opacity: 0;"] {
+    opacity: 1 !important;
+    transform: none !important;
+}
+`;
+
+// Lightbox is propless and renders null until the `lightbox-open` event carrying a
+// src/alt pair reaches it — that is how LightboxImage drives it from anywhere in
+// the page. The opener is rendered AFTER <Lightbox /> so the lightbox's own
+// listener effect is registered before the event is dispatched.
+const LightboxOpener = ({ src, alt }: { src: string; alt: string }) => {
+    useEffect(() => {
+        openLightbox({ src, alt });
+    }, [src, alt]);
+
+    return null;
+};
+
+// The overlay is position:fixed, so the cell root gives it a full-card containing
+// block to fill; without one the backdrop collapses to zero height.
+const cardHeight = { height: "calc(100vh - 48px)" };
+
+const OpenStory = () => (
+    <div className="ds-motion-settled relative" style={cardHeight}>
+        <style>{settledEnterAnimations}</style>
+        <Lightbox />
+        <LightboxOpener
+            src={landscapeImage}
+            alt="Chrome Built-in AI: adding on-device summarization to my blog with the Summarizer API"
+        />
+    </div>
+);
+
+// A square source instead of a wide one: the image is capped at 90vh/90vw and
+// object-contain keeps it whole, so the overlay reframes around it.
+const ArtworkStory = () => (
+    <div className="ds-motion-settled relative" style={cardHeight}>
+        <style>{settledEnterAnimations}</style>
+        <Lightbox />
+        <LightboxOpener src={portraitImage} alt="Bowser from Super Mario Wonder 🧑‍🔧😈👾" />
+    </div>
+);
+
+export const Open: Story = { render: () => <OpenStory /> };
+export const Artwork: Story = { render: () => <ArtworkStory /> };

--- a/packages/matrix-design-system/src/organism/menu/menu.stories.tsx
+++ b/packages/matrix-design-system/src/organism/menu/menu.stories.tsx
@@ -1,0 +1,88 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Menu } from ".";
+import { useEffect, useRef } from "react";
+
+// Typed as plain Meta/StoryObj rather than Meta<typeof Component>. These stories render
+// explicitly instead of being driven by args — several compose more than one component —
+// so binding the story type to a single component's props would demand an `args` object
+// that nothing reads.
+const meta: Meta = {
+    title: "Organism/Menu",
+    component: Menu,
+};
+
+export default meta;
+
+type Story = StoryObj;
+
+// The real site nav (src/components/features/content/nav-config.ts).
+const navHrefs = {
+    blog: "/blog",
+    blogAuthors: "/blog/authors",
+    blogAuthor: "/blog/author",
+    blogTags: "/blog/tags",
+    blogArchive: "/blog/archive",
+    blogStats: "/blog/stats",
+    dsaRoadmap: "/data-structures-and-algorithms/roadmap",
+    dsaExercises: "/data-structures-and-algorithms/exercises",
+    chat: "/chat",
+    mcp: "/mcp",
+    easterEggHunt: "/easter-egg-hunt",
+    aboutMe: "/about-me",
+    art: "/art",
+    videogames: "/videogames",
+    contact: "/contact",
+};
+
+// Menu owns its dropdowns' open state internally, so the cells that show a panel
+// click the matching trigger on mount. Matching on the trigger's own label keeps
+// the cell honest if the nav is reordered.
+const useDropdownOpenedOnMount = (label: string) => {
+    const ref = useRef<HTMLDivElement>(null);
+
+    useEffect(() => {
+        const triggers = ref.current?.querySelectorAll<HTMLButtonElement>('button[aria-haspopup="menu"]');
+        Array.from(triggers ?? [])
+            .find((trigger) => (trigger.textContent ?? "").trim() === label)
+            ?.click();
+    }, [label]);
+
+    return ref;
+};
+
+const DefaultStory = () => <Menu currentPath="/blog" navHrefs={navHrefs} />;
+
+const BlogDropdownOpenStory = () => {
+    const ref = useDropdownOpenedOnMount("Blog");
+
+    return (
+        <div ref={ref}>
+            <Menu currentPath="/blog" navHrefs={navHrefs} />
+        </div>
+    );
+};
+
+const ExploreDropdownOpenStory = () => {
+    const ref = useDropdownOpenedOnMount("Explore");
+
+    return (
+        <div ref={ref}>
+            <Menu currentPath="/blog" navHrefs={navHrefs} />
+        </div>
+    );
+};
+
+const AuthorDropdownOpenStory = () => {
+    const ref = useDropdownOpenedOnMount("The Author");
+
+    return (
+        <div ref={ref}>
+            <Menu currentPath="/blog" navHrefs={navHrefs} />
+        </div>
+    );
+};
+
+export const Default: Story = { render: () => <DefaultStory /> };
+export const BlogDropdownOpen: Story = { render: () => <BlogDropdownOpenStory /> };
+export const ExploreDropdownOpen: Story = { render: () => <ExploreDropdownOpenStory /> };
+export const AuthorDropdownOpen: Story = { render: () => <AuthorDropdownOpenStory /> };

--- a/packages/matrix-design-system/src/organism/reading-content-progress-bar/reading-content-progress-bar.stories.tsx
+++ b/packages/matrix-design-system/src/organism/reading-content-progress-bar/reading-content-progress-bar.stories.tsx
@@ -1,0 +1,70 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { ContentProgressBar } from ".";
+
+// Typed as plain Meta/StoryObj rather than Meta<typeof Component>. These stories render
+// explicitly instead of being driven by args — several compose more than one component —
+// so binding the story type to a single component's props would demand an `args` object
+// that nothing reads.
+const meta: Meta = {
+    title: "Organism/Reading Content Progress Bar",
+    component: ContentProgressBar,
+};
+
+export default meta;
+
+type Story = StoryObj;
+
+// ContentProgressBar is a position:fixed strip that docks under the header while you read. Two
+// things have to be arranged for a static card to show it:
+//
+//  - It reads reading progress from the element whose id is `contentId` (window.scrollY minus that
+//    element's offsetTop, over its scrollHeight). Each cell therefore renders a real article
+//    element with that id, offset upwards so the hook resolves a genuine mid-article percentage
+//    instead of the 0% a never-scrolled page reports.
+//  - Until the reader scrolls down it parks itself at translateY(-100px), above the fold. The
+//    wrapper's +100px transform both scopes the fixed strip to this card and cancels that park
+//    offset, so the capture shows the docked state the reader actually sees.
+
+//  - The terminal line it wraps ends in a blinking Cursor whose keyframes spend half their cycle at
+//    opacity 0, and the capture lands in that half; freezing the animation at frame 0 keeps the
+//    cursor in the shot without changing anything else.
+
+const dockBar = { transform: "translateY(100px)" };
+
+const readingFixture = (top: string, height: string) => ({ top, height });
+
+const FreezeBlink = () => <style>{".ds-blink-still .animate-blink{animation-play-state:paused}"}</style>;
+
+const DefaultStory = () => (
+    <div className="ds-blink-still relative h-32 w-full overflow-hidden">
+        <FreezeBlink />
+        <div style={dockBar}>
+            <ContentProgressBar contentId="blog-post-content" />
+        </div>
+        <article id="blog-post-content" className="absolute w-full" style={readingFixture("-1200px", "3000px")} />
+    </div>
+);
+
+const NearlyFinishedStory = () => (
+    <div className="ds-blink-still relative h-32 w-full overflow-hidden">
+        <FreezeBlink />
+        <div style={dockBar}>
+            <ContentProgressBar contentId="dsa-topic-content" />
+        </div>
+        <article id="dsa-topic-content" className="absolute w-full" style={readingFixture("-2250px", "3000px")} />
+    </div>
+);
+
+const JustStartedStory = () => (
+    <div className="ds-blink-still relative h-32 w-full overflow-hidden">
+        <FreezeBlink />
+        <div style={dockBar}>
+            <ContentProgressBar contentId="about-me-content" />
+        </div>
+        <article id="about-me-content" className="absolute w-full" style={readingFixture("-150px", "3000px")} />
+    </div>
+);
+
+export const Default: Story = { render: () => <DefaultStory /> };
+export const NearlyFinished: Story = { render: () => <NearlyFinishedStory /> };
+export const JustStarted: Story = { render: () => <JustStartedStory /> };

--- a/packages/matrix-design-system/src/stories/sample-media.ts
+++ b/packages/matrix-design-system/src/stories/sample-media.ts
@@ -1,0 +1,27 @@
+/**
+ * Placeholder imagery for stories, as inline SVG data URIs.
+ *
+ * The previews these stories came from imported real photographs out of the website's content
+ * folder. The design system cannot reach for those: it is published on its own, and a package that
+ * needs the site's files to render its own documentation is not self-contained. Data URIs keep the
+ * stories dependency-free and working offline, and nothing here is a design decision — the
+ * components under test only care that they were handed an image of a given aspect ratio.
+ */
+
+const svg = (width: number, height: number, label: string) =>
+    "data:image/svg+xml;utf8," +
+    encodeURIComponent(
+        `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}">` +
+            `<defs><linearGradient id="g" x1="0" y1="0" x2="1" y2="1">` +
+            `<stop offset="0%" stop-color="#012b12"/><stop offset="100%" stop-color="#001100"/>` +
+            `</linearGradient></defs>` +
+            `<rect width="${width}" height="${height}" fill="url(#g)"/>` +
+            `<rect x="1" y="1" width="${width - 2}" height="${height - 2}" fill="none" stroke="#31d353" stroke-opacity="0.5"/>` +
+            `<text x="50%" y="50%" fill="#31d353" font-family="monospace" font-size="${Math.round(Math.min(width, height) / 10)}" ` +
+            `text-anchor="middle" dominant-baseline="middle">${label}</text>` +
+            `</svg>`,
+    );
+
+export const landscapeImage = svg(1200, 800, "landscape");
+export const portraitImage = svg(800, 1200, "portrait");
+export const squarePortrait = svg(400, 400, "portrait");

--- a/packages/matrix-design-system/vitest.config.ts
+++ b/packages/matrix-design-system/vitest.config.ts
@@ -27,6 +27,10 @@ export default defineConfig({
                 "src/molecules/effects/matrix-header-background/**",
                 "src/molecules/effects/matrix-terminal/**",
                 "src/test-utils/**",
+                // Stories document the components; they are not shipped (`files` excludes them) and
+                // nothing tests them, so counting them drags the real figure down by ~34 points.
+                "src/**/*.stories.tsx",
+                "src/stories/**",
                 "src/index.ts",
                 "src/**/index.ts",
             ],


### PR DESCRIPTION
Second of three PRs for step 5. Adds `apps/matrix-design-system-showcase` — a Storybook over **137 stories covering 37 components** — and converts the 45 usable `.design-sync` previews into colocated `*.stories.tsx`.

## Where things live

Stories sit **in the package**, beside the components they document. The showcase owns only the toolchain and the deployment, keeping the split used everywhere else: `packages/` publishes to npm, `apps/` deploys to a URL. Its stylesheet is exactly the two lines the package's README gives a consumer:

```css
@import "tailwindcss";
@import "matrix-design-system/styles.css";
```

A showcase that styles components in a way real consumers cannot reproduce proves nothing.

## What was not converted, and why

Twelve previews are deliberately left behind: three page templates and four command-palette items that belong to the **website** now, and five internal pieces of `image-carousel`/`lightbox` the barrel never exported.

The rule is that a preview converts only if **its own name is a public export**. Without it, `ContentPageTemplate`'s preview would have been filed under `Chip` — the only design-system component it imports.

## Converting surfaced real drift

design-sync builds declarations but never typechecks a preview against the API it calls, so these had been silently rotting:

- **DropdownMenu** — the preview still passed a flat item list from before sections existed. Only one of its three arrays had ever been migrated.
- **CommandPalette** — passed `searchIndexFileName`, `chatSlug`, `easterEggHuntSlug`, `searchEasterEgg`. The component has taken **none** of these since the site-specific parts moved to `SiteCommandPalette`. Rewritten against the current four-prop API.
- **Menu** — omitted `currentPath`, which became required when the router stopped being read directly and started being injected.

Claude Design has been showing stale previews for all three.

## Three decisions worth reviewing

**Relative imports, not package-name.** Importing the package from inside itself made `typecheck` depend on `dist` — which **races its own build**: `typecheck` depends on `^build` (dependencies only), so it runs alongside the package's own build, and tsdown's `clean: true` empties `dist` underneath it. Relative imports remove the dependency entirely.

**Story bodies are components.** Several call hooks to show a component opened. A hook in a bare function is a genuine `rules-of-hooks` violation; rendering `<NameStory />` gives those hooks a real component to run in.

**Images are inline SVG data URIs** (`src/stories/sample-media.ts`). The previews imported photographs from the website's content folder, which a package that publishes on its own cannot reach.

## Tooling exemptions

Stories are exempt from dependency-cruiser and the component-architecture lint rules, for the same reason tests already are: an atom's story may legitimately show it inside a molecule, and `folder-composition` would reject every story file for not matching its folder name.

## Not included: the design-sync relocation

Its `NOTES.md` documents a setup built on:

> "This repo is a **private Next.js app**, not a published library … so there is no `dist/`. The converter therefore runs in **synth-entry mode**."

That premise no longer holds. Reconfiguring it is a re-derivation, not a path fix, and it belongs in its own change where it can be verified against the live Design project. The previews stay in place until then — deleting them now would break the sync.

(This is essentially the four-PR option from our grilling, which you declined *before* this was known.)

## Verification

- All **15** turbo gates green (up from 13 — the showcase is in the graph).
- `storybook build` clean: 137 stories, 37 components, 10 MB.
- Tailwind generates the design system's utilities into the showcase — verified `glow-container`, `text-accent` and `#001100` in the built CSS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Storybook showcase for the design system, with development, build, and deployment support.
  * Added interactive examples for components across atoms, molecules, and organisms, including menus, forms, links, media, typography, effects, and navigation.
  * Added representative sample media for visual component examples.

* **Documentation**
  * Documented Storybook usage, story locations, styling, and deployment configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->