### PR TITLE
docs: :memo: describe this package's place in the monorepo, not the old repo

### DIFF
--- a/packages/matrix-rain-webgpu/README.md
+++ b/packages/matrix-rain-webgpu/README.md
@@ -71,19 +71,27 @@ Full docs live on the site — including the interactive playground:
 
 ## Local development
 
-This repo is two packages: the publishable library at the root (`src/`) and the docs + demo site (`docs/`, an Astro + Starlight app).
+This package lives in the [chicio-blog](https://github.com/chicio/chicio-blog) monorepo. The library
+is here; its docs and demo site are the sibling [`apps/matrix-rain-showcase`](../../apps/matrix-rain-showcase)
+workspace, an Astro + Starlight app.
+
+Clone the monorepo and install once from its root — npm workspaces links the two together, so the
+showcase renders this package's source rather than a published copy.
 
 ```sh
-# Library — typecheck + lint/format
-npm install
-npm run types
-npm run check
+npm install                                          # from the repository root
 
-# Docs + demo site (Astro)
-npm --prefix docs install
-npm --prefix docs run dev
+npm run build   --workspace=matrix-rain-webgpu       # library: vite + declarations
+npm run lint    --workspace=matrix-rain-webgpu       # oxlint + oxfmt
+npm run types   --workspace=matrix-rain-webgpu       # tsc -b
+
+npm run dev     --workspace=matrix-rain-showcase     # the docs + demo site
 ```
+
+This package keeps its own toolchain — oxlint, oxfmt and Vite — rather than the monorepo's ESLint and
+tsdown. `lint` and `typecheck` are thin aliases over the former so it still joins the repository-wide
+gates (`npm run lint` from the root fans out across every workspace).
 
 ## Author
 
-Built by [Fabrizio Duroni](https://www.fabrizioduroni.it). If you enjoy it, a visit to the site is the best way to support the work. Also don't forget :star: to star this repository :star:.
+Built by [Fabrizio Duroni](https://www.fabrizioduroni.it). If you enjoy it, a visit to the site is the best way to support the work. Also don't forget :star: to star [the monorepo](https://github.com/chicio/chicio-blog) :star:.


### PR DESCRIPTION
Last of the migration tidy-up, and the reason to cut **2.0.2**: this is the README npm renders on the package page, and its *Local development* section still described the standalone repository.

## What was wrong

> This repo is two packages: the publishable library at the root (`src/`) and the docs + demo site (`docs/`, an Astro + Starlight app).
> ```sh
> npm --prefix docs install
> npm --prefix docs run dev
> ```

None of that is true here. Anyone following it from the npm page would be lost.

## What it says now

Where the package and its showcase actually live, the commands that work from the monorepo root, and why this package keeps oxlint/oxfmt/Vite while the rest of the repo uses ESLint and tsdown — with `lint`/`typecheck` as aliases so it still joins the repo-wide gates.

**Every command in it was run, not assumed:**

```
OK  npm run build --workspace=matrix-rain-webgpu
OK  npm run lint  --workspace=matrix-rain-webgpu
OK  npm run types --workspace=matrix-rain-webgpu
OK  turbo run lint   →  6 successful   (the root fan-out the README claims)
```

Also repointed the star request, which pointed at a repository that's now archived and can't accept one.

## The rest of the metadata was already correct

#569 handled it; verified rather than redone:

| field | value |
|---|---|
| `homepage` | `https://chicio.github.io/chicio-blog/matrix-rain/` |
| `bugs` | `https://github.com/chicio/chicio-blog/issues` |
| `repository` | `chicio-blog`, `directory: packages/matrix-rain-webgpu` |
| README badges | monorepo `ci.yml` / `pages.yml` |

Zero references to the old repo remain outside `CHANGELOG` history.

## After merging

`release-it` dry run confirms it will cut **2.0.2**:

```
🚀 Let's release matrix-rain-webgpu (2.0.1...2.0.2)
compare/matrix-rain-webgpu@2.0.1...matrix-rain-webgpu@2.0.2
```

Actions → **Release package** → `matrix-rain-webgpu`, `increment: patch`. That's a docs-and-metadata-only release; the published code is unchanged from 2.0.1.

19/19 turbo gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)