### PR TITLE
fix(capabilities): :bug: block the service worker in e2e and declare prebuild's outputs

### DIFF
--- a/apps/website/playwright.config.ts
+++ b/apps/website/playwright.config.ts
@@ -10,6 +10,14 @@ export default defineConfig({
     use: {
         baseURL: "http://localhost:3000",
         trace: "on-first-retry",
+        // The root layout registers a Serwist service worker on every page, and nothing in this
+        // suite exercises it. Left enabled it installs mid-test: traces from the two CI failures
+        // show `/sw.js` loading and then, 95ms and 207ms later, every subsequent request ceasing to
+        // complete — zero of them, permanently — so the router never received the RSC payload for
+        // the clicked link and the URL never changed. Both failures were a click shortly after
+        // load, which is exactly the activation window. Blocking it removes the race; PWA
+        // behaviour is no less covered than before, since no test asserted on it.
+        serviceWorkers: "block",
     },
     projects: [
         {

--- a/apps/website/turbo.json
+++ b/apps/website/turbo.json
@@ -13,6 +13,17 @@
     // ones are read during `next build`, not only at request time.
     "tasks": {
         "build": {
+            // prebuild writes outside .next: `serwist build` emits public/sw*, and
+            // copy-content-media mirrors post images into public/media/content. Neither was
+            // declared, so a cache hit restored .next, skipped prebuild, and left the site with no
+            // service worker and no content images. A workspace task replaces the root's outputs
+            // rather than merging them, so the .next entries are restated here.
+            "outputs": [
+                ".next/**",
+                "!.next/cache/**",
+                "public/sw*",
+                "public/media/content/**"
+            ],
             "env": [
                 "CONTACT_EMAIL",
                 "GOOGLE_ANALYTICS_API_SECRET",


### PR DESCRIPTION
Two causes of CI runs that fail once and pass on re-run. Both diagnosed from the uploaded Playwright
traces rather than guessed at.

## What the data says

Across the last 100 CI runs, E2E ran to completion 41 times: **39 passed, 2 failed** — a ~5% flake
rate. The Test job failed 5 times, and **all five were the `@types/react-dom` install bug** (fixed by
#618), not test flakes. The only genuine unit-test flake was fixed in #617.

So the remaining flakiness was E2E, and both failures had an identical signature.

## Cause 1 — the service worker

The root layout registers Serwist via `SerwistProvider` on **every page**, and **no test in the suite
asserts on it**. In the tests it is pure nondeterminism.

Both traces show the same thing:

| | failure A | failure B |
|---|---|---|
| `/sw.js` loaded at | 15:41:37.763 | 15:35:33.990 |
| first request that never completes | 15:41:37.858 (**+95ms**) | 15:35:34.197 (**+207ms**) |
| requests that completed after that | **0** | **0** |
| frame URL ever changed | **no** | **no** |

The service worker loads, takes control ~100–200ms later, and from that instant *nothing completes*
— so the router never receives the RSC payload for the clicked link, the URL never changes, and
`toHaveURL` times out at exactly 5s. The click itself succeeded (309ms); only the navigation
stalled.

Both failing tests clicked a link shortly after load, which is precisely the activation window.
Tests that only navigate and assert content were unaffected. All three attempts failed because each
retry recreates the same race, which is why only a fresh job run "fixes" it.

`serviceWorkers: "block"` is Playwright's first-class option for this. Verified against a build with
a real generated `sw.js`:

```
serviceWorkers=default   registrations=1  page controlled=true
serviceWorkers="block"   registrations=0  page controlled=false
```

PWA behaviour is no less covered than before — nothing tested it either way.

## Cause 2 — undeclared Turborepo outputs

`prebuild` writes **outside `.next`**: `serwist build` emits `public/sw*`, and `copy-content-media`
mirrors post images into `public/media/content`. But `build.outputs` listed only `.next` and `dist`.

A cache hit therefore restores `.next`, skips `prebuild`, and leaves the site with **no service
worker and no content images**. Reproduced directly:

```
build #1  -> cache miss, executes
build #2  -> cache hit, FULL TURBO
rm public/sw.js public/media/content
build #3  -> cache hit
            sw.js MISSING
            media/content MISSING
```

That is why a local `npm run build && npm start` served `/sw.js` as **404** while CI — which never
has a warm cache — served it 200. It also means a cached local build serves the site with broken
content images, independent of tests.

After declaring them, the same sequence restores both. A workspace task **replaces** the root's
outputs rather than merging, so the `.next` entries are restated.

## Verification

- **86 Playwright tests pass** against a build with the service worker generated and served
- cache-hit build now restores `public/sw*` and `public/media/content/**`
- `typecheck` 8/8 · `lint` 6/6 · `knip` 4/4 · `validate-architecture` 2/2 · `test:run` 5/5

## A note on the diff

`apps/website/turbo.json` is already not prettier-clean on `main` (`.prettierrc` overrides JSON to
2-space; the file is 4-space). Running `--write` reformatted 150 lines and buried the change, so the
addition is written in the file's existing style instead. The pre-existing drift is left alone —
there is no `format:check` job in CI, so nothing is enforcing it today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)