### PR TITLE
feat(capabilities): :construction_worker: wire matrix-rain-webgpu releases into the monorepo

### DIFF
--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -11,6 +11,7 @@ on:
         options:
           - matrix-component-store
           - matrix-design-system
+          - matrix-rain-webgpu
         required: true
       increment:
         description: 'Which release to cut ("initial" publishes the version already in package.json)'

--- a/.release-it.json
+++ b/.release-it.json
@@ -18,13 +18,17 @@
       "commitsOpts": {
         "path": [
           ".",
-          ":(exclude)packages"
+          ":(exclude)packages",
+          ":(exclude)apps/matrix-design-system-showcase",
+          ":(exclude)apps/matrix-rain-showcase"
         ]
       },
       "gitRawCommitsOpts": {
         "path": [
           ".",
-          ":(exclude)packages"
+          ":(exclude)packages",
+          ":(exclude)apps/matrix-design-system-showcase",
+          ":(exclude)apps/matrix-rain-showcase"
         ]
       }
     }

--- a/packages/matrix-rain-webgpu/.release-it.json
+++ b/packages/matrix-rain-webgpu/.release-it.json
@@ -1,8 +1,16 @@
 {
   "$schema": "https://unpkg.com/release-it/schema/release-it.json",
+  "git": {
+    "tagName": "matrix-rain-webgpu@${version}",
+    "tagMatch": "matrix-rain-webgpu@*",
+    "tagAnnotation": "matrix-rain-webgpu ${version}",
+    "commitMessage": "chore(release): :bookmark: matrix-rain-webgpu ${version}",
+    "commitsPath": ".",
+    "requireCommits": true
+  },
   "github": {
     "release": true,
-    "web": true
+    "releaseName": "matrix-rain-webgpu ${version}"
   },
   "npm": {
     "publish": true,
@@ -14,7 +22,14 @@
   "plugins": {
     "@release-it/conventional-changelog": {
       "preset": "conventionalcommits",
-      "infile": "CHANGELOG.md"
+      "infile": "CHANGELOG.md",
+      "tagPrefix": "matrix-rain-webgpu@",
+      "commitsOpts": {
+        "path": [".", "../../apps/matrix-rain-showcase"]
+      },
+      "gitRawCommitsOpts": {
+        "path": [".", "../../apps/matrix-rain-showcase"]
+      }
     }
   }
 }

--- a/scripts/verify-packages.mjs
+++ b/scripts/verify-packages.mjs
@@ -48,12 +48,15 @@ const OPTIONAL_ENTRIES = [
 ];
 
 // matrix-rain-webgpu's declarations use extensionless relative imports (`./matrix-rain`,
-// `./types`), which node16 resolution rejects in an ESM package — a consumer on
-// moduleResolution: nodenext sees resolution errors on its types. This is not a packaging
-// regression: the published 2.0.0 reports exactly the same thing, so it predates the move into
-// this repo. Fixing it means adding .js extensions across the library's source, which is library
-// work rather than release wiring; tracked separately. Everything else about the package is
-// checked, and the other two packages are still held to the full rule set.
+// `./types`). TypeScript rejects those in an ESM package under `moduleResolution: nodenext` — the
+// setting current projects are told to use — so a consumer on a modern toolchain gets resolution
+// errors on this package's types. (attw labels that resolution mode "node16" after the Node release
+// that introduced the algorithm; it is not about running Node 16, and nodenext behaves the same.)
+//
+// Ignored here only because it is not a packaging regression: the published 2.0.0 reports exactly
+// the same, so it predates the move into this repo, and a release-wiring change is the wrong place
+// to alter what the library emits. The fix is to add .js extensions across the library's source.
+// The other two packages are still held to the full rule set.
 const ATTW_IGNORE_RULES = {
     "matrix-rain-webgpu": ["internal-resolution-error"],
 };

--- a/scripts/verify-packages.mjs
+++ b/scripts/verify-packages.mjs
@@ -47,16 +47,30 @@ const OPTIONAL_ENTRIES = [
     },
 ];
 
-// matrix-rain-webgpu's declarations use extensionless relative imports (`./matrix-rain`,
-// `./types`). TypeScript rejects those in an ESM package under `moduleResolution: nodenext` — the
-// setting current projects are told to use — so a consumer on a modern toolchain gets resolution
-// errors on this package's types. (attw labels that resolution mode "node16" after the Node release
-// that introduced the algorithm; it is not about running Node 16, and nodenext behaves the same.)
+// matrix-rain-webgpu's declarations carry extensionless relative imports (`./matrix-rain`,
+// `./types`), which TypeScript rejects in an ESM package under `moduleResolution: nodenext`. A
+// consumer on a current toolchain therefore gets resolution errors on this package's types. (attw
+// calls that mode "node16", after the Node release that introduced the algorithm — it is not about
+// running Node 16.)
 //
-// Ignored here only because it is not a packaging regression: the published 2.0.0 reports exactly
-// the same, so it predates the move into this repo, and a release-wiring change is the wrong place
-// to alter what the library emits. The fix is to add .js extensions across the library's source.
-// The other two packages are still held to the full rule set.
+// Ignored deliberately, not pending. This is not a packaging regression: the published 2.0.0
+// reports the same, so it predates the move into this repo. Both available fixes were tried and
+// rejected:
+//
+//   - `.js` extensions in the source, or `rewriteRelativeImportExtensions` with `.ts` ones, put
+//     extensions in the code where the files do not have them (and the latter silently did nothing
+//     here, emitting `.ts` specifiers, because moduleResolution is `bundler`).
+//   - A post-emit rewrite of dist/**/*.d.ts works — verified, attw goes green — but adds a custom
+//     build step to a package deliberately kept free of them.
+//
+// The other two packages need none of this because tsdown, being a bundler, writes specifiers for
+// its output format and emits `.mjs`; `tsc --emitDeclarationOnly` copies through what the source
+// wrote. Building this package with tsdown too would remove the problem, but its `'use gpu'`
+// transform would move from unplugin-typegpu's actively maintained Vite variant to the Rolldown one,
+// which the TypeGPU docs list as limited-stability — a bad trade for a WebGPU library.
+//
+// Revisit only if this package's toolchain is ever converged. The other two packages remain held to
+// the full rule set.
 const ATTW_IGNORE_RULES = {
     "matrix-rain-webgpu": ["internal-resolution-error"],
 };

--- a/scripts/verify-packages.mjs
+++ b/scripts/verify-packages.mjs
@@ -16,7 +16,7 @@ import { globSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 
-const PACKAGES = ["matrix-component-store", "matrix-design-system"];
+const PACKAGES = ["matrix-component-store", "matrix-design-system", "matrix-rain-webgpu"];
 
 // What a consumer must always supply. Deliberately excludes every optional peer: the root barrel
 // has to resolve with only these, which is the whole reason charts, markdown and the command
@@ -46,6 +46,17 @@ const OPTIONAL_ENTRIES = [
         ],
     },
 ];
+
+// matrix-rain-webgpu's declarations use extensionless relative imports (`./matrix-rain`,
+// `./types`), which node16 resolution rejects in an ESM package — a consumer on
+// moduleResolution: nodenext sees resolution errors on its types. This is not a packaging
+// regression: the published 2.0.0 reports exactly the same thing, so it predates the move into
+// this repo. Fixing it means adding .js extensions across the library's source, which is library
+// work rather than release wiring; tracked separately. Everything else about the package is
+// checked, and the other two packages are still held to the full rule set.
+const ATTW_IGNORE_RULES = {
+    "matrix-rain-webgpu": ["internal-resolution-error"],
+};
 
 const run = (cmd, args, cwd) =>
     execFileSync(cmd, args, { cwd, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
@@ -101,6 +112,7 @@ try {
                     "--yes", "@arethetypeswrong/cli", join(workDir, file),
                     "--profile", "esm-only",
                     "--exclude-entrypoints", "styles.css", "theme.css",
+                    ...(ATTW_IGNORE_RULES[name] ?? []).flatMap((rule) => ["--ignore-rules", rule]),
                 ],
                 repoRoot,
             );
@@ -132,6 +144,15 @@ try {
         console.log("  root barrel imports with no optional peer installed");
     } catch (error) {
         fail(`root barrel needs an optional peer: ${(error.stderr || error.message).trim().split("\n")[0]}`);
+    }
+
+    // matrix-rain-webgpu declares no optional peers — typegpu and friends are real dependencies —
+    // so it has to import with only react/react-dom installed.
+    try {
+        importProbe("matrix-rain-webgpu", ["MatrixRainWebGPU", "isWebGPUSupported"]);
+        console.log("  matrix-rain-webgpu imports with only its required peers");
+    } catch (error) {
+        fail(`matrix-rain-webgpu\n${(error.stderr || error.stdout || error.message).trim()}`);
     }
 
     run("npm", ["install", "--no-audit", "--no-fund", "typescript@^5"], app);


### PR DESCRIPTION
**Step 2 of 5** from #564, still additive. **Nothing is published, nothing is deployed** — npm trusted publishing still points at the source repo, so *that* repo can still cut a release. This only prepares this one to.

## Scoping, in both directions

The `.release-it.json` that came across owned a whole repository, so a bare `vX.Y.Z` tag and an unscoped changelog were right there and wrong here. It now matches the other two packages: namespaced tags (`matrix-rain-webgpu@2.1.0`) and a changelog built only from commits touching the library and the showcase that documents it.

The **site's** changelog needed the opposite fix. It already excluded `packages/`, but the showcase lives under `apps/` — so showcase commits would have landed in the site's release notes. Both showcases are now excluded.

Verified both ways:
- the library's changelog compares `matrix-rain-webgpu@2.0.0...2.0.1`
- the only matrix-rain entry left in the site's changelog is the migration commit itself, which genuinely changed `.github/workflows/ci.yml` and the root manifests

## The baseline tag

`matrix-rain-webgpu@2.0.0` now marks the migration commit (pushed). 2.0.0 was published from the standalone repo and left no tag here, so release-it fell back to the newest tag in this repo — it was diffing against the site's `v4.0.0` and proposing **2.1.0**:

```
before:  🚀 Let's release matrix-rain-webgpu (2.0.0...2.1.0)
         compare/v4.0.0...matrix-rain-webgpu@2.1.0
after:   🚀 Let's release matrix-rain-webgpu (2.0.0...2.0.1)
         compare/matrix-rain-webgpu@2.0.0...matrix-rain-webgpu@2.0.1
```

The 51 lines of prior release history in `CHANGELOG.md` came across intact.

## Verification coverage

The package is in the release workflow's dropdown, and `verify-packages` now covers it — it packs, publint is clean, and it imports with **only react/react-dom** installed, which is the property that matters for a package whose typegpu dependencies are real rather than peer.

## One narrow exemption

Its declarations use extensionless relative imports (`./matrix-rain`, `./types`), which `node16` resolution rejects in an ESM package — a consumer on `moduleResolution: nodenext` sees resolution errors on the types.

**Not a packaging regression:** the published 2.0.0 reports exactly the same, so it predates the move. Fixing it means adding `.js` extensions across the library's source — library work, not release wiring. The other two packages are still held to the full rule set, and everything else about this one is checked.

Worth filing as its own issue; it affects real consumers today.

## Verification

19/19 turbo gates green. `npm run verify-packages` reports "Published surface verified."

Next: step 3 (Pages `/matrix-rain/`), then OIDC re-registration, then the archive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `matrix-rain-webgpu` to the available package release options.
  * Added dedicated release tagging, naming, and changelog support for the package.

* **Chores**
  * Updated package validation to cover `matrix-rain-webgpu`, including export and runtime compatibility checks.
  * Improved consolidated release note generation by excluding showcase applications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->