### PR TITLE
fix(deps): :wrench: group the coupled release and serwist families, ignore matrix-rain-webgpu

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -104,9 +104,23 @@ updates:
           - "@typegpu/*"
           - "unplugin-typegpu"
           - "@webgpu/types"
+      serwist:
+        # @serwist/next peers on serwist itself and the three ship in lockstep. They are already
+        # drifting — @serwist/build sits at both 9.5.11 and 9.5.12 in the lockfile today.
+        patterns:
+          - "serwist"
+          - "@serwist/*"
+      release:
+        # release-it and its changelog plugin move as a pair: plugin 11 accepts release-it
+        # ^18 || ^19 || ^20, plugin 12 adds ^21. A bump landing one without the other leaves a peer
+        # range nothing satisfies.
+        patterns:
+          - "release-it"
+          - "@release-it/conventional-changelog"
     ignore:
       # Workspace packages. npm resolves these to the local copy whatever the range says, so a bump
       # PR changes a number that nothing reads.
       - dependency-name: "matrix-design-system"
       - dependency-name: "matrix-component-store"
       - dependency-name: "eslint-plugin-chicio"
+      - dependency-name: "matrix-rain-webgpu"


### PR DESCRIPTION
Three gaps the first pass left, all visible now that #582 drained the backlog into 20 open PRs.

## `matrix-rain-webgpu` belongs in `ignore`

It is a workspace package:

```
packages/matrix-design-system/package.json:119:    "matrix-rain-webgpu": "^2.0.0",
```

npm resolves that to the local copy whatever the range says — the exact rationale already written
above the other three entries. It was added to the monorepo in #567, after that list was written,
so it was missed. #602 is the symptom: a PR bumping a number nothing reads.

## `serwist` group

`@serwist/next` peers on `serwist` itself, and the three ship in lockstep (all at 9.5.12). They are
already drifting — the lockfile currently holds `@serwist/build` at **both** 9.5.11 and 9.5.12.

## `release` group

`release-it` and its changelog plugin are a matched pair:

```
@release-it/conventional-changelog@11 -> release-it ^18 || ^19 || ^20
@release-it/conventional-changelog@12 -> release-it ^18 || ^19 || ^20 || ^21
```

A bump landing one without the other leaves a peer range nothing can satisfy. Same rationale as the
existing `ai-sdk` and `design-system-peers` groups.

## Verification

- `npx prettier --check .github/dependabot.yml` — clean
- YAML parses: 13 groups, 4 ignore entries, `directories: ["/"]`, limit 20
- No install, build or runtime impact

## Note

`#602` (bump release-it 20.2.1 → 21.0.2) becomes moot once #587 lands, since that PR deletes the
declaration entirely. Merge #587 first and Dependabot will close #602 on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)