### PR TITLE
fix(deps): :wrench: make the shared version pins Dependabot-manageable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
       "devDependencies": {
         "@release-it/conventional-changelog": "^12.0.0",
         "@types/react": "19.2.18",
-        "@types/react-dom": "19.2.5",
+        "@types/react-dom": "19.2.7",
         "framer-motion": "^13.1.1",
         "husky": "^9.1.7",
         "prettier": "^3.9.6",
@@ -8890,9 +8890,9 @@
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "19.2.5",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.5.tgz",
-      "integrity": "sha512-fMPwH9v7r/pp43yUd2/Mbiex5KouJwwR3dzHkhLREUC6764VyDsqxhAxv6OFEYR1RhjOyD1naqba8ECDBe7ZQg==",
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.7.tgz",
+      "integrity": "sha512-I8bPpDLcHBv1qiIiXDCy71Rt8eQDKJP0sMSWJphDdAcdqiJ1sGpZamavoEIRZmYzjia9LuEb2HlYdDpmoENpvQ==",
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,9 +13,14 @@
       ],
       "devDependencies": {
         "@release-it/conventional-changelog": "^12.0.0",
+        "@types/react": "19.2.18",
+        "@types/react-dom": "19.2.5",
+        "framer-motion": "^13.1.1",
         "husky": "^9.1.7",
         "prettier": "^3.9.6",
         "prettier-plugin-tailwindcss": "^0.8.1",
+        "react": "19.2.8",
+        "react-dom": "19.2.8",
         "release-it": "^21.0.2",
         "turbo": "^2.5.6"
       },
@@ -51,16 +56,6 @@
         "vite": "^8.1.0"
       }
     },
-    "apps/matrix-design-system-showcase/node_modules/@types/react-dom": {
-      "version": "19.2.5",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.5.tgz",
-      "integrity": "sha512-fMPwH9v7r/pp43yUd2/Mbiex5KouJwwR3dzHkhLREUC6764VyDsqxhAxv6OFEYR1RhjOyD1naqba8ECDBe7ZQg==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "^19.2.0"
-      }
-    },
     "apps/matrix-rain-showcase": {
       "version": "0.0.1",
       "dependencies": {
@@ -90,15 +85,6 @@
         "remark-math": "^6.0.0",
         "typescript": "npm:tsover@6.0.2",
         "unplugin-typegpu": "^0.12.3"
-      }
-    },
-    "apps/matrix-rain-showcase/node_modules/@types/react-dom": {
-      "version": "19.2.5",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.5.tgz",
-      "integrity": "sha512-fMPwH9v7r/pp43yUd2/Mbiex5KouJwwR3dzHkhLREUC6764VyDsqxhAxv6OFEYR1RhjOyD1naqba8ECDBe7ZQg==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "^19.2.0"
       }
     },
     "apps/matrix-rain-showcase/node_modules/brace-expansion": {
@@ -302,16 +288,6 @@
         "vitest": {
           "optional": true
         }
-      }
-    },
-    "apps/website/node_modules/@types/react-dom": {
-      "version": "19.2.5",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.5.tgz",
-      "integrity": "sha512-fMPwH9v7r/pp43yUd2/Mbiex5KouJwwR3dzHkhLREUC6764VyDsqxhAxv6OFEYR1RhjOyD1naqba8ECDBe7ZQg==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "^19.2.0"
       }
     },
     "apps/website/node_modules/commander": {
@@ -1036,18 +1012,6 @@
         "unist-util-visit": "^5.1.0",
         "unist-util-visit-parents": "^6.0.2",
         "vfile": "^6.0.3"
-      }
-    },
-    "node_modules/@astrojs/markdown-satteri": {
-      "version": "0.3.8",
-      "resolved": "https://registry.npmjs.org/@astrojs/markdown-satteri/-/markdown-satteri-0.3.8.tgz",
-      "integrity": "sha512-n8ItpFTCmlDsVR5+rwDmehSf+jFCYLWmZiisZNGuF7xILqYhsVeBfcha4qgS2Seq3fAc9Tm58ZVrvqFQ6RQgRQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@astrojs/internal-helpers": "0.10.4",
-        "@astrojs/prism": "4.0.2",
-        "github-slugger": "^2.0.0",
-        "satteri": "^0.10.3"
       }
     },
     "node_modules/@astrojs/mdx": {
@@ -8923,6 +8887,15 @@
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.5.tgz",
+      "integrity": "sha512-fMPwH9v7r/pp43yUd2/Mbiex5KouJwwR3dzHkhLREUC6764VyDsqxhAxv6OFEYR1RhjOyD1naqba8ECDBe7ZQg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
       }
     },
     "node_modules/@types/resolve": {
@@ -28886,16 +28859,6 @@
         }
       }
     },
-    "packages/matrix-design-system/node_modules/@types/react-dom": {
-      "version": "19.2.5",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.5.tgz",
-      "integrity": "sha512-fMPwH9v7r/pp43yUd2/Mbiex5KouJwwR3dzHkhLREUC6764VyDsqxhAxv6OFEYR1RhjOyD1naqba8ECDBe7ZQg==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "^19.2.0"
-      }
-    },
     "packages/matrix-design-system/node_modules/globals": {
       "version": "17.12.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-17.12.0.tgz",
@@ -28965,16 +28928,6 @@
       "peerDependencies": {
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
-      }
-    },
-    "packages/matrix-rain-webgpu/node_modules/@types/react-dom": {
-      "version": "19.2.5",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.5.tgz",
-      "integrity": "sha512-fMPwH9v7r/pp43yUd2/Mbiex5KouJwwR3dzHkhLREUC6764VyDsqxhAxv6OFEYR1RhjOyD1naqba8ECDBe7ZQg==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "^19.2.0"
       }
     },
     "packages/matrix-rain-webgpu/node_modules/brace-expansion": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "devDependencies": {
     "@release-it/conventional-changelog": "^12.0.0",
     "@types/react": "19.2.18",
-    "@types/react-dom": "19.2.5",
+    "@types/react-dom": "19.2.7",
     "framer-motion": "^13.1.1",
     "husky": "^9.1.7",
     "prettier": "^3.9.6",

--- a/package.json
+++ b/package.json
@@ -43,16 +43,23 @@
   },
   "devDependencies": {
     "@release-it/conventional-changelog": "^12.0.0",
+    "@types/react": "19.2.18",
+    "@types/react-dom": "19.2.5",
+    "framer-motion": "^13.1.1",
     "husky": "^9.1.7",
     "prettier": "^3.9.6",
     "prettier-plugin-tailwindcss": "^0.8.1",
+    "react": "19.2.8",
+    "react-dom": "19.2.8",
     "release-it": "^21.0.2",
     "turbo": "^2.5.6"
   },
   "overrides": {
-    "@types/react": "19.2.18",
-    "@types/react-dom": "19.2.5",
-    "ai": "^7.0.44"
+    "@types/react": "$@types/react",
+    "@types/react-dom": "$@types/react-dom",
+    "framer-motion": "$framer-motion",
+    "react": "$react",
+    "react-dom": "$react-dom"
   },
   "allowScripts": {
     "agent-browser@0.33.2": true,


### PR DESCRIPTION
Unblocks #613 and supersedes it. This is the third and last piece of the dependency-hygiene work
started in #582 — the half that #582 explicitly did not address.

## The bug

Dependabot never edits an `overrides` block, only dependency blocks. So the root pin stayed at
19.2.5 while every workspace moved to 19.2.7, and `npm ci` rejects the tree:

```
npm error code EUSAGE
npm error Missing: @types/react-dom@19.2.5 from lock file   (×5)
```

That is what killed #574 and is still killing #613.

## main is already wrong, quietly

The stale override does not just break Dependabot PRs — it is misresolving `main` right now:

| | |
|---|---|
| workspace manifests declare | **19.2.7** (website, design-system, ds-showcase) |
| root `overrides` forces | 19.2.5 |
| what actually installs | **19.2.5, in five separate copies** |

```
apps/matrix-design-system-showcase/node_modules/@types/react-dom => 19.2.5
apps/matrix-rain-showcase/node_modules/@types/react-dom          => 19.2.5
apps/website/node_modules/@types/react-dom                       => 19.2.5
packages/matrix-design-system/node_modules/@types/react-dom      => 19.2.5
packages/matrix-rain-webgpu/node_modules/@types/react-dom        => 19.2.5
```

An override whose version no workspace asks for stops deduping and starts fragmenting — the exact
opposite of its job. After this PR: **one copy, at 19.2.7.**

## The fix

npm's `$name` reference makes the override track a real declaration, so a Dependabot bump of the
root devDependency carries the override with it. Measured on npm 11.19.0 against a real conflict
(`make-dir@3` wants `semver ^6`, the workspace wants `^7`):

| setup | copies |
|---|---|
| no override | 2 |
| root `overrides` + root declares it (`$semver`) | **1** |
| `overrides` in a **workspace** package.json | 2 — npm silently ignores it |
| root `overrides`, `$ref`, root does **not** declare it | 2 — the `$` silently does nothing |
| root `overrides`, literal range | 1 |

So a shared pin needs **both** halves: a root devDependency and the `$` form. A literal range
alongside a root declaration is rejected outright — `npm error code EOVERRIDE: Override for X
conflicts with direct dependency` — which is exactly what `$name` exists to avoid.

## Why these five

- **`react` / `react-dom`** — five manifests declare five different ranges (`19.2.8`, `^19.2.6`,
  `^19.2.7`) that dedupe today only because the carets happen to overlap. Two copies of React break
  hooks and context across the design-system boundary.
- **`@types/react` / `@types/react-dom`** — two copies are structurally incompatible JSX types.
- **`framer-motion`** — for the reason `dependabot.yml` already records: a second copy breaks
  `AnimatePresence` across the package boundary.

## Why `ai` is deleted, not converted

It is website-only and the override is **inert** — with the website's own specs and no override,
`ai` installs as a single copy (7.0.91 in this branch). `@ai-sdk/react` tracks `ai` 1:1 on every
release (`4.0.94→7.0.91`, `4.0.95→7.0.92`, `4.0.96→7.0.93`), and the `ai-sdk` group bumps them
together — which is what the override compensated for before that group existed (#497).

Left in place it becomes a trap: at `ai` 8.x the literal `^7.0.44` would silently hold the package
on 7 against a manifest asking for 8.

## Second commit: the bump #613 wanted

Only the **root** declaration moves 19.2.5 → 19.2.7 — the three workspace manifests were already
there, which is why #613's diff was merely adding carets. With the pin now expressed as
`$@types/react-dom`, that one edit is enough for the whole tree.

The rain workspaces keep `^19.2.3`; 19.2.7 satisfies it and the override settles the version anyway.

## Verification

- one copy each of `react`, `react-dom`, `@types/react`, `@types/react-dom`, `framer-motion`, `ai`
- `npm ci` clean from the regenerated lock
- `typecheck` 8/8 · `lint` 6/6 · `knip` 4/4 · `validate-architecture` 2/2 · `test:run` 5/5 · `build` 6/6
- `verify-packages` — *Published surface verified*
- **Playwright 86 passed** — run because this changes React resolution, and per `.claude/rules/testing.md`
  the compiled output is only ever exercised by the build and the E2E suite

## Follow-up

`CLAUDE.md`'s `allowScripts`/`overrides` paragraph and the `react` group comment in
`dependabot.yml` still describe the literal-pin mechanism. Worth a docs pass once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application’s underlying platform components and development tooling.
  * No user-facing features, behavior changes, or interface updates are included in this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->