### PR TITLE
chore(deps): :wrench: group the oxc toolchain

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -110,6 +110,14 @@ updates:
         patterns:
           - "serwist"
           - "@serwist/*"
+      oxc:
+        # Not a peer contract — oxlint and oxfmt are on independent version lines. Grouped because
+        # they are one toolchain in one workspace, so a week that moves both is one review, not two.
+        patterns:
+          - "oxlint"
+          - "oxfmt"
+          - "oxc-*"
+          - "@oxc-project/*"
       release:
         # release-it and its changelog plugin move as a pair: plugin 11 accepts release-it
         # ^18 || ^19 || ^20, plugin 12 adds ^21. A bump landing one without the other leaves a peer


### PR DESCRIPTION
Requested follow-up to #603.

```yaml
      oxc:
        patterns:
          - "oxlint"
          - "oxfmt"
          - "oxc-*"
          - "@oxc-project/*"
```

`oxlint` and `oxfmt` are both declared by `packages/matrix-rain-webgpu` and both come from oxc.
`#596` (oxfmt 0.58 → 0.66) and `#609` (oxlint 1.80 → 1.81) were two separate PRs for one toolchain
in one workspace.

**Being accurate about the rationale**: unlike `react`, `ai-sdk`, `typegpu`, `serwist` and `release`,
this is *not* a peer contract. The two are on independent version lines (1.81.0 vs 0.66.0) and
neither peers on the other, so nothing breaks if they move apart. This group is noise reduction —
one review instead of two — not a correctness constraint. Worth stating so the config doesn't imply
a coupling that isn't there.

`oxc-*` and `@oxc-project/*` are included so that if either is ever promoted to a direct dependency
it lands in the same PR. Today they appear only transitively.

## Verification

- `npx prettier --check .github/dependabot.yml` — clean
- YAML parses: 14 groups
- No install, build or runtime impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)