### PR TITLE
fix(ux): :lipstick: stop the hub's brand header rendering underlined

### DIFF
--- a/.github/pages/index.html
+++ b/.github/pages/index.html
@@ -44,6 +44,8 @@
                 box-shadow: 0 10px 15px -3px rgb(0 0 0 / 0.4);
             }
             .brand {
+                text-decoration: none;
+                color: inherit;
                 display: flex;
                 align-items: center;
                 gap: 0.75rem;


### PR DESCRIPTION
The brand header is an `<a>` wrapping the logo and wordmark, but only `a.card` had `text-decoration: none` — so the browser default underlined `> CHICIO CODING` and the tagline.

Adds `text-decoration: none` (and `color: inherit`, so the link colour can't override the accent) to `.brand`.

Verified in a real browser rather than by reading the rule — computed `textDecorationLine`:

```
.brand       -> "none"
.brand-title -> "none"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)