### PR TITLE
fix(capabilities): :heavy_plus_sign: declare @astrojs/markdown-remark and move onto its processor

### DIFF
--- a/apps/matrix-rain-showcase/astro.config.mjs
+++ b/apps/matrix-rain-showcase/astro.config.mjs
@@ -1,6 +1,7 @@
 // @ts-check
 import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'astro/config';
+import { unified } from '@astrojs/markdown-remark';
 import starlight from '@astrojs/starlight';
 import react from '@astrojs/react';
 import typegpu from 'unplugin-typegpu/vite';
@@ -16,10 +17,14 @@ export default defineConfig({
 	site: 'https://chicio.github.io',
 	base: '/chicio-blog/matrix-rain/',
 	markdown: {
-		remarkPlugins: [remarkMath],
-		// External (http) links open in a new tab — covers the GitHub source links
-		// in the docs. Internal/relative links are untouched.
-		rehypePlugins: [rehypeKatex, [rehypeExternalLinks, { target: '_blank', rel: ['noopener', 'noreferrer'] }]],
+		// Sätteri is Astro's default processor but parses math without rendering it and has no
+		// external-link handling, so the docs' KaTeX and new-tab links need the unified processor.
+		processor: unified({
+			remarkPlugins: [remarkMath],
+			// External (http) links open in a new tab — covers the GitHub source links
+			// in the docs. Internal/relative links are untouched.
+			rehypePlugins: [rehypeKatex, [rehypeExternalLinks, { target: '_blank', rel: ['noopener', 'noreferrer'] }]],
+		}),
 	},
 	integrations: [
 		// Renders ```mermaid code blocks client-side (no build-time headless browser).

--- a/apps/matrix-rain-showcase/package.json
+++ b/apps/matrix-rain-showcase/package.json
@@ -12,6 +12,7 @@
     "check": "astro check"
   },
   "dependencies": {
+    "@astrojs/markdown-remark": "^7.2.4",
     "@astrojs/react": "^6.0.5",
     "@astrojs/starlight": "^0.41.3",
     "@mermaid-js/layout-elk": "^0.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -64,6 +64,7 @@
     "apps/matrix-rain-showcase": {
       "version": "0.0.1",
       "dependencies": {
+        "@astrojs/markdown-remark": "^7.2.4",
         "@astrojs/react": "^6.0.5",
         "@astrojs/starlight": "^0.41.3",
         "@mermaid-js/layout-elk": "^0.2.2",
@@ -3689,36 +3690,6 @@
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@inquirer/prompts": {
-      "version": "8.4.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-8.4.2.tgz",
-      "integrity": "sha512-XJmn/wY4AX56l1BRU+ZjDrFtg9+2uBEi4JvJQj82kwJDQKiPgSn4CEsbfGGygS4Gw6rkL4W18oATjfVfaqub2Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/checkbox": "^5.1.4",
-        "@inquirer/confirm": "^6.0.12",
-        "@inquirer/editor": "^5.1.1",
-        "@inquirer/expand": "^5.0.13",
-        "@inquirer/input": "^5.0.12",
-        "@inquirer/number": "^4.0.12",
-        "@inquirer/password": "^5.0.12",
-        "@inquirer/rawlist": "^5.2.8",
-        "@inquirer/search": "^4.1.8",
-        "@inquirer/select": "^5.1.4"
-      },
-      "engines": {
-        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -28396,7 +28367,7 @@
         "eslint-plugin-react": "^7",
         "eslint-plugin-react-hooks": "^7",
         "framer-motion": "^13.2.0",
-        "globals": "^17.12.0",
+        "globals": "^17",
         "jsdom": "^30.0.0",
         "react": "19.2.8",
         "react-dom": "19.2.8",


### PR DESCRIPTION
Unblocks #610 (`@astrojs/starlight` 0.41.10 → 0.42.0), whose Build job fails before rendering a page,
and clears the deprecation that surfaces once it builds again. Two commits.

## 1. Declare `@astrojs/markdown-remark`

```
matrix-rain-showcase:build> astro build

`markdown.remarkPlugins`, `markdown.rehypePlugins`, and `markdown.remarkRehype` run on the
`unified` processor from `@astrojs/markdown-remark`, which is no longer installed by default
now that Sätteri is the default Markdown processor.
```

The showcase's config uses the legacy markdown plugin API, which Astro 7 routes through
`@astrojs/markdown-remark` — and the showcase **never declared that package**. It built only because
something in the Starlight 0.41 tree hoisted a copy to the root:

| | `@astrojs/markdown-remark` in the tree |
|---|---|
| main (starlight 0.41.10) | 7.2.4 — present transitively |
| #610 (starlight 0.42.0) | **gone** |

A textbook phantom dependency: hoisting made an undeclared import resolve, and it broke the moment
an unrelated bump reshaped the tree.

`^7.2.4` rather than `^7.3.0` deliberately — `^7.3.0` forces a second copy nested under the showcase
while the transitive 7.2.4 stays hoisted, and Astro resolves from the root, so the nested one might
not be the copy it finds. `^7.2.4` dedupes to the single existing copy and still reaches 7.3.0 once
the transitive one disappears.

## 2. Move the plugins onto the processor

`markdown.remarkPlugins` / `rehypePlugins` are deprecated and slated for removal in a future major.
The options belong on `markdown.processor`:

```js
import { unified } from '@astrojs/markdown-remark';

markdown: {
    processor: unified({
        remarkPlugins: [remarkMath],
        rehypePlugins: [rehypeKatex, [rehypeExternalLinks, { target: '_blank', rel: [...] }]],
    }),
},
```

This also turns the dependency declared in commit 1 into an explicit import, rather than something
the config reached for implicitly.

### Why not migrate to Sätteri

Astro's message offers either processor, so it is worth saying why this stays on unified:

- **`rehype-external-links` has no Sätteri equivalent.** Its entire type surface has no link
  handling — the only related feature is Obsidian wikilinks. That plugin exists to make the GitHub
  source links in the docs open in a new tab.
- **Sätteri's math is parse-only.** It does have `math?: boolean` / `mathOptions`, but only
  `singleDollarTextMath`. `rehype-katex` does the rendering, and six `how-it-works/` docs carry real
  KaTeX (`\frac`, `\sum`, `G_{2D}(x,y)`).

Starlight itself depends on **both** `@astrojs/markdown-satteri` and `unified`/`rehype`/
`remark-directive`, so staying on unified is not working against the framework.

## Verification

Both trees, since only the second reproduces the original bug — and by inspecting the built HTML
rather than trusting an exit code:

| | starlight 0.41.10 | starlight 0.42.0 |
|---|---|---|
| `astro build` | 17 pages, exit 0 | 17 pages, exit 0 |
| deprecation warning | gone | gone |
| KaTeX rendered | `class="katex"` ×7 | `class="katex"` ×7 |
| external links | 8 files `target="_blank" rel="noopener noreferrer"` | 10 files |

The 0.42 runs invoke `astro build` directly in the workspace — the turbo run replayed a cache hit
with an identical timestamp and had not actually exercised 0.42.

Repo gates on main's versions: `typecheck` 8/8 · `lint` 6/6 · `knip` 4/4 · `validate-architecture`
2/2 · `test:run` 5/5 · `build` 6/6.

## Two incidental lockfile changes

Re-resolving from `origin/main`'s lock produced two changes this PR did not cause, both corrections:

- dropped a redundant `@inquirer/prompts@8.4.2` (a second copy alongside 8.5.2)
- aligned the website's recorded `globals` spec with its manifest (`^17.12.0` → `^17`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)