### PR TITLE
fix(ux): :recycle: subscribe to online status instead of seeding it from an effect

### DIFF
--- a/apps/website/src/components/content/contact/contact/contact-form/use-contact-form-store.ts
+++ b/apps/website/src/components/content/contact/contact/contact-form/use-contact-form-store.ts
@@ -1,10 +1,11 @@
 "use client";
 
-import React, { useState, useEffect, useCallback } from "react";
+import React, { useState, useCallback } from "react";
 import { tracking } from "@/types/configuration/tracking";
 import { trackWith } from "@/lib/tracking/tracking";
 import { contactQueue } from "@/lib/background-sync/contact-queue";
 import { ComponentStore } from "matrix-component-store";
+import { useIsOffline } from "./use-online-status";
 
 type ContactFormErrors = Record<string, string>;
 
@@ -39,23 +40,8 @@ export const useContactFormStore = (trackingCategory: string): ComponentStore<Co
     const [isSubmitting, setIsSubmitting] = useState(false);
     const [isSuccess, setIsSuccess] = useState(false);
     const [isQueued, setIsQueued] = useState(false);
-    const [isOffline, setIsOffline] = useState(false);
+    const isOffline = useIsOffline();
     const [submitError, setSubmitError] = useState<{ submit?: string }>({});
-
-    useEffect(() => {
-        setIsOffline(!navigator.onLine);
-
-        const handleOnline = () => setIsOffline(false);
-        const handleOffline = () => setIsOffline(true);
-
-        window.addEventListener("online", handleOnline);
-        window.addEventListener("offline", handleOffline);
-
-        return () => {
-            window.removeEventListener("online", handleOnline);
-            window.removeEventListener("offline", handleOffline);
-        };
-    }, []);
 
     const validateForm = useCallback((): boolean => {
         const newErrors: ContactFormErrors = {};

--- a/apps/website/src/components/content/contact/contact/contact-form/use-online-status.ts
+++ b/apps/website/src/components/content/contact/contact/contact-form/use-online-status.ts
@@ -1,0 +1,21 @@
+import { useSyncExternalStore } from "react";
+
+const subscribe = (callback: () => void) => {
+    if (typeof window === "undefined") {
+        return () => {};
+    }
+    window.addEventListener("online", callback);
+    window.addEventListener("offline", callback);
+    return () => {
+        window.removeEventListener("online", callback);
+        window.removeEventListener("offline", callback);
+    };
+};
+
+const getSnapshot = (): boolean => !navigator.onLine;
+
+const getServerSnapshot = (): boolean => false;
+
+export const useIsOffline = (): boolean => {
+    return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+};

--- a/apps/website/src/components/features/design-system-next/social-contacts/index.ts
+++ b/apps/website/src/components/features/design-system-next/social-contacts/index.ts
@@ -1,3 +1,2 @@
 export { SocialContacts } from "./social-contacts";
 export type { SocialContactsProps } from "./social-contacts";
-export type { SocialContactLinks } from "matrix-design-system";

--- a/apps/website/src/components/features/design-system-next/tag/index.ts
+++ b/apps/website/src/components/features/design-system-next/tag/index.ts
@@ -1,3 +1,2 @@
 export { Tag } from "./tag";
-export type { TagProps } from "./tag";
 export type { PrefetchStrategy } from "matrix-design-system";

--- a/apps/website/src/components/features/design-system-next/terminal-button/index.ts
+++ b/apps/website/src/components/features/design-system-next/terminal-button/index.ts
@@ -1,2 +1,1 @@
 export { TerminalButton } from "./terminal-button";
-export type { TerminalButtonProps } from "./terminal-button";

--- a/apps/website/src/components/features/easter-eggs/fighting-game-trigger/index.ts
+++ b/apps/website/src/components/features/easter-eggs/fighting-game-trigger/index.ts
@@ -1,2 +1,1 @@
 export { FightingGameTrigger } from "./fighting-game-trigger";
-export type { FightingGameTriggerProps } from "./fighting-game-trigger";

--- a/apps/website/src/components/features/terminal/terminal/terminal-prompt/index.ts
+++ b/apps/website/src/components/features/terminal/terminal/terminal-prompt/index.ts
@@ -1,2 +1,1 @@
 export { TerminalPrompt } from "./terminal-prompt";
-export type { TerminalPromptProps } from "./terminal-prompt";

--- a/apps/website/src/components/features/terminal/terminal/terminal-scrollback/index.ts
+++ b/apps/website/src/components/features/terminal/terminal/terminal-scrollback/index.ts
@@ -1,2 +1,1 @@
 export { TerminalScrollback } from "./terminal-scrollback";
-export type { TerminalScrollbackProps } from "./terminal-scrollback";

--- a/apps/website/src/components/features/terminal/terminal/terminal-scrollback/terminal-content-block/index.ts
+++ b/apps/website/src/components/features/terminal/terminal/terminal-scrollback/terminal-content-block/index.ts
@@ -1,2 +1,1 @@
 export { TerminalContentBlock } from "./terminal-content-block";
-export type { TerminalContentBlockProps } from "./terminal-content-block";


### PR DESCRIPTION
Clears both blockers on #585 so that PR can go back to being a pure dependency bump. Neither fix
depends on the upgrade — both are correct on main today.

## 1. `react-hooks/set-state-in-effect`

`eslint-plugin-react-hooks` 7 → 7.1.1 adds this rule, and the contact form's offline banner trips it:

```
apps/website/src/components/content/contact/contact/contact-form/use-contact-form-store.ts:46:9
> 46 |         setIsOffline(!navigator.onLine);
     |         ^^^^^^^^^^^^ Avoid calling setState() directly within an effect
```

The effect existed only to *seed* state that the `online`/`offline` listeners then maintained — which
is the definition of subscribing to an external system, so `useSyncExternalStore` says it directly:

```ts
const subscribe = (callback: () => void) => { ... window.addEventListener("online", callback) ... };
const getSnapshot = (): boolean => !navigator.onLine;
const getServerSnapshot = (): boolean => false;
```

Three things improve beyond silencing the rule: no seeding render on mount, `getServerSnapshot`
reports online so SSR can't flash the offline banner, and the store drops to one line. It follows
the shape already used by `usePwaInstallDecision`. The snapshot is a boolean, so it needs none of
the snapshot-caching care an object would.

## 2. Seven dead type re-exports

`knip` 6.27 → 6.34 flags type re-exports whose barrel nobody imports them through. All seven check
out — consumers take the type straight from `matrix-design-system`, or never reference it:

`SocialContactLinks`, `TagProps`, `TerminalButtonProps`, `FightingGameTriggerProps`,
`TerminalPromptProps`, `TerminalScrollbackProps`, `TerminalContentBlockProps`

The type declarations themselves are untouched — only the unused re-export line goes. Verified by
grep rather than by a green knip, since `apps/website/knip.json` counts test files as usage.

## Verification

Against **main's** tool versions:

- `npm run typecheck` 8/8 · `lint` 6/6 · `knip` 4/4 · `validate-architecture` 2/2 · `test:run` 5/5 · `build` 6/6
- Playwright: **86 passed**, run against an isolated production server on port 3123 with a config
  carrying no `webServer`, so `reuseExistingServer` could not silently test something else

Against the **upgraded** versions that #585 installs — the check that actually matters here:

```
eslint-plugin-react-hooks 7.1.1  ->  lint  6/6 pass
knip 6.34.0                      ->  knip  4/4 pass
```

## After merge

Rebase #585 (`@dependabot rebase`) and it should go green as a pure bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved contact form handling of online and offline browser status.

* **Refactor**
  * Centralized connectivity status detection for more consistent form behavior.

* **Chores**
  * Removed several internal component property types from public exports without changing the related UI components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->