### PR TITLE
fix(deps): :wrench: raise Dependabot PRs that can actually install

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,7 +19,11 @@ updates:
     # Five manifests share 34 packages, so an ungrouped bump of react or typescript arrives as four
     # or five PRs that are only correct if they all land. Raised together, CI validates them as the
     # unit they actually are.
-    open-pull-requests-limit: 10
+    #
+    # The limit is 20 rather than the default 5: eleven groups plus the ungrouped packages can
+    # legitimately need more than ten slots in one week, and a PR that cannot merge holds its slot
+    # until someone closes it. At ten, two stuck PRs were enough to starve typegpu for a month.
+    open-pull-requests-limit: 20
     groups:
       react:
         # The root pins @types/react and @types/react-dom in `overrides`, so a types bump that is not

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,13 +2,14 @@
 version: 2
 updates:
   - package-ecosystem: "npm"
-    # `directories`, not `directory`: every dependency that matters moved out of the root manifest
-    # when this became a monorepo. The root now declares 6 devDependencies; the website declares 82,
-    # the design system 40, the showcase 21.
+    # One entry, and it has to stay one entry. The root declares `workspaces: ["apps/*",
+    # "packages/*"]`, so the `/` job already discovers every workspace manifest by itself — listing
+    # those globs again here spawns a separate update job per directory, and they all rewrite the
+    # single root package-lock.json. Whichever job writes last wins, the lockfile stops agreeing
+    # with the manifests, and every check dies in `npm ci` before it runs. That is what happened to
+    # #566 and #574; #563 was the same bump as #562 raised twice and closed as redundant.
     directories:
       - "/"
-      - "/apps/*"
-      - "/packages/*"
     schedule:
       interval: "weekly"
     assignees:
@@ -90,6 +91,15 @@ updates:
       upstash:
         patterns:
           - "@upstash/*"
+      typegpu:
+        # The satellites peer-depend on the core by exact minor: @typegpu/react@0.11.2 peers
+        # typegpu ^0.11.9, and unplugin-typegpu@0.12.3 peers ^0.12.4. Moving one without the
+        # others lands a peer range nothing can satisfy.
+        patterns:
+          - "typegpu"
+          - "@typegpu/*"
+          - "unplugin-typegpu"
+          - "@webgpu/types"
     ignore:
       # Workspace packages. npm resolves these to the local copy whatever the range says, so a bump
       # PR changes a number that nothing reads.


### PR DESCRIPTION
## Why

Every check on #574 and #566 dies in 17 seconds — in `npm ci`, before any job runs:

```
npm error code EUSAGE
npm error `npm ci` can only install packages when your package.json and
          package-lock.json are in sync.
npm error Missing: @types/react-dom@19.2.5 from lock file      (#574)
npm error Invalid: lock file's eslint@9.39.4 does not satisfy eslint@10.10.0  (#566)
```

The root declares `workspaces: ["apps/*", "packages/*"]`, so the `/` update job already discovers
every workspace manifest on its own. Listing those same globs under `directories` spawned a
separate job per directory — five jobs, all rewriting the single root `package-lock.json`.
Grouping staples the results into one PR, but the lockfile only stays coherent with whichever job
wrote last.

The PR history separates the two cases cleanly:

| shape | outcome |
|---|---|
| single directory (#576 #577 #578 #579 #580 #581) | all merged |
| multi directory (#574, #566) | both dead at `npm ci` |

And #562 (raised by the `/` job) edited `apps/website/package.json` **and** the lock coherently,
while #563 — the same bump raised again by the `/apps/website` job — was closed as redundant.
The per-directory entries were never adding coverage, only contention.

## Why typegpu 0.12.4 never arrived

Blocked PRs never merge, so they hold `open-pull-requests-limit` slots forever. At the last run
#557 and #566 were open and unmergeable; the run added eight more and hit the limit of ten before
reaching the ungrouped packages. `typegpu` has been sitting at 0.11.9 since 0.12.0 shipped on
2026-08-12.

## Also: a typegpu group

The family peer-depends on the core by exact minor, so the four packages can only move together:

```
@typegpu/react@0.11.2    peers  typegpu ^0.11.9    <- rejects 0.12.4
@typegpu/noise@0.12.0    peers  typegpu ^0.12.0
unplugin-typegpu@0.12.3  peers  typegpu ^0.12.4
```

Same rationale as the existing `ai-sdk` and `design-system-peers` groups.

## Verification

- `npx prettier --check .github/dependabot.yml` — clean
- YAML parses; resulting config is `directories: ["/"]` with 11 groups
- No install, build or runtime impact — this file only affects how Dependabot raises PRs

## After merge

Close #574 and #566, then force a run (Insights → Dependency graph → Dependabot → *Check for
updates*) and confirm the regrouped PRs install cleanly.

## Follow-ups (not in this PR)

- `matrix-rain-webgpu` is the only published package declaring its own `release-it` (20 + plugin 11
  vs the root's 21 + 12). That fork nests 39 extra packages under its `node_modules/`.
- The root `overrides` pins `@types/react-dom` literally, which is what actually broke #574 —
  Dependabot never edits an `overrides` block. Fixing that needs the `$name` reference form plus a
  root declaration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Streamlined automated dependency update management.
  - Related TypeGPU packages and WebGPU type definitions are now updated together.
  - No changes to product functionality or the end-user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->