### PR TITLE
test(capabilities): :white_check_mark: flush the panel open state before driving Escape

### DIFF
--- a/apps/website/src/components/features/matrix-rain-panel/matrix-rain-control-panel/matrix-rain-control-panel.test.tsx
+++ b/apps/website/src/components/features/matrix-rain-panel/matrix-rain-control-panel/matrix-rain-control-panel.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen } from "@/test-utils";
-import { fireEvent, waitFor } from "@testing-library/react";
+import { act, fireEvent, waitFor } from "@testing-library/react";
 import { MatrixRainControlPanel } from "./matrix-rain-control-panel";
 import { RAIN_STEP_RATE_MAX } from "./use-matrix-rain-control-panel-store";
 import { closeEasterEgg, getEasterEggOverlaySlug } from "@/lib/easter-eggs/easter-egg-overlay-state";
@@ -61,7 +61,13 @@ vi.mock("matrix-design-system", async (importOriginal) => ({
 }));
 vi.mock("@/lib/tracking/tracking", () => ({ trackWith: vi.fn() }));
 
-const openPanel = () => window.dispatchEvent(new Event("matrix-rain-panel-open"));
+// act() so the open state and the effect that registers the Escape listener both flush before
+// the test interacts. Without it findByText can resolve on a committed render whose passive
+// effects have not run, and a keyDown lands with no listener attached.
+const openPanel = () =>
+    act(() => {
+        window.dispatchEvent(new Event("matrix-rain-panel-open"));
+    });
 
 describe("MatrixRainControlPanel", () => {
     beforeEach(() => {


### PR DESCRIPTION
`MatrixRainControlPanel > close behaviour > closes on Escape key` fails intermittently in CI:

```
AssertionError: expected <h4></h4> to be null
```

It surfaced on #616 — a `postcss` 8.5.23 → 8.5.28 bump, which cannot plausibly affect a jsdom
keyboard test. **Re-running the identical commit turned it green**, which is what confirmed a flake
rather than a regression.

## The race

The store registers the Escape listener from a passive effect gated on the open state:

```ts
useEffect(() => {
    if (!open) { return; }
    window.addEventListener("keydown", handleEsc, true);
    ...
}, [open, close]);
```

and the test drove it like this:

```js
const openPanel = () => window.dispatchEvent(new Event("matrix-rain-panel-open"));  // outside act()

openPanel();
await screen.findByText(/Matrix Rain Settings/);   // polls the DOM
fireEvent.keyDown(window, { key: "Escape" });      // may land before the effect flushed
```

`findByText` polls the DOM, so it can resolve on a committed render whose **passive effects have not
run**. The keyDown then lands with no listener attached, the panel never closes, and `waitFor` times
out.

Locally the website suite is 497 tests; CI runs the whole monorepo at 1132. That extra load is
enough to lose the race — which is why it reproduces in CI and not on a dev machine.

A real browser attaches the listener within a frame and no user can press Escape that fast, so this
is a test race, not a product bug. The component is unchanged.

## The fix

```js
const openPanel = () =>
    act(() => {
        window.dispatchEvent(new Event("matrix-rain-panel-open"));
    });
```

This is **convention alignment, not invention** — every other test in the repo already wraps these
dispatches:

| file | |
|---|---|
| `terminal.test.tsx:83` | `await act(async () => { window.dispatchEvent(...) })` |
| `command-palette.test.tsx:53` | `act(() => { window.dispatchEvent(...) })` |
| `site-command-palette.test.tsx:191` | `await act(async () => { window.dispatchEvent(...) })` |
| `matrix-rain-control-panel.test.tsx:64` | **raw dispatch — the outlier** |

The helper is shared by all nine tests in the file, so all nine become deterministic.

## Verification

**A green run cannot prove a flake is gone**, so to be clear about what this does and does not show:
the argument is the mechanism above plus the convention alignment. What was actually run:

- the target file, **10 consecutive runs, 9 passed each time, 0 failures**
- `typecheck` 8/8 · `lint` 6/6 · `knip` 4/4 · `validate-architecture` 2/2 · `test:run` 5/5

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved test reliability for the matrix rain control panel by ensuring panel-opening interactions and related state updates are fully processed before assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->