### PR TITLE
feat(capabilities): :rocket: publish the design system showcase to GitHub Pages

### DIFF
--- a/.github/pages/index.html
+++ b/.github/pages/index.html
@@ -1,0 +1,144 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <title>chicio — libraries</title>
+        <meta name="description" content="Playable references for the libraries built in the chicio-blog monorepo." />
+        <!--
+            Deliberately self-contained: no build step, no dependency on the design system it links
+            to. The palette is copied from packages/matrix-design-system/src/styles/theme.css so the
+            hub looks like the thing it introduces, but a landing page that needed the package built
+            in order to render would be one more thing to break.
+        -->
+        <style>
+            :root {
+                --primary: #00ff41;
+                --accent: #39ff14;
+                --background: #001100;
+                --background-light: #002200;
+                --primary-text: #e8ffe8;
+                --secondary-text: #00cc33;
+            }
+            * {
+                box-sizing: border-box;
+            }
+            body {
+                margin: 0;
+                min-height: 100vh;
+                padding: 3rem 1.5rem;
+                background: var(--background);
+                color: var(--primary-text);
+                font-family: "Courier New", monospace;
+                display: flex;
+                flex-direction: column;
+                align-items: center;
+                justify-content: center;
+                gap: 3rem;
+            }
+            header {
+                text-align: center;
+                max-width: 40rem;
+            }
+            h1 {
+                margin: 0 0 0.75rem;
+                font-size: clamp(1.75rem, 5vw, 2.75rem);
+                color: var(--accent);
+            }
+            header p {
+                margin: 0;
+                color: var(--secondary-text);
+                line-height: 1.6;
+            }
+            ul {
+                list-style: none;
+                margin: 0;
+                padding: 0;
+                display: grid;
+                gap: 1.5rem;
+                width: 100%;
+                max-width: 46rem;
+                grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr));
+            }
+            a.card {
+                display: block;
+                height: 100%;
+                padding: 1.5rem;
+                border: 1px solid var(--secondary-text);
+                border-radius: 0.75rem;
+                background: var(--background-light);
+                color: inherit;
+                text-decoration: none;
+                transition:
+                    border-color 0.2s ease,
+                    transform 0.2s ease;
+            }
+            a.card:hover,
+            a.card:focus-visible {
+                border-color: var(--accent);
+                transform: translateY(-2px);
+            }
+            a.card:focus-visible {
+                outline: 2px solid var(--accent);
+                outline-offset: 3px;
+            }
+            .card h2 {
+                margin: 0 0 0.5rem;
+                font-size: 1.15rem;
+                color: var(--accent);
+            }
+            .card p {
+                margin: 0 0 0.75rem;
+                color: var(--secondary-text);
+                line-height: 1.55;
+                font-size: 0.95rem;
+            }
+            .card code {
+                color: var(--primary);
+                font-size: 0.85rem;
+            }
+            footer {
+                color: var(--secondary-text);
+                font-size: 0.85rem;
+                text-align: center;
+            }
+            footer a {
+                color: var(--accent);
+            }
+            @media (prefers-reduced-motion: reduce) {
+                a.card {
+                    transition: none;
+                }
+                a.card:hover,
+                a.card:focus-visible {
+                    transform: none;
+                }
+            }
+        </style>
+    </head>
+    <body>
+        <header>
+            <h1>chicio — libraries</h1>
+            <p>Playable references for the libraries built in the chicio-blog monorepo.</p>
+        </header>
+
+        <ul>
+            <li>
+                <a class="card" href="./design-system/">
+                    <h2>Matrix design system</h2>
+                    <p>
+                        Every component, rendered from the stories that ship beside it. Atoms, molecules and organisms.
+                    </p>
+                    <code>npm i matrix-design-system</code>
+                </a>
+            </li>
+        </ul>
+
+        <footer>
+            <p>
+                Built from <a href="https://github.com/chicio/chicio-blog">chicio/chicio-blog</a> ·
+                <a href="https://www.fabrizioduroni.it">fabrizioduroni.it</a>
+            </p>
+        </footer>
+    </body>
+</html>

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -13,7 +13,6 @@ on:
 permissions:
   contents: read
 
-# One deploy at a time, and never interrupt one in flight.
 concurrency:
   group: pages
   cancel-in-progress: false
@@ -32,11 +31,8 @@ jobs:
           cache: 'npm'
       - name: Install dependencies
         run: npm ci
-      # --filter pulls in the design system's build, which the showcase resolves through dist.
       - name: Build the showcase
         run: npx turbo run build --filter=matrix-design-system-showcase
-      # Storybook emits relative asset paths, so it needs no knowledge of the subpath it is served
-      # from — the directory can simply be moved into place.
       - name: Assemble the site
         run: |
           mkdir -p _site

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,65 @@
+name: Deploy Pages
+
+# The hub and the design-system showcase. Only rebuilt when the things it publishes change —
+# the site itself deploys to Vercel and has nothing to do with this.
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'packages/matrix-design-system/**'
+      - 'apps/matrix-design-system-showcase/**'
+      - '.github/pages/**'
+      - '.github/workflows/pages.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# One deploy at a time, and never interrupt one in flight.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+      - name: Setup Node
+        uses: actions/setup-node@v5
+        with:
+          node-version-file: 'package.json'
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm ci
+      # --filter pulls in the design system's build, which the showcase resolves through dist.
+      - name: Build the showcase
+        run: npx turbo run build --filter=matrix-design-system-showcase
+      # Storybook emits relative asset paths, so it needs no knowledge of the subpath it is served
+      # from — the directory can simply be moved into place.
+      - name: Assemble the site
+        run: |
+          mkdir -p _site
+          cp .github/pages/index.html _site/index.html
+          cp -r apps/matrix-design-system-showcase/dist _site/design-system
+          echo "assembled:" && find _site -maxdepth 2 -name index.html
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: _site
+
+  deploy:
+    name: Deploy
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,7 +1,5 @@
 name: Deploy Pages
 
-# The hub and the design-system showcase. Only rebuilt when the things it publishes change —
-# the site itself deploys to Vercel and has nothing to do with this.
 on:
   push:
     branches: [main]

--- a/.gitignore
+++ b/.gitignore
@@ -90,6 +90,8 @@ agent/
 # The storybook build design-sync compares against — regenerated, minutes to build.
 **/.design-sync/sb-reference/
 ds-bundle/
+# assembled by the Pages workflow
+_site/
 **/.design-sync/.cache/
 **/.design-sync/learnings/
 **/.design-sync/node_modules

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,7 +117,11 @@ See `.claude/rules/code-style.md`. Key points: 4 spaces, 120 char lines, always 
 
 ## CI/CD
 
-GitHub Actions (`.github/workflows/ci.yml`): four jobs — lint (ESLint `--max-warnings 0`), knip, validate-architecture (dependency-cruiser, all rules at error), and build (Next.js). lint, knip, and validate-architecture all gate build. Upstash/Resend secrets injected for build.
+Three workflows:
+
+- **`ci.yml`** — lint (ESLint `--max-warnings 0`), knip, validate-architecture (dependency-cruiser, all rules at error), typecheck, test (coverage-gated), verify-packages, then build (Next.js) and e2e. Everything before `build` gates it. Upstash/Resend secrets injected for build.
+- **`release-package.yml`** — manual `workflow_dispatch` to publish a package, authenticated by npm OIDC trusted publishing (no `NPM_TOKEN`). Pick the package and the increment; `initial` maps to `--no-increment` for a first release.
+- **`pages.yml`** — builds the design-system showcase and deploys it with the landing page to GitHub Pages, at `chicio.github.io/chicio-blog/` with the Storybook under `/design-system/`. Only runs when the package, the showcase or the hub changes; the site itself deploys to Vercel and is unrelated. The hub source is `.github/pages/index.html`, deliberately dependency-free. Storybook emits relative asset paths, so nothing needs to know the subpath it is served from.
 
 ## Release
 


### PR DESCRIPTION
PR3, the last of step 5. A landing page at `chicio.github.io/chicio-blog/` with the Storybook under `/design-system/`, plus the workflow that builds and deploys them.

## ⚠️ Needs one setting before it can work

**Settings → Pages → Source: GitHub Actions.** `actions/deploy-pages` errors if Pages isn't enabled with that source, so the first run will fail until you flip it. I left it manual rather than adding `configure-pages` with `enablement: true` — enabling Pages on a public repo is your call, not something a workflow should do on its own.

## The hub

`.github/pages/index.html` — dependency-free static HTML. It copies the palette from the design system's `theme.css` so it looks like the thing it introduces, but a page that had to *build* the package to render would be one more thing to break, and it's the entry point.

One entry for now. matrix-rain-webgpu slots in beside it as `/matrix-rain/` when that migration happens — which is the whole reason the Storybook is mounted under a subpath rather than at the root.

## Subpath serving, verified

Storybook emits relative asset references, so nothing here configures a base. Rather than trust that, I served the assembled site from a `/chicio-blog/` prefix:

```
/chicio-blog/                                  -> 200
hub renders href="./design-system/"
/chicio-blog/design-system/                    -> 200
/chicio-blog/design-system/sb-manager/runtime.js -> 200
/chicio-blog/design-system/index.json          -> 200
```

## The workflow

Runs only when `packages/matrix-design-system/**`, `apps/matrix-design-system-showcase/**` or the hub changes — the site deploys to Vercel and has nothing to do with Pages, so a content commit shouldn't rebuild a Storybook. `concurrency: pages` with `cancel-in-progress: false`, so a deploy in flight is never interrupted.

Assembly is a copy, since Storybook's output is position-independent:

```
_site/index.html          <- .github/pages/index.html
_site/design-system/      <- apps/matrix-design-system-showcase/dist
```

## Also

`CLAUDE.md`'s CI/CD section still described four jobs from before the monorepo. It now lists the three workflows as they actually are.

All 17 turbo gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a terminal-inspired landing page for the libraries hub.
  * Added a link to the design system showcase and related project websites.
  * Added automated deployment of the landing page and showcase to GitHub Pages.
  * Added support for reduced-motion preferences.

* **Documentation**
  * Updated CI/CD documentation to cover testing, release publishing, and Pages deployment workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->