### PR TITLE
test(capabilities): :white_check_mark: cover the service worker's offline behaviour

### DIFF
--- a/apps/website/e2e/pwa.spec.ts
+++ b/apps/website/e2e/pwa.spec.ts
@@ -1,0 +1,53 @@
+import { test, expect, type Page } from "@playwright/test";
+
+// The suite blocks service workers by default (see playwright.config.ts): the root layout registers
+// one on every page, and a test that neither blocks nor waits for it races its activation, which is
+// what made two CI runs fail. These tests want the real thing, so they opt back in and then wait for
+// the exact condition rather than racing it.
+test.use({ serviceWorkers: "allow" });
+
+// `clientsClaim` is set in sw.ts, so the worker takes over the page that registered it. Waiting for
+// a non-null controller is the deterministic signal that it is now serving this page's requests.
+const waitForServiceWorker = (page: Page) =>
+    page.waitForFunction(() => navigator.serviceWorker?.controller != null, undefined, { timeout: 30_000 });
+
+test.describe("Progressive web app", () => {
+    test.describe("service worker registration", () => {
+        test("registers and takes control of the page", async ({ page }) => {
+            await page.goto("/");
+            await waitForServiceWorker(page);
+
+            const registrations = await page.evaluate(
+                async () => (await navigator.serviceWorker.getRegistrations()).length,
+            );
+            expect(registrations).toBeGreaterThan(0);
+        });
+    });
+
+    test.describe("offline behaviour", () => {
+        test("serves an already-visited page from cache while offline", async ({ page, context }) => {
+            await page.goto("/about-me");
+            await waitForServiceWorker(page);
+            // The first load happened before the worker controlled the page, so it never reached the
+            // NetworkFirst handler. Reloading puts the page in the "pages" cache.
+            await page.reload();
+
+            await context.setOffline(true);
+            await page.reload();
+
+            // A real heading from the page itself, not just a 200: this also proves the offline
+            // fallback did not stand in for it.
+            await expect(page.getByRole("heading", { name: "Biography", level: 2 })).toBeVisible();
+        });
+
+        test("falls back to the offline page for a route never visited", async ({ page, context }) => {
+            await page.goto("/");
+            await waitForServiceWorker(page);
+
+            await context.setOffline(true);
+            await page.goto("/blog/authors");
+
+            await expect(page.getByRole("heading", { name: "OFFLINE", level: 1 })).toBeVisible();
+        });
+    });
+});


### PR DESCRIPTION
Follow-up to #621. That PR blocked service workers suite-wide, which removed the flakiness but left
`sw.ts` with **zero** coverage. This adds it back deliberately, in one isolated file.

## Why it's worth testing

`sw.ts`'s own comments record two bugs already hit in production:

```
line 68:  "the browser spins forever instead of showing the offline page"
line 83:  "__WB_REVISION__ query param ... an exact-URL lookup always returns undefined"
```

Neither had a test. The third test here is the regression both would reproduce.

## Why this doesn't reintroduce the flakiness

`serviceWorkers` is a **context** option, so this file opts back in while the rest of the suite stays
blocked:

```ts
test.use({ serviceWorkers: "allow" });
```

The flake in #621 came from tests that neither blocked the worker *nor waited for it* — they raced
activation. Here the wait is on the exact condition:

```ts
page.waitForFunction(() => navigator.serviceWorker?.controller != null)
```

`sw.ts` sets `clientsClaim: true`, so a non-null controller is precisely the signal that the worker
is now serving this page's requests. Deterministic by construction rather than by timing.

## The three tests

| test | covers |
|---|---|
| registers and takes control of the page | the registration path |
| a page visited online still renders offline | the `NetworkFirst` `pages` cache |
| a route **never visited** falls back to `/offline` | **both recorded bugs** |

The cached-page test asserts on the page's own `Biography` heading, not a 200 and not a bare `h1` —
`/about-me` has no `h1`, and a status check alone would still pass if the offline fallback had
silently stood in for the real page. While debugging I confirmed the cache is genuinely populated
(`pages cached: /about-me`) and the offline reload returns 200 with the correct title.

## Not covered, deliberately

The images route's `handlerDidError` SVG placeholder. A page-level `fetch()` has
`request.destination === ""`, so it never matches that route's matcher, and driving a real `<img>`
to assert the placeholder's dimensions is more machinery than it earns. Worth revisiting if that
path ever regresses.

## Verification

- **10 consecutive runs** of `pwa.spec.ts`: 3 passed each time, **0 failures**
- full suite: **89 passed** (86 + 3) in **61s** — unchanged from before, so the spec costs ~1s, not
  the 20–30s I'd guessed
- the new tests do not disturb the existing ones
- `typecheck` 8/8 · `lint` 6/6 · `knip` 4/4 · `validate-architecture` 2/2 · `test:run` 5/5

Kept as its own file so that if it ever does get noisy you can quarantine it without giving up the
flake fix in #621.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage for Progressive Web App behavior.
  * Verifies service worker registration and offline access to previously visited pages.
  * Verifies that unvisited routes display the offline fallback page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->