### PR TITLE
feat(capabilities): :rocket: put the matrix-rain showcase on the pages hub

### DIFF
--- a/.github/pages/index.html
+++ b/.github/pages/index.html
@@ -212,6 +212,16 @@
                     <code>npm i matrix-design-system</code>
                 </a>
             </li>
+            <li>
+                <a class="card" href="./matrix-rain/">
+                    <h2>Matrix rain WebGPU</h2>
+                    <p>
+                        The falling-glyph effect, running on WebGPU and TypeGPU. Docs, a live playground and the shader
+                        internals.
+                    </p>
+                    <code>npm i matrix-rain-webgpu</code>
+                </a>
+            </li>
         </ul>
 
         <footer>

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -6,6 +6,8 @@ on:
     paths:
       - 'packages/matrix-design-system/**'
       - 'apps/matrix-design-system-showcase/**'
+      - 'packages/matrix-rain-webgpu/**'
+      - 'apps/matrix-rain-showcase/**'
       - '.github/pages/**'
       - '.github/workflows/pages.yml'
   workflow_dispatch:
@@ -32,12 +34,13 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Build the showcase
-        run: npx turbo run build --filter=matrix-design-system-showcase
+        run: npx turbo run build --filter=matrix-design-system-showcase --filter=matrix-rain-showcase
       - name: Assemble the site
         run: |
           mkdir -p _site
           cp .github/pages/index.html .github/pages/logo.png _site/
           cp -r apps/matrix-design-system-showcase/dist _site/design-system
+          cp -r apps/matrix-rain-showcase/dist _site/matrix-rain
           echo "assembled:" && find _site -maxdepth 2 -name index.html
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
**Step 3 of 5** from #564 — and the last additive one. The hub now offers both libraries, with the Astro docs app at `/matrix-rain/` beside the design system's Storybook.

Nothing published; the old repo's own Pages site is untouched. Undone by deleting the branch.

## Three changes, as planned

- a second card on the landing page
- the showcase added to the build filter
- one more `cp` in the assembly step

Path filters gain `packages/matrix-rain-webgpu/**` and `apps/matrix-rain-showcase/**`, so a change to either rebuilds the site and a change to neither doesn't.

## One asymmetry worth recording

Unlike the Storybook, **this app's output is not position-independent.** Astro bakes `base` into absolute asset paths:

```
href="/chicio-blog/matrix-rain/favicon.ico"
src="/chicio-blog/matrix-rain/_astro/page.CveMS7O9.js"
```

So it only works served at exactly that prefix. If the site ever moves to a custom domain, `astro.config.mjs` needs editing and a rebuild — where the Storybook would need nothing, because it emits relative paths.

That's the opposite of the finding from the design-system showcase, where I removed a `base` mechanism as inert. Here it's load-bearing.

## Verification

Assembled the site and served it from a `/chicio-blog/` prefix:

```
/                                              -> 200
/design-system/                                -> 200
/matrix-rain/                                  -> 200
/chicio-blog/matrix-rain/_astro/page.*.js      -> 200   (baked absolute path)
/matrix-rain/overview/introduction/            -> 200   (deep docs route)
```

Hub renders both `./design-system/` and `./matrix-rain/`. All 19 turbo gates green.

## After this

Only the two outward-facing steps remain: **re-registering npm trusted publishing** against `chicio-blog` (reversible), then the **"moved" notice and archive** (the one irreversible step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Matrix rain WebGPU demo to the online labs showcase.
  * Included links to the demo’s documentation, playground, shader details, and npm package.
  * The demo is now built and published automatically with the GitHub Pages site.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->